### PR TITLE
Update meilisearch version to 13.3 in both docker compose files

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
       - --remote-debugging-port=9222
       - --hide-scrollbars
   meilisearch:
-    image: getmeili/meilisearch:v1.11.1
+    image: getmeili/meilisearch:v1.13.3
     volumes:
       - meilisearch:/meili_data
   workers:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - --remote-debugging-port=9222
       - --hide-scrollbars
   meilisearch:
-    image: getmeili/meilisearch:v1.11.1
+    image: getmeili/meilisearch:v1.13.3
     restart: unless-stopped
     env_file:
       - .env

--- a/packages/e2e_tests/docker-compose.yml
+++ b/packages/e2e_tests/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       MEILI_MASTER_KEY: dummy
       MEILI_ADDR: http://meilisearch:7700
   meilisearch:
-    image: getmeili/meilisearch:v1.11.1
+    image: getmeili/meilisearch:v1.13.3
     restart: unless-stopped
     environment:
       MEILI_NO_ANALYTICS: "true"


### PR DESCRIPTION
Hi, as mentioned on discord this PR updates meilisearch to 1.13.3.

The big difference comes with 1.12.0 (https://www.meilisearch.com/blog/meilisearch-1-12) as it's introducing a new indexing engine which improves speed and should reduce memory usage. This works fine locally as reported by [others](https://discord.com/channels/1223681308962721802/1223681309503651844/1328993475496120341).

I directly moved to the current latest version 1.13.3 as it seems there are no breaking changes related to the codebase: https://github.com/meilisearch/meilisearch/releases/tag/v1.13.0 or [docker hub ](https://hub.docker.com/layers/getmeili/meilisearch/v1.13.3/images/sha256-c4d6ab59c18d7b3636e82af862c31861ccf8afb3e9c14dddf9d3e868840667cd). 1.13.0 also introduces AI-powered search which could maybe be handy in the future.
