### PR TITLE
hoarder-linux.sh > karakeep-linux.sh v2.1

### DIFF
--- a/docs/docs/02-Installation/06-debuntu.md
+++ b/docs/docs/02-Installation/06-debuntu.md
@@ -9,14 +9,14 @@ This script is a stripped-down version of those found in the [Proxmox Community 
 - **Debian 12** (Buster) or
 - **Ubuntu 24.04** (Noble Numbat)
 
-The script will download and install all dependencies (except for Ollama), install Hoarder, do a basic configuration of Hoarder and Meilisearch (the search app used by Hoarder), and create and enable the systemd service files needed to run Hoarder on startup. Hoarder and Meilisearch are run in the context of their low-privilege user environments for more security.
+The script will download and install all dependencies (except for Ollama), install Karakeep, do a basic configuration of Karakeep and Meilisearch (the search app used by Karakeep), and create and enable the systemd service files needed to run Karakeep on startup. Karakeep and Meilisearch are run in the context of their low-privilege user environments for more security.
 
 The script functions as an update script in addition to an installer. See **[Updating](#updating)**.
 
-### 1. Download the script from the [Hoarder repository](https://github.com/hoarder-app/hoarder/blob/main/hoarder-linux.sh).
+### 1. Download the script from the [Karakeep repository](https://github.com/karakeep-app/karakeep/blob/main/karakeep-linux.sh)
 
 ```
-wget https://raw.githubusercontent.com/hoarder-app/hoarder/main/hoarder-linux.sh
+wget https://raw.githubusercontent.com/karakeep-app/karakeep/main/karakeep-linux.sh
 ```
 
 ### 2. Run the script
@@ -26,10 +26,10 @@ wget https://raw.githubusercontent.com/hoarder-app/hoarder/main/hoarder-linux.sh
     If this is a fresh install, then run the installer by using the following command:
 
     ```shell
-    bash hoarder-linux.sh install
+    bash karakeep-linux.sh install
     ```
 
-### 3. Create an account/sign in!
+### 3. Create an account/sign in
 
     Then visit `http://localhost:3000` and you should be greated with the Sign In page.
 
@@ -37,34 +37,38 @@ wget https://raw.githubusercontent.com/hoarder-app/hoarder/main/hoarder-linux.sh
 
 > This script must be run as `root`, or as a user with `sudo` privileges.
 
-    If Hoarder has previously been installed using this script, then run the updater like so:
+    If Karakeep has previously been installed using this script, then run the updater like so:
 
     ```shell
-     bash hoarder-linux.sh update
+     bash karakeep-linux.sh update
     ```
 
 ## Services and Ports
 
-`hoarder.target` includes 4 services: `meilisearch.service`, `hoarder-web.service`, `hoarder-workers.service`, `hoarder-browser.service`. 
+`karakeep.target` includes 4 services: `meilisearch.service`, `karakeep-web.service`, `karakeep-workers.service`, `karakeep-browser.service`.
 
-- `meilisearch.service`: Provides full-text search, Hoarder Workers service connects to it, uses port `7700` by default.
+- `meilisearch.service`: Provides full-text search, Karakeep Workers service connects to it, uses port `7700` by default.
 
-- `hoarder-web.service`: Provides the hoarder web service, uses `3000` port by default.
+- `karakeep-web.service`: Provides the karakeep web service, uses `3000` port by default.
 
-- `hoarder-workers.service`: Provides the hoarder workers service, no port.
+- `karakeep-workers.service`: Provides the karakeep workers service, no port.
 
-- `hoarder-browser.service`: Provides the headless browser service, uses `9222` port by default.
+- `karakeep-browser.service`: Provides the headless browser service, uses `9222` port by default.
 
 ## Configuration, ENV file, database locations
 
-During installation, the script created a configuration file for `meilisearch`, an `ENV` file for Hoarder, and located config paths and database paths separate from the installation path of Hoarder, so as to allow for easier updating. Their names/locations are as follows:
+During installation, the script created a configuration file for `meilisearch`, an `ENV` file for Karakeep, and located config paths and database paths separate from the installation path of Karakeep, so as to allow for easier updating. Their names/locations are as follows:
 
 - `/etc/meilisearch.toml` - a basic configuration for meilisearch, that contains configs for the database location, disabling analytics, and using a master key, which prevents unauthorized connections.
 - `/var/lib/meilisearch` - Meilisearch DB location.
-- `/etc/hoarder/hoarder.env` - The Hoarder `ENV` file. Edit this file to configure Hoarder beyond the default. The web service and the workers service need to be restarted after editing this file:
-    
-    ```shell
-    sudo systemctl restart hoarder-workers hoarder-web
-    ```
-- `/var/lib/hoarder` - The Hoarder database location. If you delete the contents of this folder you will lose all your data.
+- `/etc/karakeep/karakeep.env` - The Karakeep `ENV` file. Edit this file to configure Karakeep beyond the default. The web service and the workers service need to be restarted after editing this file:
 
+    ```shell
+    sudo systemctl restart karakeep-workers karakeep-web
+    ```
+
+- `/var/lib/karakeep` - The Karakeep database location. If you delete the contents of this folder you will lose all your data.
+
+## Still Running Hoarder?
+
+There is a way to upgrade. Please see [Guides > Hoarder to Karakeep Migration](https://docs.karakeep.app/Guides/hoarder-to-karakeep-migration)

--- a/docs/docs/14-Guides/04-hoarder-to-karakeep-migration.md
+++ b/docs/docs/14-Guides/04-hoarder-to-karakeep-migration.md
@@ -16,3 +16,13 @@ index cdfc908..6297563 100644
 ```
 
 You can also change the `HOARDER_VERSION` environment variable but if you do so remember to change it in the `.env` file as well.
+
+## Migrating a Baremetal Installation
+
+If you previously used the [Debian/Ubuntu install script](https://docs.karakeep.app/Installation/debuntu) to install Hoarder, there is an option to migrate your installation to Karakeep.
+
+```bash
+bash karakeep-linux.sh migrate
+```
+
+This will migrate your installation with no user input required. After the migration, the script will also check for an update.

--- a/docs/versioned_docs/version-v0.23.1/02-Installation/06-debuntu.md
+++ b/docs/versioned_docs/version-v0.23.1/02-Installation/06-debuntu.md
@@ -9,14 +9,14 @@ This script is a stripped-down version of those found in the [Proxmox Community 
 - **Debian 12** (Buster) or
 - **Ubuntu 24.04** (Noble Numbat)
 
-The script will download and install all dependencies (except for Ollama), install Hoarder, do a basic configuration of Hoarder and Meilisearch (the search app used by Hoarder), and create and enable the systemd service files needed to run Hoarder on startup. Hoarder and Meilisearch are run in the context of their low-privilege user environments for more security.
+The script will download and install all dependencies (except for Ollama), install Karakeep, do a basic configuration of Karakeep and Meilisearch (the search app used by Karakeep), and create and enable the systemd service files needed to run Karakeep on startup. Karakeep and Meilisearch are run in the context of their low-privilege user environments for more security.
 
 The script functions as an update script in addition to an installer. See **[Updating](#updating)**.
 
-### 1. Download the script from the [Hoarder repository](https://github.com/hoarder-app/hoarder/blob/main/hoarder-linux.sh).
+### 1. Download the script from the [Karakeep repository](https://github.com/karakeep-app/karakeep/blob/main/karakeep-linux.sh)
 
 ```
-wget https://raw.githubusercontent.com/hoarder-app/hoarder/main/hoarder-linux.sh
+wget https://raw.githubusercontent.com/karakeep-app/karakeep/main/karakeep-linux.sh
 ```
 
 ### 2. Run the script
@@ -26,10 +26,10 @@ wget https://raw.githubusercontent.com/hoarder-app/hoarder/main/hoarder-linux.sh
     If this is a fresh install, then run the installer by using the following command:
 
     ```shell
-    bash hoarder-linux.sh install
+    bash karakeep-linux.sh install
     ```
 
-### 3. Create an account/sign in!
+### 3. Create an account/sign in
 
     Then visit `http://localhost:3000` and you should be greated with the Sign In page.
 
@@ -37,34 +37,38 @@ wget https://raw.githubusercontent.com/hoarder-app/hoarder/main/hoarder-linux.sh
 
 > This script must be run as `root`, or as a user with `sudo` privileges.
 
-    If Hoarder has previously been installed using this script, then run the updater like so:
+    If Karakeep has previously been installed using this script, then run the updater like so:
 
     ```shell
-     bash hoarder-linux.sh update
+     bash karakeep-linux.sh update
     ```
 
 ## Services and Ports
 
-`hoarder.target` includes 4 services: `meilisearch.service`, `hoarder-web.service`, `hoarder-workers.service`, `hoarder-browser.service`. 
+`karakeep.target` includes 4 services: `meilisearch.service`, `karakeep-web.service`, `karakeep-workers.service`, `karakeep-browser.service`.
 
-- `meilisearch.service`: Provides full-text search, Hoarder Workers service connects to it, uses port `7700` by default.
+- `meilisearch.service`: Provides full-text search, Karakeep Workers service connects to it, uses port `7700` by default.
 
-- `hoarder-web.service`: Provides the hoarder web service, uses `3000` port by default.
+- `karakeep-web.service`: Provides the karakeep web service, uses `3000` port by default.
 
-- `hoarder-workers.service`: Provides the hoarder workers service, no port.
+- `karakeep-workers.service`: Provides the karakeep workers service, no port.
 
-- `hoarder-browser.service`: Provides the headless browser service, uses `9222` port by default.
+- `karakeep-browser.service`: Provides the headless browser service, uses `9222` port by default.
 
 ## Configuration, ENV file, database locations
 
-During installation, the script created a configuration file for `meilisearch`, an `ENV` file for Hoarder, and located config paths and database paths separate from the installation path of Hoarder, so as to allow for easier updating. Their names/locations are as follows:
+During installation, the script created a configuration file for `meilisearch`, an `ENV` file for Karakeep, and located config paths and database paths separate from the installation path of Karakeep, so as to allow for easier updating. Their names/locations are as follows:
 
 - `/etc/meilisearch.toml` - a basic configuration for meilisearch, that contains configs for the database location, disabling analytics, and using a master key, which prevents unauthorized connections.
 - `/var/lib/meilisearch` - Meilisearch DB location.
-- `/etc/hoarder/hoarder.env` - The Hoarder `ENV` file. Edit this file to configure Hoarder beyond the default. The web service and the workers service need to be restarted after editing this file:
-    
-    ```shell
-    sudo systemctl restart hoarder-workers hoarder-web
-    ```
-- `/var/lib/hoarder` - The Hoarder database location. If you delete the contents of this folder you will lose all your data.
+- `/etc/karakeep/karakeep.env` - The Karakeep `ENV` file. Edit this file to configure Karakeep beyond the default. The web service and the workers service need to be restarted after editing this file:
 
+    ```shell
+    sudo systemctl restart karakeep-workers karakeep-web
+    ```
+
+- `/var/lib/karakeep` - The Karakeep database location. If you delete the contents of this folder you will lose all your data.
+
+## Still Running Hoarder?
+
+There is a way to upgrade. Please see [Guides > Hoarder to Karakeep Migration](https://docs.karakeep.app/Guides/hoarder-to-karakeep-migration)

--- a/docs/versioned_docs/version-v0.23.1/14-Guides/04-hoarder-to-karakeep-migration.md
+++ b/docs/versioned_docs/version-v0.23.1/14-Guides/04-hoarder-to-karakeep-migration.md
@@ -16,3 +16,13 @@ index cdfc908..6297563 100644
 ```
 
 You can also change the `HOARDER_VERSION` environment variable but if you do so remember to change it in the `.env` file as well.
+
+## Migrating a Baremetal Installation
+
+If you previously used the [Debian/Ubuntu install script](https://docs.karakeep.app/Installation/debuntu) to install Hoarder, there is an option to migrate your installation to Karakeep.
+
+```bash
+bash karakeep-linux.sh migrate
+```
+
+This will migrate your installation with no user input required. After the migration, the script will also check for an update.


### PR DESCRIPTION
- Adds a migrate function so users can convert their Hoarder install to a Karakeep install
- The function will also check for an update after finishing the migration
- Various fixes and optimisations
- Update docs with migration info
- Replace mentions of Hoarder with Karakeep in Debuntu install page