### PR TITLE
feat: Allow PATCH method in CORS headers

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -34,7 +34,7 @@ const nextConfig = withPWA({
           // Allows for specific methods accepted
           {
             key: "Access-Control-Allow-Methods",
-            value: "GET, POST, PUT, DELETE, OPTIONS",
+            value: "GET, POST, PUT, PATCH, DELETE, OPTIONS",
           },
           // Allows for specific headers accepted (These are a few standard ones)
           {


### PR DESCRIPTION
Hello,

I'm using the [Karakeep Plugin for Obsidian](https://github.com/jhofker/obsidian-hoarder), which [uses the PATCH method of the API](https://github.com/jhofker/obsidian-hoarder/blob/8ec6ef3288d2acf71ab494cc07707c1ee8f73d09/src/main.ts#L295).

Special reverse proxy configuration is currently required for CORS, it would be nice if this could work out of the box by allowing the method directly in the backend.