### PR TITLE
Auth/case insensitive email

### DIFF
--- a/apps/web/server/custom-adapter.ts
+++ b/apps/web/server/custom-adapter.ts
@@ -1,8 +1,14 @@
-import { DrizzleAdapter } from "@auth/drizzle-adapter";
-import { sql } from "drizzle-orm";
 import type { Adapter, AdapterUser } from "@auth/core/adapters";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
-import { users } from "@karakeep/db/schema";
+import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import { sql } from "drizzle-orm";
+
+import {
+  accounts,
+  sessions,
+  users,
+  verificationTokens,
+} from "@karakeep/db/schema";
 
 export function CustomDrizzleAdapter(
   client: BaseSQLiteDatabase<"sync" | "async", any, any>,
@@ -11,12 +17,10 @@ export function CustomDrizzleAdapter(
     accountsTable: typeof accounts;
     sessionsTable: typeof sessions;
     verificationTokensTable: typeof verificationTokens;
-  }
+  },
 ): Adapter {
-  // Initialize the default Drizzle adapter
   const defaultAdapter = DrizzleAdapter(client, schema);
 
-  // Override only getUserByEmail
   return {
     ...defaultAdapter,
     async getUserByEmail(email: string): Promise<AdapterUser | null> {

--- a/apps/web/server/custom-adapter.ts
+++ b/apps/web/server/custom-adapter.ts
@@ -1,0 +1,32 @@
+import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import { sql } from "drizzle-orm";
+import type { Adapter, AdapterUser } from "@auth/core/adapters";
+import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
+import { users } from "@karakeep/db/schema";
+
+export function CustomDrizzleAdapter(
+  client: BaseSQLiteDatabase<"sync" | "async", any, any>,
+  schema: {
+    usersTable: typeof users;
+    accountsTable: typeof accounts;
+    sessionsTable: typeof sessions;
+    verificationTokensTable: typeof verificationTokens;
+  }
+): Adapter {
+  // Initialize the default Drizzle adapter
+  const defaultAdapter = DrizzleAdapter(client, schema);
+
+  // Override only getUserByEmail
+  return {
+    ...defaultAdapter,
+    async getUserByEmail(email: string): Promise<AdapterUser | null> {
+      if (!email) return null;
+      const result = await client
+        .select()
+        .from(users)
+        .where(sql`lower(${users.email}) = ${email.toLowerCase()}`)
+        .get();
+      return (result as AdapterUser) || null;
+    },
+  };
+}

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -1,6 +1,7 @@
 import type { AdapterAccount } from "@auth/core/adapters";
+import type { SQL } from "drizzle-orm";
 import { createId } from "@paralleldrive/cuid2";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
   AnySQLiteColumn,
   index,
@@ -9,6 +10,7 @@ import {
   sqliteTable,
   text,
   unique,
+  uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
@@ -25,6 +27,29 @@ function modifiedAtField() {
     .$onUpdate(() => new Date());
 }
 
+export const users = sqliteTable(
+  "user",
+  {
+    id: text("id")
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    name: text("name").notNull(),
+    email: text("email").notNull(),
+    emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
+    image: text("image"),
+    password: text("password"),
+    role: text("role", { enum: ["admin", "user"] }).default("user"),
+  },
+  (table) => [uniqueIndex("emailUniqueIndex").on(lower(table.email))],
+);
+
+// Custom lower function for case-insensitive email uniqueness
+export function lower(email: AnySQLiteColumn): SQL {
+  return sql`lower(${email})`;
+}
+
+/******
 export const users = sqliteTable("user", {
   id: text("id")
     .notNull()
@@ -37,7 +62,7 @@ export const users = sqliteTable("user", {
   password: text("password"),
   role: text("role", { enum: ["admin", "user"] }).default("user"),
 });
-
+*******/
 export const accounts = sqliteTable(
   "account",
   {

--- a/packages/trpc/auth.ts
+++ b/packages/trpc/auth.ts
@@ -1,8 +1,9 @@
 import { randomBytes } from "crypto";
 import * as bcrypt from "bcryptjs";
+import { sql } from "drizzle-orm";
 
 import { db } from "@karakeep/db";
-import { apiKeys } from "@karakeep/db/schema";
+import { apiKeys, users } from "@karakeep/db/schema";
 import serverConfig from "@karakeep/shared/config";
 import { authFailureLogger } from "@karakeep/shared/logger";
 
@@ -84,8 +85,11 @@ export async function validatePassword(email: string, password: string) {
   if (serverConfig.auth.disablePasswordAuth) {
     throw new Error("Password authentication is currently disabled");
   }
+
+  const normalizedEmail = email.toLowerCase();
   const user = await db.query.users.findFirst({
-    where: (u, { eq }) => eq(u.email, email),
+    //    where: (u, { eq }) => eq(u.email, email),
+    where: sql`LOWER(${users.email}) = ${normalizedEmail}`,
   });
 
   if (!user) {


### PR DESCRIPTION
This pull request addresses:

[Issue #410 (comment)](https://github.com/karakeep-app/karakeep/issues/410#issuecomment-2740961459)

[Issue #411 (comment)](https://github.com/karakeep-app/karakeep/issues/411#issuecomment-2744976404)

[Issue #1189](https://github.com/karakeep-app/karakeep/issues/1189)

✅ What’s fixed:
Email matching now uses case-insensitive comparisons. 
OAuth no uses userinfo so it will much more reliably have name/nickname/username claims
DangerousAccountLinking is useable if you capitalized your email at account creation!


📌 Why this matters:
Email is technically case-sensitive, but in practice, treating it as case-insensitive is expected behavior.
Casing mismatches from normalizing email in database can cause subtle bugs and unexpected failures especially when using foreign characters. 

ℹ️ Notes:
Unique index ensure no duplicate emails 
Users still see their email as they entered it — this change only affects backend logic.
This is my first real PR to this repo — happy to revise anything that needs improvement. If i did anything poorly let me know I'll do better next time. 

Some changes will break things: 
WellknownAddress is excepted to point to well known address
Schema change to unique index will cause break if different cases of the "same" email are present. 