### PR TITLE
Fix icon visibility in dark mode for Firefox extension

### DIFF
--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -12,18 +12,18 @@
     "default_popup": "index.html",
     "theme_icons": [
       {
-        "light": "public/logo-16-darkmode.png",
-        "dark": "public/logo-16.png",
+        "light": "public/logo-16.png",
+        "dark": "public/logo-16-darkmode.png",
         "size": 16
       },
       {
-        "light": "public/logo-48-darkmode.png",
-        "dark": "public/logo-48.png",
+        "light": "public/logo-48.png",
+        "dark": "public/logo-48-darkmode.png",
         "size": 48
       },
       {
-        "light": "public/logo-128-darkmode.png",
-        "dark": "public/logo-128.png",
+        "light": "public/logo-128.png",
+        "dark": "public/logo-128-darkmode.png",
         "size": 128
       }
     ]


### PR DESCRIPTION
This fixes #1282. Seemed like it was just a simple error mixing up light mode and dark mode images. I replicated the issue in my browser and then made the fix and it came up fine.

I did have some linting issues but I ignored them as I didn't want to include linting errors I didn't touch in the fix.

This is the current version:
![Current version](https://github.com/user-attachments/assets/d5736a87-0ca1-4f43-ad63-3f5a4b941f18)

This is the version with the fix:
![Fixed version](https://github.com/user-attachments/assets/46bf1ef9-f734-42fe-aadd-39b305f420bc)

If you want me to include the linting fixes in this PR, just let me know and I'll put them in.