### PR TITLE
i18n: Add Korean language

### DIFF
--- a/packages/shared/langs.ts
+++ b/packages/shared/langs.ts
@@ -12,6 +12,7 @@ export const langNameMappings: Record<string, string> = {
   hu: "Hungarian",
   it: "Italian",
   ja: "Japanese",
+  ko: "Korean",
   pl: "Polish",
   pt_BR: "Portuguese (Brazil)",
   ru: "Russian",


### PR DESCRIPTION
### Summary

- Added `"ko": "Korean"` to `langNameMappings` in `langs.ts`.
- Korean translation file already exists in `locales/ko/translation.json`.

This allows users to select Korean in the language dropdown from the settings page.