### PR TITLE
feat: add optional `thinking` key to tagging response schema

### DIFF
--- a/apps/workers/workers/inference/tagging.ts
+++ b/apps/workers/workers/inference/tagging.ts
@@ -23,6 +23,7 @@ import {
 } from "@karakeep/shared/queues";
 
 const openAIResponseSchema = z.object({
+  thinking: z.string().optional(),
   tags: z.array(z.string()),
 });
 

--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -22,7 +22,7 @@ Please analyze the attached image and suggest relevant tags that describe its ke
 - Aim for 10-15 tags.
 - If there are no good tags, don't emit any.
 ${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
-You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.`;
+You must respond in valid JSON with optional "thinking" key for your reasoning and required "tags" key with the value as list of tags. Don't wrap the response in a markdown code.`;
 }
 
 export function buildTextPrompt(
@@ -44,7 +44,7 @@ ${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
 CONTENT START HERE
 ${c}
 CONTENT END HERE
-You must respond in JSON with the key "tags" and the value is an array of string tags.`;
+You must respond in JSON with optional "thinking" key for your reasoning and required "tags" key with the value as an array of string tags.`;
 
   const promptSize = calculateNumTokens(constructPrompt(""));
   const truncatedContent = truncateContent(content, contextLength - promptSize);


### PR DESCRIPTION
In my experience this helps all (both thinking and non thinking) models to provide better answers. I have not seen any negative side effects from that commit so far.
