### PR TITLE
fix: fit popover content box to emoji picker size

### DIFF
--- a/apps/web/components/dashboard/lists/EditListModal.tsx
+++ b/apps/web/components/dashboard/lists/EditListModal.tsx
@@ -225,7 +225,7 @@ export function EditListModal({
                           <PopoverTrigger className="h-full rounded border border-input px-2 text-2xl">
                             {field.value}
                           </PopoverTrigger>
-                          <PopoverContent>
+                          <PopoverContent className="w-auto">
                             <Picker
                               data={data}
                               onEmojiSelect={(e: { native: string }) =>


### PR DESCRIPTION
Currently when adjusting the emoji for a list, the Popover-Content box is smaller than the actual emoji picker "box" as seen on the screenshot:
![image](https://github.com/user-attachments/assets/2a71f7ae-9117-440a-af71-837788243364)

I fixed this problem with `PopoverContent className="w-auto">` which was also used in https://github.com/karakeep-app/karakeep/blob/cf97bace33fdd14f29ce947d55d17cba8fa85c11/apps/web/components/dashboard/bookmarks/EditBookmarkDialog.tsx#L283

With this fix it looks like this:
![image](https://github.com/user-attachments/assets/f3231245-c25a-4292-9a4d-b7378125d340)
