### PR TITLE
doc: new comunity project: freshrss to karakeep

### DIFF
--- a/docs/docs/13-community-projects.md
+++ b/docs/docs/13-community-projects.md
@@ -53,3 +53,11 @@ _By [@thiswillbeyourgithub](https://github.com/thiswillbeyourgithub/)_
 A python package to simplify access to the karakeep API. Can be used as a library or from the CLI. Aims for feature completeness and high test coverage but do check its feature matrix before relying too much on it.
 
 Get it [here](https://github.com/thiswillbeyourgithub/karakeep_python_api).
+
+### FreshRSS_to_Karakeep
+
+_By [@thiswillbeyourgithub](https://github.com/thiswillbeyourgithub/)_
+
+A python script to automatically create Karakeep bookmarks from your [FreshRSS](https://github.com/FreshRSS/FreshRSS) *favourites/saved* RSS item. Made to be called periodically. Based on the community project `Karakeep-Python-API` above, by the same author.
+
+Get it [here](https://github.com/thiswillbeyourgithub/freshrss_to_karakeep).


### PR DESCRIPTION
Just adding a link to my script that allows to send the RSS item I mark as *favourite* directly to karakeep as bookmarks.

Btw I don't know if you plan on doing this but on every new karakeep release I think it would be nice to shoutout new community projects made since the latest release in the release message, as I don't want to miss new contributions!
