### PR TITLE
ui(web): Copy link button greyed out when clipboard not available

### DIFF
--- a/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
@@ -48,6 +48,7 @@ export default function BookmarkOptions({ bookmark }: { bookmark: ZBookmark }) {
   const linkId = bookmark.id;
 
   const demoMode = !!useClientConfig().demoMode;
+  const isClipboardAvailable = !!navigator.clipboard;
 
   const { setOpen: setTagModalIsOpen, content: tagModal } =
     useTagModel(bookmark);
@@ -189,6 +190,7 @@ export default function BookmarkOptions({ bookmark }: { bookmark: ZBookmark }) {
 
           {bookmark.content.type === BookmarkTypes.LINK && (
             <DropdownMenuItem
+              disabled={!isClipboardAvailable}
               onClick={() => {
                 navigator.clipboard.writeText(
                   (bookmark.content as ZBookmarkedLink).url,

--- a/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkOptions.tsx
@@ -48,7 +48,7 @@ export default function BookmarkOptions({ bookmark }: { bookmark: ZBookmark }) {
   const linkId = bookmark.id;
 
   const demoMode = !!useClientConfig().demoMode;
-  const isClipboardAvailable = !!navigator.clipboard;
+  const isClipboardAvailable = navigator && !!navigator.clipboard;
 
   const { setOpen: setTagModalIsOpen, content: tagModal } =
     useTagModel(bookmark);


### PR DESCRIPTION
Fix #846 
Now the copy link button is greyed out(disabled) when clipboard is unavailable.