### PR TITLE
fix(search): add new relevance sort order

### DIFF
--- a/apps/web/app/dashboard/search/page.tsx
+++ b/apps/web/app/dashboard/search/page.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import BookmarksGrid from "@/components/dashboard/bookmarks/BookmarksGrid";
 import { FullPageSpinner } from "@/components/ui/full-page-spinner";
 import { useBookmarkSearch } from "@/lib/hooks/bookmark-search";
+import { useSortOrderStore } from "@/lib/store/useSortOrderStore";
 
 function SearchComp() {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useBookmarkSearch();
+
+  const { setSortOrder } = useSortOrderStore();
+
+  useEffect(() => {
+    // also see related cleanup code in SortOrderToggle.tsx
+    setSortOrder("relevance");
+  }, []);
 
   return (
     <div className="flex flex-col gap-3">

--- a/apps/web/components/dashboard/SortOrderToggle.tsx
+++ b/apps/web/components/dashboard/SortOrderToggle.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { ButtonWithTooltip } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -7,12 +11,24 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useTranslation } from "@/lib/i18n/client";
 import { useSortOrderStore } from "@/lib/store/useSortOrderStore";
-import { Check, SortAsc, SortDesc, ListFilter } from "lucide-react";
+import { Check, ListFilter, SortAsc, SortDesc } from "lucide-react";
 
 export default function SortOrderToggle() {
   const { t } = useTranslation();
 
+  const pathname = usePathname();
+  const isDashboardSearchPage = pathname === "/dashboard/search";
+
   const { sortOrder: currentSort, setSortOrder } = useSortOrderStore();
+
+  // also see related on page enter sortOrder.relevance init
+  // in apps/web/app/dashboard/search/page.tsx
+  useEffect(() => {
+    if (!isDashboardSearchPage && currentSort === "relevance") {
+      // reset to default sort order
+      setSortOrder("desc");
+    }
+  }, [isDashboardSearchPage, currentSort]);
 
   return (
     <DropdownMenu>
@@ -22,47 +38,43 @@ export default function SortOrderToggle() {
           delayDuration={100}
           variant="ghost"
         >
-          {currentSort === "relevance" && (
-            <ListFilter size={18} />
-          )}
-          {currentSort === "asc" && (
-            <SortAsc size={18} />
-          )}
-          {currentSort === "desc" && (
-            <SortDesc size={18} />
-          )}
+          {currentSort === "relevance" && <ListFilter size={18} />}
+          {currentSort === "asc" && <SortAsc size={18} />}
+          {currentSort === "desc" && <SortDesc size={18} />}
         </ButtonWithTooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-fit">
-      <DropdownMenuItem
-          className="justify-between cursor-pointer"
-          onClick={() => setSortOrder("relevance")}
-        >
-          <div className="flex items-center">
-            <ListFilter size={16} className="mr-2" />
-            <span>{t("actions.sort.relevant_first")}</span>
-          </div>
-          {currentSort === "relevance" && <Check className="w-4 h-4 ml-2" />}
-        </DropdownMenuItem>
+        {isDashboardSearchPage && (
+          <DropdownMenuItem
+            className="cursor-pointer justify-between"
+            onClick={() => setSortOrder("relevance")}
+          >
+            <div className="flex items-center">
+              <ListFilter size={16} className="mr-2" />
+              <span>{t("actions.sort.relevant_first")}</span>
+            </div>
+            {currentSort === "relevance" && <Check className="ml-2 h-4 w-4" />}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem
-          className="justify-between cursor-pointer"
+          className="cursor-pointer justify-between"
           onClick={() => setSortOrder("desc")}
         >
           <div className="flex items-center">
             <SortDesc size={16} className="mr-2" />
             <span>{t("actions.sort.newest_first")}</span>
           </div>
-          {currentSort === "desc" && <Check className="w-4 h-4 ml-2" />}
+          {currentSort === "desc" && <Check className="ml-2 h-4 w-4" />}
         </DropdownMenuItem>
         <DropdownMenuItem
-          className="justify-between cursor-pointer"
+          className="cursor-pointer justify-between"
           onClick={() => setSortOrder("asc")}
         >
           <div className="flex items-center">
             <SortAsc size={16} className="mr-2" />
             <span>{t("actions.sort.oldest_first")}</span>
           </div>
-          {currentSort === "asc" && <Check className="w-4 h-4 ml-2" />}
+          {currentSort === "asc" && <Check className="ml-2 h-4 w-4" />}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/components/dashboard/SortOrderToggle.tsx
+++ b/apps/web/components/dashboard/SortOrderToggle.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useTranslation } from "@/lib/i18n/client";
 import { useSortOrderStore } from "@/lib/store/useSortOrderStore";
-import { Check, SortAsc, SortDesc } from "lucide-react";
+import { Check, SortAsc, SortDesc, ListFilter } from "lucide-react";
 
 export default function SortOrderToggle() {
   const { t } = useTranslation();
@@ -22,33 +22,47 @@ export default function SortOrderToggle() {
           delayDuration={100}
           variant="ghost"
         >
-          {currentSort === "asc" ? (
+          {currentSort === "relevance" && (
+            <ListFilter size={18} />
+          )}
+          {currentSort === "asc" && (
             <SortAsc size={18} />
-          ) : (
+          )}
+          {currentSort === "desc" && (
             <SortDesc size={18} />
           )}
         </ButtonWithTooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-fit">
+      <DropdownMenuItem
+          className="justify-between cursor-pointer"
+          onClick={() => setSortOrder("relevance")}
+        >
+          <div className="flex items-center">
+            <ListFilter size={16} className="mr-2" />
+            <span>{t("actions.sort.relevant_first")}</span>
+          </div>
+          {currentSort === "relevance" && <Check className="w-4 h-4 ml-2" />}
+        </DropdownMenuItem>
         <DropdownMenuItem
-          className="cursor-pointer justify-between"
+          className="justify-between cursor-pointer"
           onClick={() => setSortOrder("desc")}
         >
           <div className="flex items-center">
             <SortDesc size={16} className="mr-2" />
             <span>{t("actions.sort.newest_first")}</span>
           </div>
-          {currentSort === "desc" && <Check className="ml-2 h-4 w-4" />}
+          {currentSort === "desc" && <Check className="w-4 h-4 ml-2" />}
         </DropdownMenuItem>
         <DropdownMenuItem
-          className="cursor-pointer justify-between"
+          className="justify-between cursor-pointer"
           onClick={() => setSortOrder("asc")}
         >
           <div className="flex items-center">
             <SortAsc size={16} className="mr-2" />
             <span>{t("actions.sort.oldest_first")}</span>
           </div>
-          {currentSort === "asc" && <Check className="ml-2 h-4 w-4" />}
+          {currentSort === "asc" && <Check className="w-4 h-4 ml-2" />}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/components/dashboard/SortOrderToggle.tsx
+++ b/apps/web/components/dashboard/SortOrderToggle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import { usePathname } from "next/navigation";
 import { ButtonWithTooltip } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -9,26 +8,25 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useIsSearchPage } from "@/lib/hooks/bookmark-search";
 import { useTranslation } from "@/lib/i18n/client";
 import { useSortOrderStore } from "@/lib/store/useSortOrderStore";
 import { Check, ListFilter, SortAsc, SortDesc } from "lucide-react";
 
 export default function SortOrderToggle() {
   const { t } = useTranslation();
-
-  const pathname = usePathname();
-  const isDashboardSearchPage = pathname === "/dashboard/search";
+  const isInSearchPage = useIsSearchPage();
 
   const { sortOrder: currentSort, setSortOrder } = useSortOrderStore();
 
   // also see related on page enter sortOrder.relevance init
   // in apps/web/app/dashboard/search/page.tsx
   useEffect(() => {
-    if (!isDashboardSearchPage && currentSort === "relevance") {
+    if (!isInSearchPage && currentSort === "relevance") {
       // reset to default sort order
       setSortOrder("desc");
     }
-  }, [isDashboardSearchPage, currentSort]);
+  }, [isInSearchPage, currentSort]);
 
   return (
     <DropdownMenu>
@@ -44,7 +42,7 @@ export default function SortOrderToggle() {
         </ButtonWithTooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-fit">
-        {isDashboardSearchPage && (
+        {isInSearchPage && (
           <DropdownMenuItem
             className="cursor-pointer justify-between"
             onClick={() => setSortOrder("relevance")}

--- a/apps/web/components/dashboard/bookmarks/UpdatableBookmarksGrid.tsx
+++ b/apps/web/components/dashboard/bookmarks/UpdatableBookmarksGrid.tsx
@@ -23,7 +23,11 @@ export default function UpdatableBookmarksGrid({
   showEditorCard?: boolean;
   itemsPerPage?: number;
 }) {
-  const sortOrder = useSortOrderStore((state) => state.sortOrder);
+  let sortOrder = useSortOrderStore((state) => state.sortOrder);
+  if (sortOrder === "relevance") {
+    // Relevance is not supported in the `getBookmarks` endpoint.
+    sortOrder = "desc";
+  }
 
   const finalQuery = { ...query, sortOrder, includeContent: false };
 

--- a/apps/web/lib/hooks/bookmark-search.ts
+++ b/apps/web/lib/hooks/bookmark-search.ts
@@ -6,6 +6,11 @@ import { keepPreviousData } from "@tanstack/react-query";
 
 import { parseSearchQuery } from "@karakeep/shared/searchQueryParser";
 
+export function useIsSearchPage() {
+  const pathname = usePathname();
+  return pathname.startsWith("/dashboard/search");
+}
+
 function useSearchQuery() {
   const searchParams = useSearchParams();
   const searchQuery = decodeURIComponent(searchParams.get("q") ?? "");
@@ -17,8 +22,8 @@ function useSearchQuery() {
 export function useDoBookmarkSearch() {
   const router = useRouter();
   const { searchQuery, parsedSearchQuery } = useSearchQuery();
+  const isInSearchPage = useIsSearchPage();
   const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | undefined>();
-  const pathname = usePathname();
 
   useEffect(() => {
     return () => {
@@ -49,7 +54,7 @@ export function useDoBookmarkSearch() {
     debounceSearch,
     searchQuery,
     parsedSearchQuery,
-    isInSearchPage: pathname.startsWith("/dashboard/search"),
+    isInSearchPage,
   };
 }
 

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -79,6 +79,7 @@
     "ignore": "Ignore",
     "sort": {
       "title": "Sort",
+      "relevant_first": "Most Relevant First",
       "newest_first": "Newest First",
       "oldest_first": "Oldest First"
     }

--- a/apps/web/lib/store/useSortOrderStore.ts
+++ b/apps/web/lib/store/useSortOrderStore.ts
@@ -8,6 +8,6 @@ interface SortOrderState {
 }
 
 export const useSortOrderStore = create<SortOrderState>((set) => ({
-  sortOrder: "desc", // default sort order
+  sortOrder: "relevance", // default sort order
   setSortOrder: (sortOrder) => set({ sortOrder }),
 }));

--- a/apps/web/lib/store/useSortOrderStore.ts
+++ b/apps/web/lib/store/useSortOrderStore.ts
@@ -8,6 +8,6 @@ interface SortOrderState {
 }
 
 export const useSortOrderStore = create<SortOrderState>((set) => ({
-  sortOrder: "relevance", // default sort order
+  sortOrder: "desc", // default sort order
   setSortOrder: (sortOrder) => set({ sortOrder }),
 }));

--- a/packages/shared/types/bookmarks.ts
+++ b/packages/shared/types/bookmarks.ts
@@ -12,7 +12,7 @@ export const enum BookmarkTypes {
   UNKNOWN = "unknown",
 }
 
-export const zSortOrder = z.enum(["asc", "desc"]);
+export const zSortOrder = z.enum(["asc", "desc", "relevance"]);
 export type ZSortOrder = z.infer<typeof zSortOrder>;
 
 export const zAssetTypesSchema = z.enum([

--- a/packages/shared/types/bookmarks.ts
+++ b/packages/shared/types/bookmarks.ts
@@ -178,7 +178,7 @@ export const zGetBookmarksRequestSchema = z.object({
   // The value is currently not being used, but keeping it so that client can still set it to true for older
   // servers.
   useCursorV2: z.boolean().optional(),
-  sortOrder: zSortOrder.optional().default("desc"),
+  sortOrder: zSortOrder.exclude(["relevance"]).optional().default("desc"),
   includeContent: z.boolean().optional().default(false),
 });
 export type ZGetBookmarksRequest = z.infer<typeof zGetBookmarksRequestSchema>;
@@ -238,6 +238,6 @@ export const zSearchBookmarksRequestSchema = z.object({
   text: z.string(),
   limit: z.number().max(MAX_NUM_BOOKMARKS_PER_PAGE).optional(),
   cursor: zSearchBookmarksCursor.nullish(),
-  sortOrder: zSortOrder.optional().default("desc"),
+  sortOrder: zSortOrder.optional().default("relevance"),
   includeContent: z.boolean().optional().default(false),
 });

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -712,7 +712,7 @@ export const bookmarksAppRouter = router({
       if (!input.limit) {
         input.limit = DEFAULT_NUM_BOOKMARKS_PER_PAGE;
       }
-      const sortOrder = input.sortOrder || "desc";
+      const sortOrder = input.sortOrder || "relevance";
       const client = await getSearchIdxClient();
       if (!client) {
         throw new TRPCError({
@@ -735,11 +735,16 @@ export const bookmarksAppRouter = router({
         filter = [`userId = '${ctx.user.id}'`];
       }
 
+      /**
+       * preserve legacy behaviour
+       */
+      const createdAtSortOrder = sortOrder === "relevance" ? "desc" : sortOrder;
+
       const resp = await client.search(parsedQuery.text, {
         filter,
         showRankingScore: true,
         attributesToRetrieve: ["id"],
-        sort: [`createdAt:${sortOrder}`],
+        sort: [`createdAt:${createdAtSortOrder}`],
         limit: input.limit,
         ...(input.cursor
           ? {
@@ -775,7 +780,18 @@ export const bookmarksAppRouter = router({
           assets: true,
         },
       });
-      results.sort((a, b) => idToRank[b.id] - idToRank[a.id]);
+
+      switch (true) {
+        case sortOrder === "relevance":
+          results.sort((a, b) => idToRank[b.id] - idToRank[a.id]);
+          break;
+        case sortOrder === "desc":
+          results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+          break;
+        case sortOrder === "asc":
+          results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+          break;
+      }
 
       return {
         bookmarks: results.map((b) => toZodSchema(b, input.includeContent)),
@@ -805,6 +821,12 @@ export const bookmarksAppRouter = router({
           delete input.listId;
         }
       }
+
+      /**
+       * preserve legacy behaviour
+       */
+      const createdAtSortOrder =
+        input.sortOrder === "relevance" ? "desc" : input.sortOrder;
 
       const sq = ctx.db.$with("bookmarksSq").as(
         ctx.db
@@ -860,7 +882,7 @@ export const bookmarksAppRouter = router({
                   )
                 : undefined,
               input.cursor
-                ? input.sortOrder === "asc"
+                ? createdAtSortOrder === "asc"
                   ? or(
                       gt(bookmarks.createdAt, input.cursor.createdAt),
                       and(

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -822,12 +822,6 @@ export const bookmarksAppRouter = router({
         }
       }
 
-      /**
-       * preserve legacy behaviour
-       */
-      const createdAtSortOrder =
-        input.sortOrder === "relevance" ? "desc" : input.sortOrder;
-
       const sq = ctx.db.$with("bookmarksSq").as(
         ctx.db
           .select()
@@ -882,7 +876,7 @@ export const bookmarksAppRouter = router({
                   )
                 : undefined,
               input.cursor
-                ? createdAtSortOrder === "asc"
+                ? input.sortOrder === "asc"
                   ? or(
                       gt(bookmarks.createdAt, input.cursor.createdAt),
                       and(


### PR DESCRIPTION
## Summary

* add new sort order `relevance`
* retain existing(legacy) search's sort logic as `relevance`
* add new `asc` and `desc` sort logic

fixes #1335

## Notes

I'm wasn't super sure how karakeep handles the translation, so let me know if there are follow up tasks, and anything else that I should tweak for this PR, thanks!

