### PR TITLE
Add share to PWA

### DIFF
--- a/apps/mobile/lib/upload.ts
+++ b/apps/mobile/lib/upload.ts
@@ -56,10 +56,11 @@ export function useUploadAsset(
       return zUploadResponseSchema.parse(await resp.json());
     },
     onSuccess: (resp) => {
-      const assetId = resp.assetId;
-      const assetType =
-        resp.contentType === "application/pdf" ? "pdf" : "image";
-      createBookmark({ type: BookmarkTypes.ASSET, assetId, assetType });
+      resp.forEach((r) => {
+        const assetId = r.assetId;
+        const assetType = r.contentType === "application/pdf" ? "pdf" : "image";
+        createBookmark({ type: BookmarkTypes.ASSET, assetId, assetType });
+      });
     },
     onError: (e) => {
       if (options.onError) {

--- a/apps/web/app/api/bookmarks/create/route.tsx
+++ b/apps/web/app/api/bookmarks/create/route.tsx
@@ -1,0 +1,66 @@
+import { redirect } from "next/navigation";
+import { api, createContextFromRequest } from "@/server/api/client";
+import { TRPCError } from "@trpc/server";
+
+import { BookmarkTypes } from "@hoarder/shared/types/bookmarks";
+import { ZUploadResponse } from "@hoarder/shared/types/uploads";
+
+import { POST as apiUploadAssets } from "../../assets/route";
+
+export const dynamic = "force-dynamic";
+export async function POST(request: Request) {
+  const ctx = await createContextFromRequest(request);
+  if (!ctx.user) {
+    redirect("/signin");
+  }
+
+  try {
+    const uploadResponse = await apiUploadAssets(request.clone());
+
+    if (!uploadResponse.ok) {
+      throw uploadResponse;
+    }
+
+    const assets = (await uploadResponse.json()) as ZUploadResponse;
+
+    const promises = assets.map(
+      async (asset) =>
+        await api.bookmarks.createBookmark({
+          ...asset,
+          type: BookmarkTypes.ASSET,
+          assetType: asset.contentType === "application/pdf" ? "pdf" : "image",
+        }),
+    );
+
+    await Promise.all(promises);
+  } catch (err) {
+    let error = "Unknown error";
+
+    if (err instanceof Response) {
+      const data = (await err.json()) as unknown;
+
+      error =
+        typeof data === "object" &&
+        data !== null &&
+        "message" in data &&
+        typeof data.message === "string"
+          ? data.message
+          : error;
+    }
+    if (err instanceof TRPCError) {
+      error = err.message ?? error;
+    }
+
+    const params = new URLSearchParams({ error });
+    redirect("/dashboard/bookmarks?" + params.toString());
+  }
+
+  const formData = await request.formData();
+  const text = formData.get("text");
+
+  if (typeof text === "string") {
+    await api.bookmarks.createBookmark({ type: BookmarkTypes.TEXT, text });
+  }
+
+  redirect("/dashboard/bookmarks");
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,6 +6,7 @@ import "@hoarder/tailwind-config/globals.css";
 import type { Viewport } from "next";
 import React from "react";
 import { cookies } from "next/headers";
+import ErrorToast from "@/components/dashboard/ErrorToast";
 import { Toaster } from "@/components/ui/toaster";
 import Providers from "@/lib/providers";
 import {
@@ -67,6 +68,7 @@ export default async function RootLayout({
           <ReactQueryDevtools initialIsOpen={false} />
         </Providers>
         <Toaster />
+        <ErrorToast />
       </body>
     </html>
   );

--- a/apps/web/components/dashboard/ErrorToast.tsx
+++ b/apps/web/components/dashboard/ErrorToast.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function ErrorToast() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const error = searchParams.get("error");
+    if (error) {
+      toast({ variant: "destructive", description: error });
+
+      const newParams = new URLSearchParams(searchParams);
+      newParams.delete("error");
+      router.replace(pathname + "?" + newParams.toString());
+    }
+  }, [searchParams, pathname, router, toast]);
+
+  return null;
+}

--- a/apps/web/components/dashboard/UploadDropzone.tsx
+++ b/apps/web/components/dashboard/UploadDropzone.tsx
@@ -32,9 +32,13 @@ export function useUploadAsset() {
 
   const { mutateAsync: runUploadAsset } = useUpload({
     onSuccess: async (resp) => {
-      const assetType =
-        resp.contentType === "application/pdf" ? "pdf" : "image";
-      await createBookmark({ ...resp, type: BookmarkTypes.ASSET, assetType });
+      await Promise.all(
+        resp.map(async (r) => {
+          const assetType =
+            r.contentType === "application/pdf" ? "pdf" : "image";
+          await createBookmark({ ...r, type: BookmarkTypes.ASSET, assetType });
+        }),
+      );
     },
     onError: (err, req) => {
       toast({

--- a/apps/web/components/dashboard/preview/AttachmentBox.tsx
+++ b/apps/web/components/dashboard/preview/AttachmentBox.tsx
@@ -143,11 +143,13 @@ export default function AttachmentBox({ bookmark }: { bookmark: ZBookmark }) {
                   onFileSelect={(file) =>
                     uploadAsset(file, {
                       onSuccess: (resp) => {
-                        replaceAsset({
-                          bookmarkId: bookmark.id,
-                          oldAssetId: asset.id,
-                          newAssetId: resp.assetId,
-                        });
+                        resp.forEach((r) =>
+                          replaceAsset({
+                            bookmarkId: bookmark.id,
+                            oldAssetId: asset.id,
+                            newAssetId: r.assetId,
+                          }),
+                        );
                       },
                     })
                   }
@@ -196,13 +198,15 @@ export default function AttachmentBox({ bookmark }: { bookmark: ZBookmark }) {
               onFileSelect={(file) =>
                 uploadAsset(file, {
                   onSuccess: (resp) => {
-                    attachAsset({
-                      bookmarkId: bookmark.id,
-                      asset: {
-                        id: resp.assetId,
-                        assetType: "bannerImage",
-                      },
-                    });
+                    resp.forEach((r) =>
+                      attachAsset({
+                        bookmarkId: bookmark.id,
+                        asset: {
+                          id: r.assetId,
+                          assetType: "bannerImage",
+                        },
+                      }),
+                    );
                   },
                 })
               }

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -21,5 +21,25 @@
   ],
   "start_url": "/",
   "display": "standalone",
-  "orientation": "portrait"
+  "orientation": "portrait",
+  "share_target": {
+    "method": "POST",
+    "action": "/api/bookmarks/create",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "image",
+          "accept": ["image/*"]
+        },
+        {
+          "name": "file",
+          "accept": ["application/pdf"]
+        }
+      ]
+    }
+  }
 }

--- a/packages/shared/types/uploads.ts
+++ b/packages/shared/types/uploads.ts
@@ -6,11 +6,13 @@ export const zUploadErrorSchema = z.object({
 
 export type ZUploadError = z.infer<typeof zUploadErrorSchema>;
 
-export const zUploadResponseSchema = z.object({
-  assetId: z.string(),
-  contentType: z.string(),
-  size: z.number(),
-  fileName: z.string(),
-});
+export const zUploadResponseSchema = z.array(
+  z.object({
+    assetId: z.string(),
+    contentType: z.string(),
+    size: z.number(),
+    fileName: z.string(),
+  }),
+);
 
 export type ZUploadResponse = z.infer<typeof zUploadResponseSchema>;


### PR DESCRIPTION
Adds PWA in sharing options for images and PDF files, as well as sharing selected text.
I know a native app exists but I prefer the PWA, so I'm adding a button for upload files (in [another pull request](https://github.com/hoarder-app/hoarder/pull/561)) and the share option because it was missing.

<img src="https://github.com/user-attachments/assets/83ffaa84-1c75-4fa4-9268-fb2150d8cc5b" width="50%" _height="100">

Hoarder is the PWA version

---

I'm not sure if this is the best possible implementation as I'm not really familiar with Next, I'm open to your comments