### PR TITLE
FIxed sidebar link to github

### DIFF
--- a/apps/web/components/shared/sidebar/Sidebar.tsx
+++ b/apps/web/components/shared/sidebar/Sidebar.tsx
@@ -32,7 +32,11 @@ export default async function Sidebar({
       </div>
       {extraSections}
       <Link
-        href={`https://github.com/karakeep-app/karakeep`}
+        href={
+          serverConfig.serverVersion === "nightly"
+            ? `https://github.com/karakeep-app/karakeep`
+            : `https://github.com/hoarder-app/hoarder/releases/tag/v${serverConfig.serverVersion}`
+        }
         target="_blank"
         rel="noopener noreferrer"
         className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400 hover:underline"

--- a/apps/web/components/shared/sidebar/Sidebar.tsx
+++ b/apps/web/components/shared/sidebar/Sidebar.tsx
@@ -32,7 +32,7 @@ export default async function Sidebar({
       </div>
       {extraSections}
       <Link
-        href={`https://github.com/hoarder-app/hoarder/releases/tag/v${serverConfig.serverVersion}`}
+        href={`https://github.com/karakeep-app/karakeep`}
         target="_blank"
         rel="noopener noreferrer"
         className="mt-auto flex items-center border-t pt-2 text-sm text-gray-400 hover:underline"


### PR DESCRIPTION
A. v${serverConfig.serverVersion} for docker images is translated to `vnightly` which is absent.

B. Link points to hoarder, which redirects after, probably legacy.

C. For me, it is more convenient to go directly to repository home and navigate from there. 