### PR TITLE
feat(tags): infer todo tag from text content

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   web:
     build:

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -38,6 +38,8 @@ Please analyze the text between the sentences "CONTENT START HERE" and "CONTENT 
 - The tags language must be in ${lang}.
 - If it's a famous website you may also include a tag for the website. If the tag is not generic enough, don't include it.
 - The content can include text for cookie consent and privacy policy, ignore those while tagging.
+- If the content appears to be a task, to-do item, or something that requires future action, include a "todo" tag.
+- Look for indicators of tasks such as action verbs, deadlines, imperative sentences, or checklist-like structures.
 - Aim for 3-5 tags.
 - If there are no good tags, leave the array empty.
 ${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}


### PR DESCRIPTION
## Summary 

Add extra prompt instruction, to infer text bookmarks as potential tasks, and give it an `#todo` tag

## Notes

Firstly, thank you for this wonderful app! This is truly the bookmark app of my dreams. This is partially why I am making this PR to introduce a change that is catered specifically to my workflow.

In my opinion, I'm coming from the same perspective as what you wrote in the recent changelog:

> Karakeep was born because I don't want to spend time organizing what I hoard. I just throw stuff in there and karakeep's tagging and search will help me retrieve it later.

I love the autotagging feature and all i need to make it perfect is to allow me to make "todos" without having to select a special input type, and have the LLM to infer it.

I see that https://github.com/karakeep-app/karakeep/pull/505#issuecomment-2398016762 there is a consideration to allow users to insert their own custom prompts, but I have a selfish desire to make todo an official minor feature of karakeep (so that I don't have maintain a small long-lived fork 😅)

There are more changes I want to suggest for this workflow, but considering that this came out of nowhere, I wanted to make this PR and open the conversation of potentially adding this use-case.

## Demo

https://github.com/user-attachments/assets/654e8db0-bce6-43a6-a89d-7b0cfcf0e41e
