### PR TITLE
Replace hoarder with karakeep in github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,15 +47,15 @@ body:
     attributes:
       label: Device Details
       description: |
-        If this is an issue that occurs when using the Hoarder interface, please provide details of the device/browser used which presents the reported issue.
+        If this is an issue that occurs when using the Karakeep interface, please provide details of the device/browser used which presents the reported issue.
       placeholder: (eg. Firefox 97 (64-bit) on Windows 11)
     validations:
       required: false
   - type: input
     id: bsversion
     attributes:
-      label: Exact Hoarder Version
-      description: This can be found in the bottom left of the page (eg Hoarder v0.18.0)
+      label: Exact Karakeep Version
+      description: This can be found in the bottom left of the page (e.g. Karakeep v0.18.0)
       placeholder: (eg. v0.18.0)
     validations:
       required: true
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Have you checked the troubleshooting guide?
       description: |
-        We have a troubleshooting guide that you can find [here](https://docs.hoarder.app/next/troubleshooting). Please check it out as you might find a solution to your problem.
+        We have a troubleshooting guide that you can find [here](https://docs.karakeep.app/next/troubleshooting). Please check it out as you might find a solution to your problem.
       options:
         - label: I have checked the troubleshooting guide and I haven't found a solution to my problem
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,20 +1,20 @@
 name: Feature Request
-description: Request a new feature or idea to be added to Hoarder
+description: Request a new feature or idea to be added to Karakeep
 labels: ["feature request", "status/untriaged"]
 body:
   - type: textarea
     id: description
     attributes:
       label: Describe the feature you'd like
-      description: Provide a clear description of the feature you'd like implemented in Hoarder
+      description: Provide a clear description of the feature you'd like implemented in Karakeep
     validations:
       required: true
   - type: textarea
     id: benefits
     attributes:
-      label: Describe the benefits this would bring to existing Hoarder users
+      label: Describe the benefits this would bring to existing Karakeep users
       description: |
-        Explain the measurable benefits this feature would achieve for existing Hoarder users.
+        Explain the measurable benefits this feature would achieve for existing Karakeep users.
         These benefits should details outcomes in terms of what this request solves/achieves, and should not be specific to implementation.
         This helps us understand the core desired goal so that a variety of potential implementations could be explored.
         This field is important. Lack of input here may lead to early issue closure.
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Have you searched for an existing open/closed issue?
       description: |
-        To help us keep these issues under control, please ensure you have first [searched our issue list](https://github.com/hoarder-app/Hoarder/issues?q=is%3Aissue) for any existing issues that cover the fundamental benefit/goal of your request.
+        To help us keep these issues under control, please ensure you have first [searched our issue list](https://github.com/karakeep-app/karakeep/issues?q=is%3Aissue) for any existing issues that cover the fundamental benefit/goal of your request.
       options:
         - label: I have searched for existing issues and none cover my fundamental request
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,8 +1,8 @@
 name: Question / Support Request
-description: Get help with anything related to Hoarder
+description: Get help with anything related to Karakeep
 labels: ["question"]
 body:
   - type: markdown
     attributes:
       value: |
-        We use Github discussions for anything that's not a bug report or a feature request. Please ask your question in the [Q&A section](https://github.com/hoarder-app/hoarder/discussions/categories/q-a) and someone will answer it soon!
+        We use Github discussions for anything that's not a bug report or a feature request. Please ask your question in the [Q&A section](https://github.com/karakeep-app/karakeep/discussions/categories/q-a) and someone will answer it soon!


### PR DESCRIPTION
While creating an issue yesterday I noticed that it still contains the old name. 
I replaced hoarder with karakeep in all three github templates.