### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 Karakeep (previously Hoarder) is a self-hostable bookmark-everything app with a touch of AI for the data hoarders out there.
 
+<a href="https://glama.ai/mcp/servers/@karakeep-app/karakeep">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@karakeep-app/karakeep/badge" alt="Karakeep server MCP server" />
+</a>
+
 ![homepage screenshot](https://github.com/hoarder-app/hoarder/blob/main/screenshots/homepage.png?raw=true)
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Karakeep MCP server](https://glama.ai/mcp/servers/@karakeep-app/karakeep) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@karakeep-app/karakeep">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@karakeep-app/karakeep/badge" alt="Karakeep server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.