### PR TITLE
feat(mobile/android): Add monochrome app icon

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -34,7 +34,8 @@
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#000000"
+        "backgroundColor": "#000000",
+        "monochromeImage": "./assets/adaptive-icon.png"
       },
       "splash": {
         "image": "./assets/splash.png",


### PR DESCRIPTION
This adds the "monochromeImage" setting to add support for [Themed App Icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive).

I tested it locally on an android emulator, and it looks like this:
![Screenshot_1744538046](https://github.com/user-attachments/assets/753d11fa-4348-4fa8-8eb2-fbe8a92e5058)

Closes #885 