### PR TITLE
fix: Browser extension tab tracking and tags page performance

### DIFF
--- a/apps/browser-extension/src/SavePage.tsx
+++ b/apps/browser-extension/src/SavePage.tsx
@@ -42,7 +42,7 @@ export default function SavePage() {
       if (!newBookmarkRequest) {
         const [currentTab] = await chrome.tabs.query({
           active: true,
-          lastFocusedWindow: true,
+          currentWindow: true,
         });
         if (currentTab?.url) {
           newBookmarkRequest = {

--- a/apps/browser-extension/src/components/ui/dialog.tsx
+++ b/apps/browser-extension/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
         className,
       )}
       {...props}

--- a/apps/browser-extension/src/components/ui/popover.tsx
+++ b/apps/browser-extension/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
         className,
       )}
       {...props}

--- a/apps/web/app/dashboard/tags/page.tsx
+++ b/apps/web/app/dashboard/tags/page.tsx
@@ -5,7 +5,7 @@ import { api } from "@/server/api/client";
 
 export default async function TagsPage() {
   const { t } = await useTranslation();
-  const allTags = (await api.tags.list()).tags;
+  const { tags: allTags } = await api.tags.list({ limit: 100 });
 
   return (
     <div className="space-y-4 rounded-md border bg-background p-4">

--- a/apps/web/components/dashboard/cleanups/TagDuplicationDetention.tsx
+++ b/apps/web/components/dashboard/cleanups/TagDuplicationDetention.tsx
@@ -200,7 +200,7 @@ function SuggestionRow({
 
 export function TagDuplicationDetection() {
   const [expanded, setExpanded] = useState(false);
-  let { data: allTags } = api.tags.list.useQuery(undefined, {
+  const { data: allTags } = api.tags.list.useQuery(undefined, {
     refetchOnWindowFocus: false,
   });
 
@@ -208,8 +208,8 @@ export function TagDuplicationDetection() {
     useSuggestions();
 
   useEffect(() => {
-    allTags = allTags ?? { tags: [] };
-    const sortedTags = allTags.tags.sort((a, b) =>
+    const tagsData = allTags ?? { tags: [], total: 0, hasMore: false };
+    const sortedTags = tagsData.tags.sort((a, b) =>
       normalizeTag(a.name).localeCompare(normalizeTag(b.name)),
     );
 

--- a/apps/web/components/dashboard/highlights/HighlightCard.tsx
+++ b/apps/web/components/dashboard/highlights/HighlightCard.tsx
@@ -55,7 +55,7 @@ export default function HighlightCard({
         <blockquote
           cite={highlight.bookmarkId}
           className={cn(
-            "prose border-l-[6px] p-2 pl-6 italic dark:prose-invert prose-p:text-sm",
+            "prose dark:prose-invert prose-p:text-sm border-l-[6px] p-2 pl-6 italic",
             HIGHLIGHT_COLOR_MAP["border-l"][highlight.color],
           )}
         >

--- a/apps/web/components/dashboard/preview/LinkContentSection.tsx
+++ b/apps/web/components/dashboard/preview/LinkContentSection.tsx
@@ -124,7 +124,7 @@ function CachedContentSection({ bookmarkId }: { bookmarkId: string }) {
     content = (
       <BookmarkHTMLHighlighter
         htmlContent={cachedContent || ""}
-        className="prose mx-auto dark:prose-invert"
+        className="prose dark:prose-invert mx-auto"
         highlights={highlights?.highlights ?? []}
         onDeleteHighlight={(h) =>
           deleteHighlight({

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
       className,
     )}
     {...props}
@@ -39,7 +39,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
         className,
       )}
       {...props}

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -46,7 +46,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
       className,
     )}
     {...props}
@@ -64,7 +64,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         className,
       )}
       {...props}

--- a/apps/web/components/ui/markdown/markdown-editor.tsx
+++ b/apps/web/components/ui/markdown/markdown-editor.tsx
@@ -102,7 +102,7 @@ const MarkdownEditor = memo(
           ) : (
             <RichTextPlugin
               contentEditable={
-                <ContentEditable className="prose h-full w-full min-w-full overflow-auto p-2 dark:prose-invert prose-p:m-0" />
+                <ContentEditable className="prose dark:prose-invert prose-p:m-0 h-full w-full min-w-full overflow-auto p-2" />
               }
               ErrorBoundary={LexicalErrorBoundary}
             />

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
         className,
       )}
       {...props}

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -74,7 +74,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -23,7 +23,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none",
   {
     variants: {
       variant: {

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md",
       className,
     )}
     {...props}

--- a/packages/trpc/routers/tags.pagination.test.ts
+++ b/packages/trpc/routers/tags.pagination.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { CustomTestContext } from "../testUtils";
+import { defaultBeforeEach } from "../testUtils";
+
+beforeEach<CustomTestContext>(defaultBeforeEach(true));
+
+describe("Tags Pagination", () => {
+  test<CustomTestContext>("should return paginated tags with default limit", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 60 tags
+    const tagPromises = [];
+    for (let i = 0; i < 60; i++) {
+      tagPromises.push(
+        api.create({ name: `tag-${i.toString().padStart(3, "0")}` }),
+      );
+    }
+    await Promise.all(tagPromises);
+
+    // Get first page with default limit
+    const result = await api.list();
+
+    expect(result.tags).toHaveLength(50); // Default limit
+    expect(result.total).toBe(60);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test<CustomTestContext>("should return paginated tags with custom limit", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 30 tags
+    const tagPromises = [];
+    for (let i = 0; i < 30; i++) {
+      tagPromises.push(api.create({ name: `tag-${i}` }));
+    }
+    await Promise.all(tagPromises);
+
+    // Get first page with custom limit
+    const result = await api.list({ limit: 10 });
+
+    expect(result.tags).toHaveLength(10);
+    expect(result.total).toBe(30);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test<CustomTestContext>("should return correct data with offset", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 25 tags with predictable names
+    const createdTags = [];
+    for (let i = 0; i < 25; i++) {
+      const tag = await api.create({
+        name: `tag-${i.toString().padStart(2, "0")}`,
+      });
+      createdTags.push(tag);
+    }
+
+    // Get second page
+    const result = await api.list({ limit: 10, offset: 10 });
+
+    expect(result.tags).toHaveLength(10);
+    expect(result.total).toBe(25);
+    expect(result.hasMore).toBe(true);
+
+    // Verify we got some tags from the middle range
+    const tagNames = result.tags.map((t) => t.name);
+    const hasExpectedTags = tagNames.some((name) => {
+      const num = parseInt(name.replace("tag-", ""));
+      return num >= 10 && num < 20;
+    });
+    expect(hasExpectedTags).toBe(true);
+  });
+
+  test<CustomTestContext>("should handle last page correctly", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 55 tags
+    const tagPromises = [];
+    for (let i = 0; i < 55; i++) {
+      tagPromises.push(api.create({ name: `tag-${i}` }));
+    }
+    await Promise.all(tagPromises);
+
+    // Get last page
+    const result = await api.list({ limit: 50, offset: 50 });
+
+    expect(result.tags).toHaveLength(5); // Only 5 remaining
+    expect(result.total).toBe(55);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test<CustomTestContext>("should handle empty result set", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Don't create any tags
+    const result = await api.list();
+
+    expect(result.tags).toHaveLength(0);
+    expect(result.total).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test<CustomTestContext>("should respect maximum limit constraint", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 150 tags
+    const tagPromises = [];
+    for (let i = 0; i < 150; i++) {
+      tagPromises.push(api.create({ name: `tag-${i}` }));
+    }
+    await Promise.all(tagPromises);
+
+    // Try to get more than max limit - should throw validation error
+    await expect(() => api.list({ limit: 200 })).rejects.toThrow(
+      /less than or equal to 100/,
+    );
+
+    // Verify max limit works correctly
+    const result = await api.list({ limit: 100 });
+    expect(result.tags).toHaveLength(100);
+    expect(result.total).toBe(150);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test<CustomTestContext>("should handle offset beyond total count", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 10 tags
+    const tagPromises = [];
+    for (let i = 0; i < 10; i++) {
+      tagPromises.push(api.create({ name: `tag-${i}` }));
+    }
+    await Promise.all(tagPromises);
+
+    // Request with offset beyond total
+    const result = await api.list({ limit: 10, offset: 20 });
+
+    expect(result.tags).toHaveLength(0);
+    expect(result.total).toBe(10);
+    expect(result.hasMore).toBe(false);
+  });
+
+  test<CustomTestContext>("should work without pagination parameters (backwards compatibility)", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 75 tags
+    const tagPromises = [];
+    for (let i = 0; i < 75; i++) {
+      tagPromises.push(api.create({ name: `tag-${i}` }));
+    }
+    await Promise.all(tagPromises);
+
+    // Call without any parameters
+    const result = await api.list();
+
+    expect(result.tags).toHaveLength(50); // Default limit
+    expect(result.total).toBe(75);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test<CustomTestContext>("should handle pagination for many tags efficiently", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create 250 tags (simulating a scaled-down version of issue #1404)
+    const batchSize = 50;
+    for (let batch = 0; batch < 5; batch++) {
+      const tagPromises = [];
+      for (let i = 0; i < batchSize; i++) {
+        const index = batch * batchSize + i;
+        tagPromises.push(
+          api.create({ name: `tag-${index.toString().padStart(4, "0")}` }),
+        );
+      }
+      await Promise.all(tagPromises);
+    }
+
+    // Get first page - should be fast even with many tags
+    const startTime = Date.now();
+    const result = await api.list({ limit: 100 });
+    const endTime = Date.now();
+
+    expect(result.tags).toHaveLength(100);
+    expect(result.total).toBe(250);
+    expect(result.hasMore).toBe(true);
+
+    // Query should be fast (less than 500ms for test environment)
+    expect(endTime - startTime).toBeLessThan(500);
+  });
+
+  test<CustomTestContext>("should only return tags for the authenticated user", async ({
+    apiCallers,
+  }) => {
+    const api1 = apiCallers[0].tags;
+    const api2 = apiCallers[1].tags;
+
+    // Create tags for user 1
+    await api1.create({ name: "user1-tag-1" });
+    await api1.create({ name: "user1-tag-2" });
+
+    // Create tags for user 2
+    await api2.create({ name: "user2-tag-1" });
+    await api2.create({ name: "user2-tag-2" });
+
+    // Get tags for user 1 - should only see own tags
+    const result1 = await api1.list();
+    expect(result1.tags).toHaveLength(2);
+    expect(result1.total).toBe(2);
+    expect(result1.hasMore).toBe(false);
+    expect(result1.tags.every((t) => t.name.startsWith("user1-tag"))).toBe(
+      true,
+    );
+
+    // Get tags for user 2 - should only see own tags
+    const result2 = await api2.list();
+    expect(result2.tags).toHaveLength(2);
+    expect(result2.total).toBe(2);
+    expect(result2.hasMore).toBe(false);
+    expect(result2.tags.every((t) => t.name.startsWith("user2-tag"))).toBe(
+      true,
+    );
+  });
+
+  test<CustomTestContext>("should include correct tag counts in pagination results", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].tags;
+
+    // Create some tags
+    await api.create({ name: "tag-with-bookmarks" });
+    await api.create({ name: "tag-without-bookmarks" });
+
+    const result = await api.list();
+
+    // All tags should have proper structure
+    expect(result.tags).toHaveLength(2);
+    result.tags.forEach((tag) => {
+      expect(tag).toHaveProperty("id");
+      expect(tag).toHaveProperty("name");
+      expect(tag).toHaveProperty("numBookmarks");
+      expect(tag).toHaveProperty("numBookmarksByAttachedType");
+      expect(tag.numBookmarksByAttachedType).toHaveProperty("ai");
+      expect(tag.numBookmarksByAttachedType).toHaveProperty("human");
+    });
+  });
+});


### PR DESCRIPTION
- Fix browser extension tab tracking by using currentWindow instead of lastFocusedWindow
  - Resolves issue where extension would track incorrect tab when popup was opened
  - Fixes issue #111 comment

- Optimize tags page performance for large tag collections
  - Add pagination support to tags.list API endpoint (limit/offset)
  - Limit initial tag load to 100 tags to improve page load time
  - Add search functionality to filter tags on client side
  - Add test coverage
  - Fixes #1404