### PR TITLE
Fix JSON in MCP documentation

### DIFF
--- a/docs/docs/09-mcp.md
+++ b/docs/docs/09-mcp.md
@@ -21,7 +21,7 @@ From NPM:
     "karakeep": {
       "command": "npx",
       "args": [
-        "@karakeep/mcp",
+        "@karakeep/mcp"
       ],
       "env": {
         "KARAKEEP_API_ADDR": "https://<YOUR_SERVER_ADDR>",


### PR DESCRIPTION
Small typo fix. The JSON for the MCP was invalid.