### PR TITLE
feat(web): Add support for merging lists

### DIFF
--- a/apps/web/components/dashboard/lists/ListOptions.tsx
+++ b/apps/web/components/dashboard/lists/ListOptions.tsx
@@ -6,12 +6,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useTranslation } from "@/lib/i18n/client";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { FolderInput, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { ZBookmarkList } from "@karakeep/shared/types/lists";
 
 import { EditListModal } from "../lists/EditListModal";
 import DeleteListConfirmationDialog from "./DeleteListConfirmationDialog";
+import { MergeListModal } from "./MergeListModal";
 
 export function ListOptions({
   list,
@@ -28,6 +29,7 @@ export function ListOptions({
 
   const [deleteListDialogOpen, setDeleteListDialogOpen] = useState(false);
   const [newNestedListModalOpen, setNewNestedListModalOpen] = useState(false);
+  const [mergeListModalOpen, setMergeListModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
 
   return (
@@ -42,6 +44,11 @@ export function ListOptions({
       <EditListModal
         open={editModalOpen}
         setOpen={setEditModalOpen}
+        list={list}
+      />
+      <MergeListModal
+        open={mergeListModalOpen}
+        setOpen={setMergeListModalOpen}
         list={list}
       />
       <DeleteListConfirmationDialog
@@ -64,6 +71,13 @@ export function ListOptions({
         >
           <Plus className="size-4" />
           <span>{t("lists.new_nested_list")}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="flex gap-2"
+          onClick={() => setMergeListModalOpen(true)}
+        >
+          <FolderInput className="size-4" />
+          <span>{t("lists.merge_list")}</span>
         </DropdownMenuItem>
         <DropdownMenuItem
           className="flex gap-2"

--- a/apps/web/components/dashboard/lists/MergeListModal.tsx
+++ b/apps/web/components/dashboard/lists/MergeListModal.tsx
@@ -22,12 +22,13 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/use-toast";
 import { useTranslation } from "@/lib/i18n/client";
-import { useMergeLists } from "@hoarder/shared-react/hooks/lists";
-import { ZBookmarkList, zMergeListSchema } from "@hoarder/shared/types/lists";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { X } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+
+import { useMergeLists } from "@karakeep/shared-react/hooks/lists";
+import { ZBookmarkList, zMergeListSchema } from "@karakeep/shared/types/lists";
 
 import { BookmarkListSelector } from "./BookmarkListSelector";
 

--- a/apps/web/components/dashboard/lists/MergeListModal.tsx
+++ b/apps/web/components/dashboard/lists/MergeListModal.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import { ActionButton } from "@/components/ui/action-button";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "@/components/ui/use-toast";
+import { useTranslation } from "@/lib/i18n/client";
+import {
+  useDeleteBookmarkList,
+  useMergeLists,
+} from "@hoarder/shared-react/hooks/lists";
+import { ZBookmarkList, zMergeListSchema } from "@hoarder/shared/types/lists";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { X } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { BookmarkListSelector } from "./BookmarkListSelector";
+
+export function MergeListModal({
+  open: userOpen,
+  setOpen: userSetOpen,
+  list,
+  children,
+}: {
+  open?: boolean;
+  setOpen?: (v: boolean) => void;
+  list: ZBookmarkList;
+  children?: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  if (
+    (userOpen !== undefined && !userSetOpen) ||
+    (userOpen === undefined && userSetOpen)
+  ) {
+    throw new Error("You must provide both open and setOpen or neither");
+  }
+  const [customOpen, customSetOpen] = useState(false);
+  const form = useForm<z.infer<typeof zMergeListSchema>>({
+    resolver: zodResolver(zMergeListSchema),
+    defaultValues: {
+      sourceId: list?.id ?? "",
+      targetId: "",
+      deleteAfterMerge: true,
+    },
+  });
+  const [open, setOpen] = [
+    userOpen ?? customOpen,
+    userSetOpen ?? customSetOpen,
+  ];
+
+  useEffect(() => {
+    form.reset({
+      sourceId: list?.id ?? "",
+      targetId: "",
+      deleteAfterMerge: true,
+    });
+  }, [open]);
+
+  const { mutate: mergeLists, isPending: isMerging } = useMergeLists({
+    onSuccess: () => {
+      toast({
+        description: t("toasts.lists.merged"),
+      });
+      setOpen(false);
+      form.reset();
+    },
+    onError: (e) => {
+      if (e.data?.code == "BAD_REQUEST") {
+        if (e.data.zodError) {
+          toast({
+            variant: "destructive",
+            description: Object.values(e.data.zodError.fieldErrors)
+              .flat()
+              .join("\n"),
+          });
+        } else {
+          toast({
+            variant: "destructive",
+            description: e.message,
+          });
+        }
+      } else {
+        toast({
+          variant: "destructive",
+          title: t("common.something_went_wrong"),
+        });
+      }
+    },
+  });
+
+  const { mutate: deleteList, isPending: isDeleting } = useDeleteBookmarkList({
+    onSuccess: () => {
+      toast({
+        description: t("toasts.lists.deleted"),
+      });
+    },
+    onError: () => {
+      toast({
+        variant: "destructive",
+        description: t("common.something_went_wrong"),
+      });
+    },
+  });
+
+  const onSubmit = form.handleSubmit(
+    async (value: z.infer<typeof zMergeListSchema>) => {
+      mergeLists(value, {
+        onSuccess: () => {
+          if (value.deleteAfterMerge) {
+            deleteList({ listId: list.id });
+          }
+        },
+      });
+    },
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(s) => {
+        form.reset();
+        setOpen(s);
+      }}
+    >
+      {children && <DialogTrigger asChild>{children}</DialogTrigger>}
+      <DialogContent>
+        <Form {...form}>
+          <form onSubmit={onSubmit}>
+            <DialogHeader>
+              <DialogTitle>{t("lists.merge_list")}</DialogTitle>
+            </DialogHeader>
+            <div className="flex w-full gap-2 py-4">
+              <span className="inline-flex aspect-square h-10 items-center justify-center rounded border border-input bg-transparent px-2 text-2xl">
+                {list?.icon ?? "🚀"}
+              </span>
+              <Input
+                type="text"
+                className="w-full"
+                value={list?.name ?? ""}
+                disabled
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="deleteAfterMerge"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between space-x-2 space-y-0 pb-4">
+                  <label className="text-xs text-muted-foreground">
+                    {t("lists.delete_after_merge")}
+                  </label>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={(checked) => {
+                        field.onChange(checked);
+                      }}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="targetId"
+              render={({ field }) => (
+                <FormItem className="grow pb-4">
+                  <FormLabel>{t("lists.destination_list")}</FormLabel>
+                  <div className="flex items-center gap-1">
+                    <FormControl>
+                      <BookmarkListSelector
+                        hideSubtreeOf={list ? list.id : undefined}
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder={t("lists.no_destination")}
+                      />
+                    </FormControl>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => {
+                        form.reset({ targetId: "" });
+                      }}
+                    >
+                      <X />
+                    </Button>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="sm:justify-end">
+              <DialogClose asChild>
+                <Button type="button" variant="secondary">
+                  {t("actions.cancel")}
+                </Button>
+              </DialogClose>
+              <ActionButton
+                type="submit"
+                onClick={onSubmit}
+                loading={isMerging || isDeleting}
+              >
+                {t("actions.merge")}
+              </ActionButton>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -223,6 +223,10 @@
     "new_list": "New List",
     "edit_list": "Edit List",
     "new_nested_list": "New Nested List",
+    "merge_list": "Merge List",
+    "destination_list": "Destination List",
+    "delete_after_merge": "Delete original list after merge",
+    "no_destination": "No Destination",
     "parent_list": "Parent List",
     "no_parent": "No Parent",
     "list_type": "List Type",
@@ -361,7 +365,9 @@
     },
     "lists": {
       "created": "List has been created!",
-      "updated": "List has been updated!"
+      "updated": "List has been updated!",
+      "merged": "List has been merged!",
+      "deleted": "List has been deleted!"
     }
   },
   "banners": {

--- a/apps/web/lib/i18n/locales/zh/translation.json
+++ b/apps/web/lib/i18n/locales/zh/translation.json
@@ -214,6 +214,10 @@
     "favourites": "收藏",
     "new_list": "新列表",
     "new_nested_list": "新嵌套列表",
+    "merge_list": "合并列表",
+    "destination_list": "目标列表",
+    "delete_after_merge": "合并后删除源列表",
+    "no_destination": "未选中目标",
     "no_parent": "没有父级",
     "parent_list": "父级列表",
     "list_type": "列表类型",
@@ -309,7 +313,9 @@
     },
     "lists": {
       "created": "列表已创建！",
-      "updated": "列表已更新！"
+      "updated": "列表已更新！",
+      "merged": "列表已合并！",
+      "deleted": "列表已删除！"
     }
   },
   "cleanups": {

--- a/packages/shared-react/hooks/lists.ts
+++ b/packages/shared-react/hooks/lists.ts
@@ -36,6 +36,21 @@ export function useEditBookmarkList(
   });
 }
 
+export function useMergeLists(
+  ...opts: Parameters<typeof api.lists.merge.useMutation>
+) {
+  const apiUtils = api.useUtils();
+  return api.lists.merge.useMutation({
+    ...opts[0],
+    onSuccess: (res, req, meta) => {
+      apiUtils.lists.list.invalidate();
+      apiUtils.bookmarks.getBookmarks.invalidate({ listId: req.targetId });
+      apiUtils.lists.stats.invalidate();
+      return opts[0]?.onSuccess?.(res, req, meta);
+    },
+  });
+}
+
 export function useAddBookmarkToList(
   ...opts: Parameters<typeof api.lists.addToList.useMutation>
 ) {

--- a/packages/shared/types/lists.ts
+++ b/packages/shared/types/lists.ts
@@ -85,3 +85,16 @@ export const zEditBookmarkListSchemaWithValidation = zEditBookmarkListSchema
       "Smart lists cannot have unqualified terms (aka full text search terms) in the query",
     path: ["query"],
   });
+
+export const zMergeListSchema = z
+  .object({
+    sourceId: z.string().min(1, "Source list must be selected"),
+    targetId: z.string().min(1, "Destination list must be selected"),
+    deleteAfterMerge: z.boolean().default(true),
+  })
+  .refine((val) => val.sourceId !== val.targetId, {
+    message: "Cannot merge a list into itself",
+    path: ["targetId"],
+  });
+
+export type ZMergeList = z.infer<typeof zMergeListSchema>;

--- a/packages/shared/types/lists.ts
+++ b/packages/shared/types/lists.ts
@@ -88,9 +88,9 @@ export const zEditBookmarkListSchemaWithValidation = zEditBookmarkListSchema
 
 export const zMergeListSchema = z
   .object({
-    sourceId: z.string().min(1, "Source list must be selected"),
-    targetId: z.string().min(1, "Destination list must be selected"),
-    deleteAfterMerge: z.boolean().default(true),
+    sourceId: z.string(),
+    targetId: z.string(),
+    deleteSourceAfterMerge: z.boolean(),
   })
   .refine((val) => val.sourceId !== val.targetId, {
     message: "Cannot merge a list into itself",

--- a/packages/trpc/routers/lists.ts
+++ b/packages/trpc/routers/lists.ts
@@ -43,9 +43,14 @@ export const listsAppRouter = router({
   merge: authedProcedure
     .input(zMergeListSchema)
     .mutation(async ({ input, ctx }) => {
-      const sourceList = await List.fromId(ctx, input.sourceId);
-      const targetList = await List.fromId(ctx, input.targetId);
-      return await sourceList.mergeInto(targetList);
+      const [sourceList, targetList] = await Promise.all([
+        List.fromId(ctx, input.sourceId),
+        List.fromId(ctx, input.targetId),
+      ]);
+      return await sourceList.mergeInto(
+        targetList,
+        input.deleteSourceAfterMerge,
+      );
     }),
   delete: authedProcedure
     .input(

--- a/packages/trpc/routers/lists.ts
+++ b/packages/trpc/routers/lists.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   zBookmarkListSchema,
   zEditBookmarkListSchemaWithValidation,
+  zMergeListSchema,
   zNewBookmarkListSchema,
 } from "@karakeep/shared/types/lists";
 
@@ -38,6 +39,13 @@ export const listsAppRouter = router({
     .use(ensureListOwnership)
     .mutation(async ({ input, ctx }) => {
       return await ctx.list.update(input);
+    }),
+  merge: authedProcedure
+    .input(zMergeListSchema)
+    .mutation(async ({ input, ctx }) => {
+      const sourceList = await List.fromId(ctx, input.sourceId);
+      const targetList = await List.fromId(ctx, input.targetId);
+      return await sourceList.mergeInto(targetList);
     }),
   delete: authedProcedure
     .input(


### PR DESCRIPTION
This PR implements the feature requested in #1060, enabling users to merge contents from one list into another selected non-smart list with deduplication functionality.

#### Key Changes
- Added new merge functionality with deduplication between lists in trpc/models
- Added corresponding UI components to support the merge feature (see screenshot below)

#### Screenshot
<div style="display: flex; flex-direction: column; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/28de2a8c-1015-4934-8a82-679d5c6652a3" height="300" alt="Merge list interface" style="max-height: 100%; width: auto;"/>
  <img src="https://github.com/user-attachments/assets/8ef41fe0-5f68-4fca-b552-3e2dec6bc545" width="600" alt="Merge confirmation dialog" style="max-width: 100%; height: auto;"/>
</div>

#### Internationalization (i18n) Notes
New form labels have been added with translations for:
 - English (en)
 - Chinese (zh)
 
Translations for other supported languages are currently missing. I’m unsure if it’s expected for contributors to provide full translations, or if there’s a separate process for translations. I'm happy to add AI-generated translations if that's acceptable--just let me know.

#### Related Issue Discovery
During implementation, I noticed an edge case in how text-type bookmarks are handled during import, and it could affect the expected user flow:
When importing bookmarks from files that exported from this app, the system creates new text-type bookmarks with identical content but different bookmark IDs in each import. In a word, the import function does not deduplicate text-type bookmarks. 

This leads to:
  - Multiple imported lists containing duplicate bookmarks with different IDs.
  - The merge function is unable to deduplicate these bookmarks, as it relies on bookmark IDs for comparison.
  - That might break the ideal workflow described in #1060, where users re-import to sync updates and expect merging to help clean up duplicates.
    
If this behavior isn’t intended, I think it might make sense to track it as a separate issue.