### PR TITLE
UI fix: move smart list doc link up to prevent misclick

### DIFF
--- a/apps/web/components/dashboard/lists/EditListModal.tsx
+++ b/apps/web/components/dashboard/lists/EditListModal.tsx
@@ -352,6 +352,14 @@ export function EditListModal({
                   return (
                     <FormItem className="grow pb-4">
                       <FormLabel>{t("lists.search_query")}</FormLabel>
+                      <FormDescription>
+                        <Link
+                          href="https://docs.karakeep.app/Guides/search-query-language"
+                          className="italic"
+                        >
+                          {t("lists.search_query_help")}
+                        </Link>
+                      </FormDescription>
                       <div className="relative">
                         <FormControl>
                           <Input
@@ -369,14 +377,6 @@ export function EditListModal({
                           />
                         </FormControl>
                       </div>
-                      <FormDescription>
-                        <Link
-                          href="https://docs.karakeep.app/Guides/search-query-language"
-                          className="italic"
-                        >
-                          {t("lists.search_query_help")}
-                        </Link>
-                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   );


### PR DESCRIPTION
In the model to create a smart list, I moved the "Learn more about the search query language" link above the "Search Query" field, as otherwise the mouse cursor is exactly above that link when switching from Manual to Smart list. This is mainly a fix for touchscreen users as I misclicked several times when wanting to create new smart lists.



![image](https://github.com/user-attachments/assets/ad362f6a-a4e0-4cad-bc14-bf031d64f289)


Edit: this seems to be maybe a somewhat wider problem, as I see this happen elsewhere too. For example when assigning a list to an already crawled bookmark, the "cancel" button can be clicked on right away when touching the list name:
![image](https://github.com/user-attachments/assets/821dd06c-3697-4090-9f40-90370882ff58)
Maybe there is a "general delay" we can set to prevent misclicks on touchscreens?