### PR TITLE
feat: Add import support for Tab Session Manager

### DIFF
--- a/apps/web/components/settings/ImportExport.tsx
+++ b/apps/web/components/settings/ImportExport.tsx
@@ -16,6 +16,7 @@ import {
   parseNetscapeBookmarkFile,
   parseOmnivoreBookmarkFile,
   parsePocketBookmarkFile,
+  parseTabSessionManagerStateFile,
 } from "@/lib/importBookmarkParser";
 import { cn } from "@/lib/utils";
 import { useMutation } from "@tanstack/react-query";
@@ -161,7 +162,13 @@ export function ImportExportRow() {
       source,
     }: {
       file: File;
-      source: "html" | "pocket" | "omnivore" | "hoarder" | "linkwarden";
+      source:
+        | "html"
+        | "pocket"
+        | "omnivore"
+        | "hoarder"
+        | "linkwarden"
+        | "tab-session-manager";
     }) => {
       if (source === "html") {
         return await parseNetscapeBookmarkFile(file);
@@ -173,6 +180,8 @@ export function ImportExportRow() {
         return await parseOmnivoreBookmarkFile(file);
       } else if (source === "linkwarden") {
         return await parseLinkwardenBookmarkFile(file);
+      } else if (source === "tab-session-manager") {
+        return await parseTabSessionManagerStateFile(file);
       } else {
         throw new Error("Unknown source");
       }
@@ -340,6 +349,25 @@ export function ImportExportRow() {
             className="flex items-center gap-2"
             onFileSelect={(file) =>
               runUploadBookmarkFile({ file, source: "linkwarden" })
+            }
+          >
+            <p>Import</p>
+          </FilePickerButton>
+        </ImportCard>
+        <ImportCard
+          text="Tab Session Manager"
+          description={t(
+            "settings.import.import_bookmarks_from_tab_session_manager_export",
+          )}
+        >
+          <FilePickerButton
+            size={"sm"}
+            loading={false}
+            accept=".json"
+            multiple={false}
+            className="flex items-center gap-2"
+            onFileSelect={(file) =>
+              runUploadBookmarkFile({ file, source: "tab-session-manager" })
             }
           >
             <p>Import</p>

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -142,6 +142,7 @@
       "import_bookmarks_from_omnivore_export": "Import Bookmarks from Omnivore export",
       "import_bookmarks_from_linkwarden_export": "Import Bookmarks from Linkwarden export",
       "import_bookmarks_from_hoarder_export": "Import Bookmarks from Hoarder export",
+      "import_bookmarks_from_tab_session_manager_export": "Import Bookmarks from Tab Session Manager",
       "export_links_and_notes": "Export Links and Notes",
       "imported_bookmarks": "Imported Bookmarks"
     },

--- a/apps/web/lib/i18n/locales/es/translation.json
+++ b/apps/web/lib/i18n/locales/es/translation.json
@@ -73,7 +73,8 @@
       "import_bookmarks_from_hoarder_export": "Importar marcadores desde exportación de Hoarder",
       "import_bookmarks_from_html_file": "Importar marcadores desde archivo HTML",
       "import_bookmarks_from_omnivore_export": "Importar marcadores desde exportación de Omnivore",
-      "import_bookmarks_from_linkwarden_export": "Importar marcadores desde Linkwarden"
+      "import_bookmarks_from_linkwarden_export": "Importar marcadores desde Linkwarden",
+      "import_bookmarks_from_tab_session_manager_export": "Importar marcadores desde Tab Session Manager"
     },
     "api_keys": {
       "api_keys": "Claves APIs",

--- a/apps/web/lib/importBookmarkParser.ts
+++ b/apps/web/lib/importBookmarkParser.ts
@@ -183,67 +183,14 @@ export async function parseTabSessionManagerStateFile(
   const textContent = await file.text();
 
   const zTab = z.object({
-    id: z.number(),
-    index: z.number(),
-    windowId: z.number(),
-    highlighted: z.boolean(),
-    active: z.boolean(),
-    attention: z.boolean(),
-    pinned: z.boolean(),
-    status: z.string(),
-    hidden: z.boolean(),
-    discarded: z.boolean(),
-    incognito: z.boolean(),
-    width: z.number(),
-    height: z.number(),
-    lastAccessed: z.number(),
-    audible: z.boolean(),
-    autoDiscardable: z.boolean(),
-    mutedInfo: z.object({
-      muted: z.boolean(),
-    }),
-    isArticle: z.boolean().optional(),
-    isInReaderMode: z.boolean(),
-    sharingState: z.object({
-      camera: z.boolean(),
-      microphone: z.boolean(),
-    }),
-    successorTabId: z.number(),
-    cookieStoreId: z.string(),
     url: z.string(),
     title: z.string(),
-    favIconUrl: z.string().optional(),
-  });
-
-  const zWindow = z.record(z.string(), zTab);
-
-  const zWindows = z.record(z.string(), zWindow);
-
-  const zWindowInfo = z.object({
-    id: z.number(),
-    focused: z.boolean(),
-    top: z.number(),
-    left: z.number(),
-    width: z.number(),
-    height: z.number(),
-    incognito: z.boolean(),
-    type: z.string(),
-    state: z.string(),
-    alwaysOnTop: z.boolean(),
-    title: z.string(),
+    lastAccessed: z.number(),
   });
 
   const zSession = z.object({
-    windows: zWindows,
-    windowsNumber: z.number(),
-    windowsInfo: z.record(z.string(), zWindowInfo),
-    tabsNumber: z.number(),
-    name: z.string(),
+    windows: z.record(z.string(), z.record(z.string(), zTab)),
     date: z.number(),
-    lastEditedTime: z.number(),
-    tags: z.array(z.string()).optional(),
-    sessionStartTime: z.number(),
-    id: z.string(),
   });
 
   const zTabSessionManagerSchema = z.array(zSession);

--- a/apps/web/lib/importBookmarkParser.ts
+++ b/apps/web/lib/importBookmarkParser.ts
@@ -177,6 +177,99 @@ export async function parseLinkwardenBookmarkFile(
   });
 }
 
+export async function parseTabSessionManagerStateFile(
+  file: File,
+): Promise<ParsedBookmark[]> {
+  const textContent = await file.text();
+
+  const zTab = z.object({
+    id: z.number(),
+    index: z.number(),
+    windowId: z.number(),
+    highlighted: z.boolean(),
+    active: z.boolean(),
+    attention: z.boolean(),
+    pinned: z.boolean(),
+    status: z.string(),
+    hidden: z.boolean(),
+    discarded: z.boolean(),
+    incognito: z.boolean(),
+    width: z.number(),
+    height: z.number(),
+    lastAccessed: z.number(),
+    audible: z.boolean(),
+    autoDiscardable: z.boolean(),
+    mutedInfo: z.object({
+      muted: z.boolean(),
+    }),
+    isArticle: z.boolean().optional(),
+    isInReaderMode: z.boolean(),
+    sharingState: z.object({
+      camera: z.boolean(),
+      microphone: z.boolean(),
+    }),
+    successorTabId: z.number(),
+    cookieStoreId: z.string(),
+    url: z.string(),
+    title: z.string(),
+    favIconUrl: z.string().optional(),
+  });
+
+  const zWindow = z.record(z.string(), zTab);
+
+  const zWindows = z.record(z.string(), zWindow);
+
+  const zWindowInfo = z.object({
+    id: z.number(),
+    focused: z.boolean(),
+    top: z.number(),
+    left: z.number(),
+    width: z.number(),
+    height: z.number(),
+    incognito: z.boolean(),
+    type: z.string(),
+    state: z.string(),
+    alwaysOnTop: z.boolean(),
+    title: z.string(),
+  });
+
+  const zSession = z.object({
+    windows: zWindows,
+    windowsNumber: z.number(),
+    windowsInfo: z.record(z.string(), zWindowInfo),
+    tabsNumber: z.number(),
+    name: z.string(),
+    date: z.number(),
+    lastEditedTime: z.number(),
+    tags: z.array(z.string()).optional(),
+    sessionStartTime: z.number(),
+    id: z.string(),
+  });
+
+  const zTabSessionManagerSchema = z.array(zSession);
+
+  const parsed = zTabSessionManagerSchema.safeParse(JSON.parse(textContent));
+  if (!parsed.success) {
+    throw new Error(
+      `The uploaded JSON file contains an invalid Tab Session Manager bookmark file: ${parsed.error.toString()}`,
+    );
+  }
+
+  // Get the object in data that has the most recent `date`
+  const { windows } = parsed.data.reduce((prev, curr) =>
+    prev.date > curr.date ? prev : curr,
+  );
+
+  return Object.values(windows).flatMap((window) =>
+    Object.values(window).map((tab) => ({
+      title: tab.title,
+      content: { type: BookmarkTypes.LINK as const, url: tab.url },
+      tags: [],
+      addDate: tab.lastAccessed,
+    })),
+  );
+}
+
 export function deduplicateBookmarks(
   bookmarks: ParsedBookmark[],
 ): ParsedBookmark[] {


### PR DESCRIPTION
Tab Session Manager is a browser extension ([Chrome](https://chromewebstore.google.com/detail/tab-session-manager/iaiomicjabeggjcfkbimgmglanimpnae), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/tab-session-manager/)) to manually or automatically save the state of your browser (windows and tabs). I personally use it regularly to combat my hundreds of open tabs nature.

Adding support to import an Sessions export file.

The JSON file generated by Tab Session Manager contains multiple Sessions (all of the manually or automatically created), so the import will get the newest session and import all of the tabs across windows.