### PR TITLE
Allow custom prompts through environment variables

### DIFF
--- a/apps/web/lib/clientConfig.tsx
+++ b/apps/web/lib/clientConfig.tsx
@@ -10,6 +10,9 @@ export const ClientConfigCtx = createContext<ClientConfig>({
   },
   inference: {
     inferredTagLang: "english",
+    taggingPrompt: "",
+    imagePrompt: "",
+    summarizationPrompt: "",
   },
   serverVersion: undefined,
   disableNewReleaseCheck: true,

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -26,6 +26,37 @@ const allEnv = z.object({
   INFERENCE_IMAGE_MODEL: z.string().default("gpt-4o-mini"),
   EMBEDDING_TEXT_MODEL: z.string().default("text-embedding-3-small"),
   INFERENCE_CONTEXT_LENGTH: z.coerce.number().default(2048),
+  TAGGING_PROMPT: z.coerce.string().default(
+    `You are a bot in a read-it-later app and your responsibility is to help with automatic tagging.
+Please analyze the text between the sentences "CONTENT START HERE" and "CONTENT END HERE" and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
+- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
+- The tags language must be in {{ lang }}.
+- If it's a famous website you may also include a tag for the website. If the tag is not generic enough, don't include it.
+- The content can include text for cookie consent and privacy policy, ignore those while tagging.
+- Aim for 3-5 tags.
+- If there are no good tags, leave the array empty.
+{{ customPrompts }}
+
+CONTENT START HERE
+{{ content }}
+CONTENT END HERE
+You must respond in JSON with the key "tags" and the value is an array of string tags.`,
+  ),
+  IMAGE_PROMPT: z.coerce.string().default(`
+You are a bot in a read-it-later app and your responsibility is to help with automatic tagging.
+Please analyze the attached image and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
+- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
+- The tags language must be in  {{ lang }}.
+- If the tag is not generic enough, don't include it.
+- Aim for 10-15 tags.
+- If there are no good tags, don't emit any.
+{{ customPrompts }}
+You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.`),
+  SUMMARIZATION_PROMPT: z.coerce.string().default(`
+Summarize the following content responding ONLY with the summary. You MUST follow the following rules:
+- Summary must be in 3-4 sentences.
+- The summary language must be in {{ lang }}.
+{{ customPrompts }}`),
   OCR_CACHE_DIR: z.string().optional(),
   OCR_LANGS: z
     .string()
@@ -92,6 +123,9 @@ const serverConfigSchema = allEnv.transform((val) => {
       imageModel: val.INFERENCE_IMAGE_MODEL,
       inferredTagLang: val.INFERENCE_LANG,
       contextLength: val.INFERENCE_CONTEXT_LENGTH,
+      taggingPrompt: val.TAGGING_PROMPT,
+      imagePrompt: val.IMAGE_PROMPT,
+      summarizationPrompt: val.SUMMARIZATION_PROMPT,
     },
     embedding: {
       textModel: val.EMBEDDING_TEXT_MODEL,
@@ -153,6 +187,9 @@ export const clientConfig = {
   },
   inference: {
     inferredTagLang: serverConfig.inference.inferredTagLang,
+    taggingPrompt: serverConfig.inference.taggingPrompt,
+    imagePrompt: serverConfig.inference.imagePrompt,
+    summarizationPrompt: serverConfig.inference.summarizationPrompt,
   },
   serverVersion: serverConfig.serverVersion,
   disableNewReleaseCheck: serverConfig.disableNewReleaseCheck,

--- a/packages/shared/prompts.test.ts
+++ b/packages/shared/prompts.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildContentPromptFromTemplate,
+  buildPromptFromTemplate,
+} from "./prompts";
+
+describe("Prompts", () => {
+  test("Build prompt from template", () => {
+    const template = `
+Language: {{ lang }}
+All tags: {{ tags }}
+AI tags: {{ aiTags }}
+Human tags: {{ userTags }}
+Custom prompts: {{ customPrompts }}
+`;
+    const lang = "English";
+    const tags = {
+      all: ["ai1", "ai2", "h1", "h2"],
+      ai: ["ai1", "ai2"],
+      human: ["h1", "h2"],
+    };
+    const customPrompts = ["custom prompt: $tags, $aiTags, $userTags"];
+    expect(buildPromptFromTemplate(template, lang, tags, customPrompts))
+      .toEqual(`
+Language: English
+All tags: [ai1, ai2, h1, h2]
+AI tags: [ai1, ai2]
+Human tags: [h1, h2]
+Custom prompts: - custom prompt: [ai1, ai2, h1, h2], [ai1, ai2], [h1, h2]
+`);
+  });
+
+  test("Build content prompt from template", () => {
+    const template = `
+Language: {{ lang }}
+All tags: {{ tags }}
+AI tags: {{ aiTags }}
+Human tags: {{ userTags }}
+Custom prompts: {{ customPrompts }}
+Content: {{ content }}
+`;
+    const lang = "English";
+    const tags = {
+      all: ["ai1", "ai2", "h1", "h2"],
+      ai: ["ai1", "ai2"],
+      human: ["h1", "h2"],
+    };
+    const customPrompts = ["custom prompt: $tags, $aiTags, $userTags"];
+    const content = "Bookmark content";
+    expect(
+      buildContentPromptFromTemplate(
+        template,
+        lang,
+        tags,
+        customPrompts,
+        content,
+        1_000,
+      ),
+    ).toEqual(`
+Language: English
+All tags: [ai1, ai2, h1, h2]
+AI tags: [ai1, ai2]
+Human tags: [h1, h2]
+Custom prompts: - custom prompt: [ai1, ai2, h1, h2], [ai1, ai2], [h1, h2]
+Content: Bookmark content
+`);
+  });
+
+  test("Build content prompt: content truncation", () => {
+    const template = `Content: {{ content }}`;
+    const tags = {
+      all: [],
+      ai: [],
+      human: [],
+    };
+    const content = "Bookmark content to be truncated";
+    expect(
+      buildContentPromptFromTemplate(template, "", tags, [], content, 4),
+    ).toEqual(`Content: Bookmark content`);
+  });
+});

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -12,57 +12,55 @@ function truncateContent(content: string, length: number) {
   return content;
 }
 
-export function buildImagePrompt(lang: string, customPrompts: string[]) {
-  return `
-You are a bot in a read-it-later app and your responsibility is to help with automatic tagging.
-Please analyze the attached image and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
-- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
-- The tags language must be in ${lang}.
-- If the tag is not generic enough, don't include it.
-- Aim for 10-15 tags.
-- If there are no good tags, don't emit any.
-${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
-You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.`;
+export interface PromptTags {
+  all: string[];
+  ai: string[];
+  human: string[];
 }
 
-export function buildTextPrompt(
+function fillPromptTemplate(
+  template: string,
+  customPrompts: string[],
+  tags: PromptTags,
+  lang = "",
+  content = "",
+) {
+  const allTags = `[${tags.all.join(", ")}]`;
+  const aiTags = `[${tags.ai.join(", ")}]`;
+  const userTags = `[${tags?.human?.join(", ")}]`;
+  const customPromptsGroup = customPrompts.map((p) => `- ${p}`).join("\n");
+
+  return template
+    .replace(RegExp("{{ lang }}", "g"), lang)
+    .replace(RegExp("{{ customPrompts }}", "g"), customPromptsGroup)
+    .replace(RegExp("$tags", "g"), "{{ tags }}")
+    .replace(RegExp("$aiTags", "g"), "{{ aiTags }}")
+    .replace(RegExp("$userTags", "g"), "{{ userTags }}")
+    .replace(RegExp("{{ tags }}", "g"), allTags)
+    .replace(RegExp("{{ aiTags }}", "g"), aiTags)
+    .replace(RegExp("{{ userTags }}", "g"), userTags)
+    .replace(RegExp("{{ content }}", "g"), content);
+}
+
+export function buildPromptFromTemplate(
+  promptTemplate: string,
   lang: string,
+  tags: PromptTags,
+  customPrompts: string[],
+) {
+  return fillPromptTemplate(promptTemplate, customPrompts, tags, lang);
+}
+
+export function buildContentPromptFromTemplate(
+  promptTemplate: string,
+  lang: string,
+  tags: PromptTags,
   customPrompts: string[],
   content: string,
   contextLength: number,
 ) {
-  const constructPrompt = (c: string) => `
-You are a bot in a read-it-later app and your responsibility is to help with automatic tagging.
-Please analyze the text between the sentences "CONTENT START HERE" and "CONTENT END HERE" and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
-- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
-- The tags language must be in ${lang}.
-- If it's a famous website you may also include a tag for the website. If the tag is not generic enough, don't include it.
-- The content can include text for cookie consent and privacy policy, ignore those while tagging.
-- Aim for 3-5 tags.
-- If there are no good tags, leave the array empty.
-${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
-CONTENT START HERE
-${c}
-CONTENT END HERE
-You must respond in JSON with the key "tags" and the value is an array of string tags.`;
-
-  const promptSize = calculateNumTokens(constructPrompt(""));
-  const truncatedContent = truncateContent(content, contextLength - promptSize);
-  return constructPrompt(truncatedContent);
-}
-
-export function buildSummaryPrompt(
-  lang: string,
-  customPrompts: string[],
-  content: string,
-  contextLength: number,
-) {
-  const constructPrompt = (c: string) => `
-    Summarize the following content responding ONLY with the summary. You MUST follow the following rules:
-- Summary must be in 3-4 sentences.
-- The summary language must be in ${lang}.
-${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
-    ${c}`;
+  const constructPrompt = (c: string) =>
+    fillPromptTemplate(promptTemplate, customPrompts, tags, lang, c);
 
   const promptSize = calculateNumTokens(constructPrompt(""));
   const truncatedContent = truncateContent(content, contextLength - promptSize);

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -31,14 +31,14 @@ function fillPromptTemplate(
   const customPromptsGroup = customPrompts.map((p) => `- ${p}`).join("\n");
 
   return template
-    .replace(RegExp("{{ lang }}", "g"), lang)
     .replace(RegExp("{{ customPrompts }}", "g"), customPromptsGroup)
-    .replace(RegExp("$tags", "g"), "{{ tags }}")
-    .replace(RegExp("$aiTags", "g"), "{{ aiTags }}")
-    .replace(RegExp("$userTags", "g"), "{{ userTags }}")
+    .replace(RegExp("\\$tags", "g"), "{{ tags }}")
+    .replace(RegExp("\\$aiTags", "g"), "{{ aiTags }}")
+    .replace(RegExp("\\$userTags", "g"), "{{ userTags }}")
     .replace(RegExp("{{ tags }}", "g"), allTags)
     .replace(RegExp("{{ aiTags }}", "g"), aiTags)
     .replace(RegExp("{{ userTags }}", "g"), userTags)
+    .replace(RegExp("{{ lang }}", "g"), lang)
     .replace(RegExp("{{ content }}", "g"), content);
 }
 


### PR DESCRIPTION
### Description
This PR introduces prompt customization through environment variables mentioned in #1018.
It solves issues with local language models being incompatible with prompts hardcoded inside the application.
This feature is backward compatible - if none of new environment variables is defined, Hoarder should behave exactly as it behaved before. 

### Technical details
3 new optional environment variables are defined:
* `TAGGING_PROMPT` - tag generation for text content,
* `IMAGE_PROMPT` - tag generation for images,
* `SUMMARIZATION_PROMPT` - summarizing text.

Default prompts are moved into `config.ts` and they are used if corresponding environment variables were not defined.

#### Filling prompts with data
In current solution, content is being inflated into the prompt text using string interpolation. Since there is no string interpolation in environment variables, I introduced markers which are replaced by actual values when building a prompt. The marker values are: 
* `tags`, 
* `aiTags`, 
* `userTags`, 
* `lang`, 
* `customPrompts`  (tagging rules),
* `content`. 

Values `tags`, `aiTags`, `userTags` existed before and were used in "Tagging Rules" feature.
However, I decided to change current markers from using dollar sign (`$variableName`) to doubled curly braces (`{{ variableName }}`), because dollar sign would have to be escaped when defined inside `.env` file (I'm not insisting on this, we can discuss other templating solutions). To keep backward compatibility, markers `tags`, `aiTags` and `userTags` can also be defined with dollar-sign notation.

### Custom prompts through env variables vs custom prompts using tagging rules
Hoarder already allows some customization in prompts using "tagging rules" in AI settings. However, tagging rules don't change the entire prompt. But I don't think these features would be in conflict with each other - custom prompt defined through environment variable sets the prompt template for the entire Hoarder instance, while tagging rules are additional per-user settings which could be inflated into the global prompt template with `{{ customPrompts }}` marker. In this way they supplement each other.