### PR TITLE
minor: allow specifying source location when building via docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 ################# Base Builder ##############
 FROM node:22-alpine AS base
 
-WORKDIR /app
+ARG SOURCE_DIR=/app  # Default value if not specified
+WORKDIR ${SOURCE_DIR}
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
@@ -11,7 +12,7 @@ RUN npm install -g corepack@0.31.0 && corepack enable
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat make g++ py3-pip linux-headers
 
-COPY . .
+COPY . ${SOURCE_DIR}/
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV PUPPETEER_SKIP_DOWNLOAD true
 RUN pnpm install --frozen-lockfile
@@ -23,16 +24,22 @@ RUN cd packages/db && \
 
 
 # Compile the web app
-RUN (cd apps/web && pnpm exec next build --experimental-build-mode compile)
+RUN (cd ${SOURCE_DIR}/apps/web && pnpm exec next build --experimental-build-mode compile)
+
+# Then copy the built files from source_dir to /app for runtime
+RUN mkdir -p /app/apps/web && cp -r ${SOURCE_DIR}/apps/web/.next /app/apps/web/
+RUN cp -r ${SOURCE_DIR}/apps/web/public /app/apps/web/
 
 # Build the worker code
 RUN pnpm deploy --node-linker=isolated --filter @karakeep/workers --prod /prod/workers
 
 # Build the cli
-RUN (cd apps/cli && pnpm build)
+RUN (cd ${SOURCE_DIR}/apps/cli && pnpm build)
+RUN mkdir -p /app/apps/cli && cp -r ${SOURCE_DIR}/apps/cli/dist /app/apps/cli/
 
 # Build the mcp server
-RUN (cd apps/mcp && pnpm build)
+RUN (cd ${SOURCE_DIR}/apps/mcp && pnpm build)
+RUN mkdir -p /app/apps/mcp && cp -r ${SOURCE_DIR}/apps/mcp/dist /app/apps/mcp/
 
 ################# The All-in-one builder ##############
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,7 @@
 FROM node:22-alpine
 
-WORKDIR /app
+ARG SOURCE_DIR=/app  # Default value if not specified
+WORKDIR ${SOURCE_DIR}
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
@@ -9,6 +10,6 @@ RUN apk add --no-cache libc6-compat make g++ py3-pip linux-headers git
 
 RUN corepack enable
 
-COPY . .
+COPY . ${SOURCE_DIR}/
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV PUPPETEER_SKIP_DOWNLOAD true

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -4,6 +4,8 @@ services:
       dockerfile: docker/Dockerfile
       context: ..
       target: aio
+      args:
+        SOURCE_DIR: /appsource
     restart: unless-stopped
     volumes:
       - data:/data

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,9 +3,11 @@ services:
   web:
     build:
       dockerfile: Dockerfile.dev
+      args:
+        SOURCE_DIR: /appsource
     volumes:
       - data:/data
-      - ..:/app
+      - ..:/appsource
     ports:
       - 3000:3000
     env_file:
@@ -34,9 +36,11 @@ services:
   workers:
     build:
       dockerfile: Dockerfile.dev
+      args:
+        SOURCE_DIR: /appsource
     volumes:
       - data:/data
-      - ..:/app
+      - ..:/appsource
     env_file:
       - .env
     working_dir: /app
@@ -54,6 +58,8 @@ services:
   prep:
     build:
       dockerfile: Dockerfile.dev
+      args:
+        SOURCE_DIR: /appsource
     env_file:
       - .env
     working_dir: /app
@@ -61,7 +67,7 @@ services:
       DATA_DIR: /data
     volumes:
       - data:/data
-      - ..:/app
+      - ..:/appsource
     command:
      - /bin/sh
      - -c


### PR DESCRIPTION
- **new: allow to specify the source directory when building**
- **update the docker compose files to use SOURCE_DIR**

Hi,

**This is low importance, maybe a mistake, if the reviewer is low on bandwidth please consider skipping this one and reviewing other PRs instead, thanks!**

I'm fairly new to docker and had some trouble getting the building process to work after modifying the sources.

My issue was mainly that because the sources are mounted to /app, and the building process outputs to /app, I could build the container but to run it I'd have to comment the runtime volume mounting at /app (because it happens after docker loads the built output).

I ended up figuring out how to modify the Dockerfile files to make them accept a source dir.

This has been working well for me but I'm not sure if it can break things for others.

For reference, here's how my own docker-compose.yml file is setup that I run with `docker compose up web --build:

```yml
services:
  web:
    restart: unless-stopped
    volumes:
      - ./data/web:/data
      - ./thefork:/appsource

    # To either run from image or build from scratch, uncomment one of the two sections

    # # START OF FROM IMAGE
    # image: ghcr.io/karakeep-app/karakeep:${KARAKEEP_VERSION:-release}
    # # END OF FROM IMAGE

    # # To build the app:
    # 0. comment the image: above
    # 1. uncomment the building lines below
    # # START OF BUILDING
    build:
      context: ./thefork
      target: aio
      dockerfile: docker/Dockerfile
      args:
        SOURCE_DIR: /appsource
    working_dir: /app
    # # END OF BUILDING

    # ...rest of the config...
```
