### PR TITLE
Add icon to show the archive status of a bookmark

### DIFF
--- a/apps/web/components/dashboard/bookmarks/BookmarkActionBar.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkActionBar.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Maximize2 } from "lucide-react";
+import { Archive, Maximize2 } from "lucide-react";
 
 import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
 
@@ -18,6 +18,7 @@ export default function BookmarkActionBar({
       {bookmark.favourited && (
         <FavouritedActionIcon className="m-1 size-8 rounded p-1" favourited />
       )}
+      {bookmark.archived && <Archive className="m-1 size-8 rounded p-1" />}
       <Link
         href={`/dashboard/preview/${bookmark.id}`}
         className={cn(buttonVariants({ variant: "ghost" }), "px-2")}


### PR DESCRIPTION
Adds an archive icon to the bookmark card to show the archive status of a bookmark

Closes #1368 

Before:
![Screenshot_20250507_173348](https://github.com/user-attachments/assets/341724d5-b39f-4b37-a6a0-40e391fc3f06)

After:
![Screenshot_20250507_173410](https://github.com/user-attachments/assets/33ed04a2-8f1b-45f5-9038-0a9b13137be2)
