### PR TITLE
readme: replace hoarder with karakeep in urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
-    <a href="https://github.com/hoarder-app/hoarder/actions/workflows/ci.yml">
-        <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/hoarder-app/hoarder/ci.yml" />
+    <a href="https://github.com/karakeep-app/karakeep/actions/workflows/ci.yml">
+        <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/karakeep-app/karakeep/ci.yml" />
     </a>
-    <a href="https://github.com/hoarder-app/hoarder/releases">
-        <img alt="GitHub Release" src="https://img.shields.io/github/v/release/hoarder-app/hoarder" />
+    <a href="https://github.com/karakeep-app/karakeep/releases">
+        <img alt="GitHub Release" src="https://img.shields.io/github/v/release/karakeep-app/karakeep" />
     </a>
     <a href="https://discord.gg/NrgeYywsFh">
         <img alt="Discord" src="https://img.shields.io/discord/1223681308962721802?label=chat%20on%20discord" />
@@ -17,7 +17,7 @@
 
 Karakeep (previously Hoarder) is a self-hostable bookmark-everything app with a touch of AI for the data hoarders out there.
 
-![homepage screenshot](https://github.com/hoarder-app/hoarder/blob/main/screenshots/homepage.png?raw=true)
+![homepage screenshot](https://github.com/karakeep-app/karakeep/blob/main/screenshots/homepage.png?raw=true)
 
 ## Features
 
@@ -27,8 +27,8 @@ Karakeep (previously Hoarder) is a self-hostable bookmark-everything app with a 
 - 🔎 Full text search of all the content stored.
 - ✨ AI-based (aka chatgpt) automatic tagging. With supports for local models using ollama!
 - 🎆 OCR for extracting text from images.
-- 🔖 [Chrome plugin](https://chromewebstore.google.com/detail/hoarder/kgcjekpmcjjogibpjebkhaanilehneje) and [Firefox addon](https://addons.mozilla.org/en-US/firefox/addon/hoarder/) for quick bookmarking.
-- 📱 An [iOS app](https://apps.apple.com/us/app/hoarder-app/id6479258022), and an [Android app](https://play.google.com/store/apps/details?id=app.hoarder.hoardermobile&pcampaignid=web_share).
+- 🔖 [Chrome plugin](https://chromewebstore.google.com/detail/karakeep/kgcjekpmcjjogibpjebkhaanilehneje) and [Firefox addon](https://addons.mozilla.org/en-US/firefox/addon/karakeep/) for quick bookmarking.
+- 📱 An [iOS app](https://apps.apple.com/us/app/karakeep-app/id6479258022), and an [Android app](https://play.google.com/store/apps/details?id=app.hoarder.hoardermobile&pcampaignid=web_share).
 - 📰 Auto hoarding from RSS feeds.
 - 🔌 REST API.
 - 🌐 Mutli-language support.
@@ -44,11 +44,11 @@ Karakeep (previously Hoarder) is a self-hostable bookmark-everything app with a 
 
 ## Documentation
 
-- [Installation](https://docs.hoarder.app/Installation/docker)
-- [Configuration](https://docs.hoarder.app/configuration)
-- [Screenshots](https://docs.hoarder.app/screenshots)
-- [Security Considerations](https://docs.hoarder.app/security-considerations)
-- [Development](https://docs.hoarder.app/Development/setup)
+- [Installation](https://docs.karakeep.app/Installation/docker)
+- [Configuration](https://docs.karakeep.app/configuration)
+- [Screenshots](https://docs.karakeep.app/screenshots)
+- [Security Considerations](https://docs.karakeep.app/security-considerations)
+- [Development](https://docs.karakeep.app/Development/setup)
 
 ## Demo
 
@@ -105,4 +105,4 @@ If you're enjoying using Karakeep, drop a ⭐️ on the repo!
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hoarder-app/hoarder&type=Date)](https://star-history.com/#hoarder-app/hoarder&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=karakeep-app/karakeep&type=Date)](https://star-history.com/#karakeep-app/karakeep&Date)


### PR DESCRIPTION
This PR updates urls referencing hoarder with karakeep in throughout the README.
It leaves the Weblate and Android app urls unchanged since alternatives to these don't yet exist.