### PR TITLE
ui: harmonize tab bar for link content in preview + enhancements

### DIFF
--- a/apps/web/app/dashboard/@modal/(.)preview/[bookmarkId]/page.tsx
+++ b/apps/web/app/dashboard/@modal/(.)preview/[bookmarkId]/page.tsx
@@ -24,7 +24,7 @@ export default function BookmarkPreviewPage({
   return (
     <Dialog open={open} onOpenChange={setOpenWithRouter}>
       <DialogContent
-        className="h-[90%] max-w-[90%] overflow-hidden p-0"
+        className="h-[95%] max-w-[96%] overflow-hidden p-0"
         hideCloseBtn={true}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >

--- a/apps/web/components/dashboard/preview/ActionBar.tsx
+++ b/apps/web/components/dashboard/preview/ActionBar.tsx
@@ -50,7 +50,7 @@ export default function ActionBar({ bookmark }: { bookmark: ZBookmark }) {
     });
 
   return (
-    <div className="flex items-center justify-center gap-3">
+    <div className="flex items-center justify-center gap-6">
       <Tooltip delayDuration={0}>
         <EditBookmarkDialog
           bookmark={bookmark}

--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -141,6 +141,7 @@ export default function BookmarkPreview({
         )}
         <Separator />
       </div>
+      <ActionBar bookmark={bookmark} />
       <CreationTime createdAt={bookmark.createdAt} />
       <SummarizeBookmarkArea bookmark={bookmark} />
       <div className="flex items-center gap-4">
@@ -153,7 +154,6 @@ export default function BookmarkPreview({
       </div>
       <AttachmentBox bookmark={bookmark} />
       <HighlightsBox bookmarkId={bookmark.id} />
-      <ActionBar bookmark={bookmark} />
     </div>
   );
 

--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -178,8 +178,8 @@ export default function BookmarkPreview({
         <TabsList
           className={`sticky top-0 z-10 grid h-auto w-full grid-cols-2`}
         >
-          <TabsTrigger value="content">{t("preview.tabs.content")}</TabsTrigger>
-          <TabsTrigger value="details">{t("preview.tabs.details")}</TabsTrigger>
+          <TabsTrigger value="content" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.tabs.content")}</TabsTrigger>
+          <TabsTrigger value="details" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.tabs.details")}</TabsTrigger>
         </TabsList>
         <TabsContent
           value="content"

--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -178,8 +178,8 @@ export default function BookmarkPreview({
         <TabsList
           className={`sticky top-0 z-10 grid h-auto w-full grid-cols-2`}
         >
-          <TabsTrigger value="content" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.tabs.content")}</TabsTrigger>
-          <TabsTrigger value="details" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.tabs.details")}</TabsTrigger>
+          <TabsTrigger value="content" className="select-none overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.tabs.content")}</TabsTrigger>
+          <TabsTrigger value="details" className="select-none overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.tabs.details")}</TabsTrigger>
         </TabsList>
         <TabsContent
           value="content"

--- a/apps/web/components/dashboard/preview/BookmarkPreview.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkPreview.tsx
@@ -183,7 +183,7 @@ export default function BookmarkPreview({
         </TabsList>
         <TabsContent
           value="content"
-          className="h-full flex-1 overflow-hidden overflow-y-auto bg-background p-2 data-[state=inactive]:hidden"
+          className="h-full flex-1 overflow-hidden overflow-y-auto bg-background data-[state=inactive]:hidden"
         >
           {contentSection}
         </TabsContent>

--- a/apps/web/components/dashboard/preview/LinkContentSection.tsx
+++ b/apps/web/components/dashboard/preview/LinkContentSection.tsx
@@ -2,14 +2,7 @@ import { useState } from "react";
 import Image from "next/image";
 import BookmarkHTMLHighlighter from "@/components/dashboard/preview/BookmarkHtmlHighlighter";
 import { FullPageSpinner } from "@/components/ui/full-page-spinner";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "@/components/ui/use-toast";
 import { useTranslation } from "@/lib/i18n/client";
 import { api } from "@/lib/trpc";
@@ -173,56 +166,67 @@ export default function LinkContentSection({
   bookmark: ZBookmark;
 }) {
   const { t } = useTranslation();
-  const [section, setSection] = useState<string>("cached");
+  const [activeTab, setActiveTab] = useState<string>("cached");
 
   if (bookmark.content.type != BookmarkTypes.LINK) {
     throw new Error("Invalid content type");
   }
 
-  let content;
-  if (section === "cached") {
-    content = <CachedContentSection bookmarkId={bookmark.id} />;
-  } else if (section === "archive") {
-    content = <FullPageArchiveSection link={bookmark.content} />;
-  } else if (section === "video") {
-    content = <VideoSection link={bookmark.content} />;
-  } else {
-    content = <ScreenshotSection link={bookmark.content} />;
-  }
-
   return (
-    <div className="flex h-full flex-col items-center gap-2">
-      <Select onValueChange={setSection} value={section}>
-        <SelectTrigger className="w-fit">
-          <span className="mr-2">
-            <SelectValue />
-          </span>
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectItem value="cached">{t("preview.reader_view")}</SelectItem>
-            <SelectItem
-              value="screenshot"
-              disabled={!bookmark.content.screenshotAssetId}
-            >
-              {t("common.screenshot")}
-            </SelectItem>
-            <SelectItem
-              value="archive"
-              disabled={
-                !bookmark.content.fullPageArchiveAssetId &&
-                !bookmark.content.precrawledArchiveAssetId
-              }
-            >
-              {t("common.archive")}
-            </SelectItem>
-            <SelectItem value="video" disabled={!bookmark.content.videoAssetId}>
-              {t("common.video")}
-            </SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-      {content}
-    </div>
+    <Tabs
+      value={activeTab}
+      onValueChange={setActiveTab}
+      className="flex h-full w-full flex-col overflow-hidden"
+    >
+      <TabsList
+        className={`sticky top-0 z-10 grid h-auto w-full grid-cols-4`}
+      >
+        <TabsTrigger value="cached" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.reader_view")}</TabsTrigger>
+        <TabsTrigger
+          value="screenshot"
+          disabled={!bookmark.content.screenshotAssetId}
+          className="overflow-hidden whitespace-nowrap text-ellipsis text-left"
+        >
+          {t("common.screenshot")}
+        </TabsTrigger>
+        <TabsTrigger
+          value="archive"
+          disabled={
+            !bookmark.content.fullPageArchiveAssetId &&
+            !bookmark.content.precrawledArchiveAssetId
+          }
+          className="overflow-hidden whitespace-nowrap text-ellipsis text-left"
+        >
+          {t("common.archive")}
+        </TabsTrigger>
+        <TabsTrigger value="video" disabled={!bookmark.content.videoAssetId} className="overflow-hidden whitespace-nowrap text-ellipsis text-left">
+          {t("common.video")}
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent
+        value="cached"
+        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+      >
+        <CachedContentSection bookmarkId={bookmark.id} />
+      </TabsContent>
+      <TabsContent
+        value="screenshot"
+        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+      >
+        <ScreenshotSection link={bookmark.content} />
+      </TabsContent>
+      <TabsContent
+        value="archive"
+        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+      >
+        <FullPageArchiveSection link={bookmark.content} />
+      </TabsContent>
+      <TabsContent
+        value="video"
+        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+      >
+        <VideoSection link={bookmark.content} />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/apps/web/components/dashboard/preview/LinkContentSection.tsx
+++ b/apps/web/components/dashboard/preview/LinkContentSection.tsx
@@ -181,11 +181,11 @@ export default function LinkContentSection({
       <TabsList
         className={`grid h-auto w-full grid-cols-4`}
       >
-        <TabsTrigger value="cached" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.reader_view")}</TabsTrigger>
+        <TabsTrigger value="cached" className="select-none overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.reader_view")}</TabsTrigger>
         <TabsTrigger
           value="screenshot"
           disabled={!bookmark.content.screenshotAssetId}
-          className="overflow-hidden whitespace-nowrap text-ellipsis text-left"
+          className="select-none overflow-hidden whitespace-nowrap text-ellipsis text-left"
         >
           {t("common.screenshot")}
         </TabsTrigger>
@@ -195,11 +195,11 @@ export default function LinkContentSection({
             !bookmark.content.fullPageArchiveAssetId &&
             !bookmark.content.precrawledArchiveAssetId
           }
-          className="overflow-hidden whitespace-nowrap text-ellipsis text-left"
+          className="select-none overflow-hidden whitespace-nowrap text-ellipsis text-left"
         >
           {t("common.archive")}
         </TabsTrigger>
-        <TabsTrigger value="video" disabled={!bookmark.content.videoAssetId} className="overflow-hidden whitespace-nowrap text-ellipsis text-left">
+        <TabsTrigger value="video" disabled={!bookmark.content.videoAssetId} className="select-none overflow-hidden whitespace-nowrap text-ellipsis text-left">
           {t("common.video")}
         </TabsTrigger>
       </TabsList>

--- a/apps/web/components/dashboard/preview/LinkContentSection.tsx
+++ b/apps/web/components/dashboard/preview/LinkContentSection.tsx
@@ -179,7 +179,7 @@ export default function LinkContentSection({
       className="flex h-full w-full flex-col overflow-hidden"
     >
       <TabsList
-        className={`sticky top-0 z-10 grid h-auto w-full grid-cols-4`}
+        className={`grid h-auto w-full grid-cols-4`}
       >
         <TabsTrigger value="cached" className="overflow-hidden whitespace-nowrap text-ellipsis text-left">{t("preview.reader_view")}</TabsTrigger>
         <TabsTrigger
@@ -205,25 +205,25 @@ export default function LinkContentSection({
       </TabsList>
       <TabsContent
         value="cached"
-        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+        className="h-full flex-1 overflow-hidden overflow-y-auto px-2 data-[state=inactive]:hidden"
       >
         <CachedContentSection bookmarkId={bookmark.id} />
       </TabsContent>
       <TabsContent
         value="screenshot"
-        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+        className="h-full flex-1 overflow-hidden overflow-y-auto px-2 data-[state=inactive]:hidden"
       >
         <ScreenshotSection link={bookmark.content} />
       </TabsContent>
       <TabsContent
         value="archive"
-        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+        className="h-full flex-1 overflow-hidden overflow-y-auto px-2 data-[state=inactive]:hidden"
       >
         <FullPageArchiveSection link={bookmark.content} />
       </TabsContent>
       <TabsContent
         value="video"
-        className="h-full flex-1 overflow-hidden overflow-y-auto data-[state=inactive]:hidden"
+        className="h-full flex-1 overflow-hidden overflow-y-auto px-2 data-[state=inactive]:hidden"
       >
         <VideoSection link={bookmark.content} />
       </TabsContent>


### PR DESCRIPTION
This is a continuation of #1425, where now I added a tab bar to choose between "reader view", "archive", etc.

I had to add an ellipsis mechanism in case the UI is super scaled up, otherwise there were overlapping button labels.

Feedback much appreciated!

![Screenshot_20250527-003909_1](https://github.com/user-attachments/assets/a0d69cbb-e962-43cd-a2cb-aa5c0dedcb19)