### PR TITLE
feat: position highlight menu based on device type

### DIFF
--- a/apps/web/components/dashboard/preview/BookmarkHtmlHighlighter.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkHtmlHighlighter.tsx
@@ -19,6 +19,7 @@ interface ColorPickerMenuProps {
   onDelete?: () => void;
   selectedHighlight: Highlight | null;
   onClose: () => void;
+  isMobile: boolean;
 }
 
 const ColorPickerMenu: React.FC<ColorPickerMenuProps> = ({
@@ -27,6 +28,7 @@ const ColorPickerMenu: React.FC<ColorPickerMenuProps> = ({
   onDelete,
   selectedHighlight,
   onClose,
+  isMobile,
 }) => {
   return (
     <Popover
@@ -44,7 +46,10 @@ const ColorPickerMenu: React.FC<ColorPickerMenuProps> = ({
           top: position?.y,
         }}
       />
-      <PopoverContent side="top" className="flex w-fit items-center gap-1 p-2">
+      <PopoverContent
+        side={isMobile ? "bottom" : "top"}
+        className="flex w-fit items-center gap-1 p-2"
+      >
         {SUPPORTED_HIGHLIGHT_COLORS.map((color) => (
           <Button
             size="none"
@@ -113,6 +118,9 @@ function BookmarkHTMLHighlighter({
   const [selectedHighlight, setSelectedHighlight] = useState<Highlight | null>(
     null,
   );
+  const isMobile = useState(
+    () => typeof window !== 'undefined' && window.matchMedia("(pointer: coarse)").matches
+  )[0];
 
   // Apply existing highlights when component mounts or highlights change
   useEffect(() => {
@@ -160,7 +168,7 @@ function BookmarkHTMLHighlighter({
     window.getSelection()?.addRange(newRange);
   }, [pendingHighlight, contentRef]);
 
-  const handleMouseUp = (e: React.MouseEvent) => {
+  const handlePointerUp = (e: React.PointerEvent) => {
     const selection = window.getSelection();
 
     // Check if we clicked on an existing highlight
@@ -192,11 +200,11 @@ function BookmarkHTMLHighlighter({
       return;
     }
 
-    // Position the menu above the selection
+    // Position the menu based on device type
     const rect = range.getBoundingClientRect();
     setMenuPosition({
-      x: rect.left + rect.width / 2, // Center the menu
-      y: rect.top,
+      x: rect.left + rect.width / 2, // Center the menu horizontally
+      y: isMobile ? rect.bottom : rect.top, // Position below on mobile, above otherwise
     });
 
     // Store the highlight for later use
@@ -333,7 +341,7 @@ function BookmarkHTMLHighlighter({
         role="presentation"
         ref={contentRef}
         dangerouslySetInnerHTML={{ __html: htmlContent }}
-        onMouseUp={handleMouseUp}
+        onPointerUp={handlePointerUp}
         className={className}
       />
       <ColorPickerMenu
@@ -342,6 +350,7 @@ function BookmarkHTMLHighlighter({
         onDelete={handleDelete}
         selectedHighlight={selectedHighlight}
         onClose={closeColorPicker}
+        isMobile={isMobile}
       />
     </div>
   );

--- a/apps/web/components/dashboard/preview/BookmarkHtmlHighlighter.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkHtmlHighlighter.tsx
@@ -119,7 +119,9 @@ function BookmarkHTMLHighlighter({
     null,
   );
   const isMobile = useState(
-    () => typeof window !== 'undefined' && window.matchMedia("(pointer: coarse)").matches
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(pointer: coarse)").matches,
   )[0];
 
   // Apply existing highlights when component mounts or highlights change


### PR DESCRIPTION
Hi, 

this PR adds the highlight functionality to touch devices, mostly mobile devices for the web version.
The main fix as discussed in the issue #1220  is using `onPointerUp={handlePointerUp} `instead of `onMouseUp`. 
With that change, the highlight menu appears on e.g. mobile. 

Besides that, I also adjusted `setMenuPosition` to move the menu below the selected text according to the `isMobile` check as in most cases the device context menu is above. The mobile check was found here and seems to be good for this use case:
https://stackoverflow.com/a/52855084/9950786

Here's how it now looks on mobile:

![image](https://github.com/user-attachments/assets/f0a4a702-b7aa-486e-a89a-086581c8a755)


This doesn't adjust the web version:
**Current latest stable after selecting Qualcomm:**


<img width="380" alt="image" src="https://github.com/user-attachments/assets/fcf25eeb-7475-4262-914c-d1e53c3bfde0" />

**My PR:**


<img width="289" alt="image" src="https://github.com/user-attachments/assets/96f79cc8-5ab4-4c94-a446-0b4eda43b6d3" />


