### PR TITLE
Feature: Add US English as option in User Settings

### DIFF
--- a/apps/web/lib/i18n/locales/en_US/translation.json
+++ b/apps/web/lib/i18n/locales/en_US/translation.json
@@ -149,10 +149,10 @@
       "align_right": "Right Align"
     },
     "quickly_focus": "You can quickly focus on this field by pressing ⌘ + E",
-    "multiple_urls_dialog_title": "Importing URLs as separate Bookmarks?",
+    "multiple_urls_dialog_title": "Importing URLs as separate bookmarks?",
     "multiple_urls_dialog_desc": "The input contains multiple URLs on separate lines. Do you want to import them as separate bookmarks?",
-    "import_as_text": "Import as Text Bookmark",
-    "import_as_separate_bookmarks": "Import as separate Bookmarks",
+    "import_as_text": "Import as text bookmark",
+    "import_as_separate_bookmarks": "Import as separate bookmarks",
     "placeholder": "Paste a link or an image, write a note, or drag and drop an image in here…",
     "placeholder_v2": "Paste a link, write a note, or drop an image…",
     "new_item": "NEW ITEM",
@@ -266,7 +266,7 @@
       "rule_has_been_created": "Rule's been created!",
       "rule_has_been_updated": "Rule has been updated!",
       "rule_has_been_deleted": "Rule's been deleted!",
-      "no_rules_created_yet": "No rules created yet, dude",
+      "no_rules_created_yet": "No rules have been created yet",
       "create_your_first_rule": "Create your first rule to automate your workflow",
       "conditions_types": {
         "always": "Always",
@@ -381,7 +381,7 @@
     "created_on_or_before": "Created on or Before",
     "not_created_on_or_before": "Not Created on or Before",
     "created_within": "Created Within",
-    "created_earlier_than": "Created Earlier Than",
+    "created_earlier_than": "Created earlier than",
     "day_s": " Day(s)",
     "week_s": " Week(s)",
     "month_s": " Month(s)",
@@ -390,17 +390,17 @@
     "week_s_ago": " Week(s) Ago",
     "month_s_ago": " Month(s) Ago",
     "year_s_ago": " Year(s) Ago",
-    "url_contains": "URL Contains",
+    "url_contains": "URL contains",
     "is_in_list": "Is In List",
     "is_not_in_list": "Is not In List",
     "has_tag": "Has Tag",
-    "does_not_have_tag": "Does Not Have Tag",
-    "full_text_search": "Full Text Search",
+    "does_not_have_tag": "Does not have tag",
+    "full_text_search": "Full text search",
     "type_is": "Type is",
     "type_is_not": "Type is not",
-    "url_does_not_contain": "URL Does Not Contain",
-    "is_from_feed": "Is from RSS Feed",
-    "is_not_from_feed": "Is not from RSS Feed",
+    "url_does_not_contain": "URL does not contain",
+    "is_from_feed": "Is from RSS feed",
+    "is_not_from_feed": "Is not from RSS feed",
     "and": "And",
     "or": "Or"
   },
@@ -411,18 +411,18 @@
   },
   "toasts": {
     "bookmarks": {
-      "deleted": "The bookmark has been deleted!",
-      "refetch": "Re-fetch has been added to the queue!",
+      "deleted": "The bookmark has been deleted",
+      "refetch": "Re-fetch has been added to the queue",
       "full_page_archive": "Full Page Archive creation has been triggered",
       "delete_from_list": "The bookmark has been deleted from the list",
-      "clipboard_copied": "Link has been added to your clipboard!",
-      "updated": "The bookmark has been updated!"
+      "clipboard_copied": "Link has been added to your clipboard",
+      "updated": "The bookmark has been updated"
     },
     "lists": {
-      "created": "List has been created!",
-      "updated": "List has been updated!",
-      "merged": "List has been merged!",
-      "deleted": "List has been deleted!"
+      "created": "List has been created",
+      "updated": "List has been updated",
+      "merged": "List has been merged",
+      "deleted": "List has been deleted"
     }
   },
   "dialogs": {

--- a/packages/shared/langs.ts
+++ b/packages/shared/langs.ts
@@ -6,6 +6,7 @@ export const langNameMappings: Record<string, string> = {
   da: "Danish",
   nl: "Dutch",
   en: "English",
+  en_US: "English (US)",
   fr: "French",
   gl: "Galician",
   de: "German",


### PR DESCRIPTION
This pull request focuses on improving language consistency in user-facing text and adding support for a new language variant. The changes include updates to English (US) translations for better grammar and tone, and the addition of `en_US` to the language mappings.

### Language Consistency Improvements:

* Updated several strings in `apps/web/lib/i18n/locales/en_US/translation.json` to use consistent capitalization and tone, such as changing "Import as Text Bookmark" to "Import as text bookmark" and "No rules created yet, dude" to "No rules have been created yet" [[1]](diffhunk://#diff-1a4cddfab06d3ca6379b7f7fde5caeff84782ab02de2d6f8523fe827c82bb223L152-R155) [[2]](diffhunk://#diff-1a4cddfab06d3ca6379b7f7fde5caeff84782ab02de2d6f8523fe827c82bb223L269-R269) [[3]](diffhunk://#diff-1a4cddfab06d3ca6379b7f7fde5caeff84782ab02de2d6f8523fe827c82bb223L384-R384) [[4]](diffhunk://#diff-1a4cddfab06d3ca6379b7f7fde5caeff84782ab02de2d6f8523fe827c82bb223L393-R403) [[5]](diffhunk://#diff-1a4cddfab06d3ca6379b7f7fde5caeff84782ab02de2d6f8523fe827c82bb223L414-R425).

### Language Support:

* Added `en_US` as a new language variant in the `langNameMappings` object in `packages/shared/langs.ts`.