### PR TITLE
feat: handle "deleted" webhook events

### DIFF
--- a/apps/web/lib/i18n/locales/en_US/translation.json
+++ b/apps/web/lib/i18n/locales/en_US/translation.json
@@ -205,7 +205,8 @@
         "title": "Events",
         "crawled": "Crawled",
         "created": "Created",
-        "edited": "Edited"
+        "edited": "Edited",
+        "deleted": "Deleted"
       },
       "auth_token": "Auth Token",
       "delete_webhook": "Delete Webhook",

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -419,7 +419,7 @@ export const webhooksTable = sqliteTable(
       .references(() => users.id, { onDelete: "cascade" }),
     events: text("events", { mode: "json" })
       .notNull()
-      .$type<("created" | "edited" | "crawled" | "ai tagged")[]>(),
+      .$type<("created" | "edited" | "crawled" | "ai tagged" | "deleted")[]>(),
     token: text("token"),
   },
   (bl) => [index("webhooks_userId_idx").on(bl.userId)],

--- a/packages/shared/queues.ts
+++ b/packages/shared/queues.ts
@@ -172,7 +172,7 @@ export const AssetPreprocessingQueue =
 // Webhook worker
 export const zWebhookRequestSchema = z.object({
   bookmarkId: z.string(),
-  operation: z.enum(["crawled", "created", "edited", "ai tagged"]),
+  operation: z.enum(["crawled", "created", "edited", "ai tagged", "deleted"]),
 });
 export type ZWebhookRequest = z.infer<typeof zWebhookRequestSchema>;
 export const WebhookQueue = new SqliteQueue<ZWebhookRequest>(

--- a/packages/shared/types/webhooks.ts
+++ b/packages/shared/types/webhooks.ts
@@ -8,6 +8,7 @@ export const zWebhookEventSchema = z.enum([
   "edited",
   "crawled",
   "ai tagged",
+  "deleted",
 ]);
 export type ZWebhookEvent = z.infer<typeof zWebhookEventSchema>;
 

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -660,6 +660,7 @@ export const bookmarksAppRouter = router({
           ),
         );
       await triggerSearchDeletion(input.bookmarkId);
+      await triggerWebhook(input.bookmarkId, "deleted");
       if (deleted.changes > 0 && bookmark) {
         await cleanupAssetForBookmark({
           asset: bookmark.asset,


### PR DESCRIPTION
Add support to a `deleted` webhook event, that is triggered when a user deletes a bookmark. Fixes #1463.