### PR TITLE
feat: Add text highlighting to note bookmarks

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,7 +5,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "@karakeep/tailwind-config/globals.css";
 
 import type { Viewport } from "next";
-import React from "react";
+import { ReactNode } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import Providers from "@/lib/providers";
 import { getUserLocalSettings } from "@/lib/userLocalSettings/userLocalSettings";
@@ -44,7 +44,7 @@ export const viewport: Viewport = {
 export default async function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   const session = await getServerAuthSession();
   const userSettings = await getUserLocalSettings();
@@ -54,6 +54,7 @@ export default async function RootLayout({
       className="sm:overflow-hidden"
       lang={userSettings.lang}
       dir={isRTL ? "rtl" : "ltr"}
+      suppressHydrationWarning
     >
       <body className={inter.className}>
         <NuqsAdapter>

--- a/apps/web/components/dashboard/preview/BookmarkTextHighlighter.tsx
+++ b/apps/web/components/dashboard/preview/BookmarkTextHighlighter.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useRef, useState, FC, ComponentProps, PointerEvent } from "react";
+import { ActionButton } from "@/components/ui/action-button";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { PopoverAnchor } from "@radix-ui/react-popover";
+import { Check, Trash2 } from "lucide-react";
+import Markdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { dracula } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+
+import {
+  SUPPORTED_HIGHLIGHT_COLORS,
+  ZHighlightColor,
+} from "@karakeep/shared/types/highlights";
+
+import { HIGHLIGHT_COLOR_MAP } from "./highlights";
+
+interface ColorPickerMenuProps {
+  position: { x: number; y: number } | null;
+  onColorSelect: (color: ZHighlightColor) => void;
+  onDelete?: () => void;
+  selectedHighlight: TextHighlight | null;
+  onClose: () => void;
+  isMobile: boolean;
+}
+
+const ColorPickerMenu: FC<ColorPickerMenuProps> = ({
+  position,
+  onColorSelect,
+  onDelete,
+  selectedHighlight,
+  onClose,
+  isMobile,
+}) => {
+  return (
+    <Popover
+      open={position !== null}
+      onOpenChange={(val) => {
+        if (!val) {
+          onClose();
+        }
+      }}
+    >
+      <PopoverAnchor
+        className="fixed"
+        style={{
+          left: position?.x,
+          top: position?.y,
+        }}
+      />
+      <PopoverContent
+        side={isMobile ? "bottom" : "top"}
+        className="flex w-fit items-center gap-1 p-2"
+      >
+        {SUPPORTED_HIGHLIGHT_COLORS.map((color) => (
+          <Button
+            size="none"
+            key={color}
+            onClick={() => onColorSelect(color)}
+            variant="none"
+            className={cn(
+              `size-8 rounded-full hover:border focus-visible:ring-0`,
+              HIGHLIGHT_COLOR_MAP.bg[color],
+            )}
+          >
+            {selectedHighlight?.color === color && (
+              <Check className="size-5 text-gray-600" />
+            )}
+          </Button>
+        ))}
+        {selectedHighlight && (
+          <ActionButton
+            loading={false}
+            size="none"
+            className="size-8 rounded-full"
+            onClick={onDelete}
+            variant="ghost"
+          >
+            <Trash2 className="size-5 text-destructive" />
+          </ActionButton>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export interface TextHighlight {
+  id: string;
+  startOffset: number;
+  endOffset: number;
+  color: ZHighlightColor;
+  text: string | null;
+}
+
+interface TextHighlighterProps {
+  markdownContent: string;
+  className?: string;
+  highlights?: TextHighlight[];
+  onHighlight?: (highlight: TextHighlight) => void;
+  onUpdateHighlight?: (highlight: TextHighlight) => void;
+  onDeleteHighlight?: (highlight: TextHighlight) => void;
+}
+
+function PreWithCopyBtn({ className, ...props }: ComponentProps<"pre">) {
+  const ref = useRef<HTMLPreElement>(null);
+  return (
+    <span className="group relative">
+      <pre ref={ref} className={cn(className, "")} {...props} />
+    </span>
+  );
+}
+
+function BookmarkTextHighlighter({
+  markdownContent,
+  className,
+  highlights = [],
+  onHighlight,
+  onUpdateHighlight,
+  onDeleteHighlight,
+}: TextHighlighterProps) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [menuPosition, setMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const [pendingHighlight, setPendingHighlight] =
+    useState<TextHighlight | null>(null);
+  const [selectedHighlight, setSelectedHighlight] =
+    useState<TextHighlight | null>(null);
+  const isMobile = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(pointer: coarse)").matches,
+  )[0];
+
+  // Apply existing highlights when component mounts or highlights change
+  useEffect(() => {
+    if (!contentRef.current) return;
+
+    // Clear existing highlights first
+    const existingHighlights = contentRef.current.querySelectorAll(
+      "span[data-highlight]",
+    );
+    existingHighlights.forEach((el) => {
+      const parent = el.parentNode;
+      if (parent) {
+        while (el.firstChild) {
+          parent.insertBefore(el.firstChild, el);
+        }
+        parent.removeChild(el);
+      }
+    });
+
+    // Normalize whitespace to ensure consistent text offsets
+    if (contentRef.current) {
+      contentRef.current.normalize();
+    }
+
+    // Apply all highlights
+    highlights.forEach((highlight) => {
+      applyHighlightByOffset(highlight);
+    });
+  });
+
+  // Re-apply the selection when the pending range changes
+  useEffect(() => {
+    if (!pendingHighlight) {
+      return;
+    }
+    if (!contentRef.current) {
+      return;
+    }
+    const ranges = getRangeFromHighlight(pendingHighlight);
+    if (!ranges) {
+      return;
+    }
+    const newRange = document.createRange();
+    newRange.setStart(ranges[0].node, ranges[0].start);
+    newRange.setEnd(
+      ranges[ranges.length - 1].node,
+      ranges[ranges.length - 1].end,
+    );
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(newRange);
+  }, [pendingHighlight, contentRef]);
+
+  const handlePointerUp = (e: PointerEvent) => {
+    const selection = window.getSelection();
+
+    // Check if we clicked on an existing highlight
+    const target = e.target as HTMLElement;
+    if (target.dataset.highlight) {
+      const highlightId = target.dataset.highlightId;
+      if (highlightId && highlights) {
+        const highlight = highlights.find((h) => h.id === highlightId);
+        if (!highlight) {
+          return;
+        }
+        setSelectedHighlight(highlight);
+        setMenuPosition({
+          x: e.clientX,
+          y: e.clientY,
+        });
+        return;
+      }
+    }
+
+    if (!selection || selection.isCollapsed || !contentRef.current) {
+      return;
+    }
+
+    const range = selection.getRangeAt(0);
+
+    // Only process selections within our component
+    if (!contentRef.current.contains(range.commonAncestorContainer)) {
+      return;
+    }
+
+    // Position the menu based on device type
+    const rect = range.getBoundingClientRect();
+    setMenuPosition({
+      x: rect.left + rect.width / 2, // Center the menu horizontally
+      y: isMobile ? rect.bottom : rect.top, // Position below on mobile, above otherwise
+    });
+
+    // Store the highlight for later use
+    setPendingHighlight(createHighlightFromRange(range, "yellow"));
+  };
+
+  const handleColorSelect = (color: ZHighlightColor) => {
+    if (pendingHighlight) {
+      pendingHighlight.color = color;
+      onHighlight?.(pendingHighlight);
+    } else if (selectedHighlight) {
+      selectedHighlight.color = color;
+      onUpdateHighlight?.(selectedHighlight);
+    }
+    closeColorPicker();
+  };
+
+  const closeColorPicker = () => {
+    setMenuPosition(null);
+    setPendingHighlight(null);
+    setSelectedHighlight(null);
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const handleDelete = () => {
+    if (selectedHighlight && onDeleteHighlight) {
+      onDeleteHighlight(selectedHighlight);
+      closeColorPicker();
+    }
+  };
+
+  const getTextNodeOffset = (node: Node): number => {
+    let offset = 0;
+    const walker = document.createTreeWalker(
+      contentRef.current!,
+      NodeFilter.SHOW_TEXT,
+      null,
+    );
+
+    while (walker.nextNode()) {
+      if (walker.currentNode === node) {
+        return offset;
+      }
+      offset += walker.currentNode.textContent?.length ?? 0;
+    }
+    return -1;
+  };
+
+  const createHighlightFromRange = (
+    range: Range,
+    color: ZHighlightColor,
+  ): TextHighlight | null => {
+    if (!contentRef.current) return null;
+
+    const startOffset =
+      getTextNodeOffset(range.startContainer) + range.startOffset;
+    const endOffset = getTextNodeOffset(range.endContainer) + range.endOffset;
+
+    if (startOffset === -1 || endOffset === -1) return null;
+
+    const highlight: TextHighlight = {
+      id: "NOT_SET",
+      startOffset,
+      endOffset,
+      color,
+      text: range.toString(),
+    };
+
+    applyHighlightByOffset(highlight);
+    return highlight;
+  };
+
+  const getRangeFromHighlight = (highlight: TextHighlight) => {
+    if (!contentRef.current) return;
+
+    let currentOffset = 0;
+    const walker = document.createTreeWalker(
+      contentRef.current,
+      NodeFilter.SHOW_TEXT,
+      null,
+    );
+
+    const ranges: { node: Text; start: number; end: number }[] = [];
+
+    // Find all text nodes that need highlighting
+    let node: Text | null;
+    while ((node = walker.nextNode() as Text)) {
+      const nodeLength = node.length;
+      const nodeStart = currentOffset;
+      const nodeEnd = nodeStart + nodeLength;
+
+      if (nodeStart < highlight.endOffset && nodeEnd > highlight.startOffset) {
+        ranges.push({
+          node,
+          start: Math.max(0, highlight.startOffset - nodeStart),
+          end: Math.min(nodeLength, highlight.endOffset - nodeStart),
+        });
+      }
+
+      currentOffset += nodeLength;
+    }
+    return ranges;
+  };
+
+  const applyHighlightByOffset = (highlight: TextHighlight) => {
+    const ranges = getRangeFromHighlight(highlight);
+    if (!ranges) {
+      return;
+    }
+    // Apply highlights to found ranges
+    ranges.forEach(({ node, start, end }) => {
+      if (start > 0) {
+        node.splitText(start);
+        node = node.nextSibling as Text;
+        end -= start;
+      }
+      if (end < node.length) {
+        node.splitText(end);
+      }
+
+      const span = document.createElement("span");
+      span.classList.add(HIGHLIGHT_COLOR_MAP.bg[highlight.color]);
+      span.classList.add("text-gray-600");
+      span.dataset.highlight = "true";
+      span.dataset.highlightId = highlight.id;
+      node.parentNode?.insertBefore(span, node);
+      span.appendChild(node);
+    });
+  };
+
+  return (
+    <div>
+      <div
+        role="presentation"
+        ref={contentRef}
+        onPointerUp={handlePointerUp}
+        className={cn("prose dark:prose-invert", className)}
+      >
+        <Markdown
+          remarkPlugins={[remarkGfm, remarkBreaks]}
+          components={{
+            pre({ ...props }) {
+              return <PreWithCopyBtn {...props} />;
+            },
+            code({ className, children, ...props }) {
+              const match = /language-(\w+)/.exec(className ?? "");
+              return match ? (
+                // @ts-expect-error -- Refs are not compatible for some reason
+                <SyntaxHighlighter
+                  PreTag="div"
+                  language={match[1]}
+                  {...props}
+                  style={dracula}
+                >
+                  {String(children).replace(/\n$/, "")}
+                </SyntaxHighlighter>
+              ) : (
+                <code className={className} {...props}>
+                  {children}
+                </code>
+              );
+            },
+          }}
+        >
+          {markdownContent}
+        </Markdown>
+      </div>
+      <ColorPickerMenu
+        position={menuPosition}
+        onColorSelect={handleColorSelect}
+        onDelete={handleDelete}
+        selectedHighlight={selectedHighlight}
+        onClose={closeColorPicker}
+        isMobile={isMobile}
+      />
+    </div>
+  );
+}
+
+export default BookmarkTextHighlighter;

--- a/apps/web/components/dashboard/preview/HighlightsBox.tsx
+++ b/apps/web/components/dashboard/preview/HighlightsBox.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -28,10 +29,10 @@ export default function HighlightsBox({ bookmarkId }: { bookmarkId: string }) {
       </CollapsibleTrigger>
       <CollapsibleContent className="group flex flex-col py-3 text-sm">
         {highlights.highlights.map((highlight) => (
-          <>
-            <HighlightCard key={highlight.id} highlight={highlight} clickable />
+          <Fragment key={highlight.id}>
+            <HighlightCard highlight={highlight} clickable />
             <Separator className="m-2 h-0.5 bg-gray-200 last:hidden" />
-          </>
+          </Fragment>
         ))}
       </CollapsibleContent>
     </Collapsible>

--- a/packages/e2e_tests/tests/api/text-highlights.test.ts
+++ b/packages/e2e_tests/tests/api/text-highlights.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, inject, it } from "vitest";
+
+import { createKarakeepClient } from "@karakeep/sdk";
+
+import { createTestUser } from "../../utils/api";
+
+describe("Text Bookmark Highlights API", () => {
+  const port = inject("karakeepPort");
+
+  if (!port) {
+    throw new Error("Missing required environment variables");
+  }
+
+  let client: ReturnType<typeof createKarakeepClient>;
+  let apiKey: string;
+
+  beforeEach(async () => {
+    apiKey = await createTestUser();
+    client = createKarakeepClient({
+      baseUrl: `http://localhost:${port}/api/v1/`,
+      headers: {
+        "Content-Type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+    });
+  });
+
+  it("should create highlights on text bookmarks with markdown content", async () => {
+    // Create a text bookmark with markdown content
+    const { data: createdBookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "text",
+        title: "Markdown Test Bookmark",
+        text: `# Heading 1
+
+This is a **bold** text with *italic* content.
+
+## Heading 2
+
+Here's a list:
+- Item 1
+- Item 2
+- Item 3
+
+And a code block:
+\`\`\`javascript
+console.log("Hello, world!");
+\`\`\`
+
+Final paragraph with more text to highlight.`,
+      },
+    });
+
+    expect(createdBookmark).toBeDefined();
+    expect(createdBookmark?.content.type).toBe("text");
+
+    // Create highlights on different parts of the markdown text
+    const highlights = [
+      {
+        text: "Heading 1",
+        startOffset: 2,
+        endOffset: 11,
+        color: "yellow" as const,
+        note: "Main heading",
+      },
+      {
+        text: "bold",
+        startOffset: 27,
+        endOffset: 31,
+        color: "red" as const,
+        note: "Bold text",
+      },
+      {
+        text: "italic",
+        startOffset: 43,
+        endOffset: 49,
+        color: "green" as const,
+        note: "Italic text",
+      },
+      {
+        text: "console.log",
+        startOffset: 150,
+        endOffset: 161,
+        color: "blue" as const,
+        note: "JavaScript code",
+      },
+    ];
+
+    const createdHighlights = [];
+    for (const highlight of highlights) {
+      const { data: createdHighlight, response } = await client.POST(
+        "/highlights",
+        {
+          body: {
+            bookmarkId: createdBookmark!.id,
+            startOffset: highlight.startOffset,
+            endOffset: highlight.endOffset,
+            text: highlight.text,
+            note: highlight.note,
+            color: highlight.color,
+          },
+        },
+      );
+
+      expect(response.status).toBe(201);
+      expect(createdHighlight).toBeDefined();
+      expect(createdHighlight?.text).toBe(highlight.text);
+      expect(createdHighlight?.color).toBe(highlight.color);
+      expect(createdHighlight?.note).toBe(highlight.note);
+      createdHighlights.push(createdHighlight!);
+    }
+
+    // Verify all highlights are retrievable for the bookmark
+    const { data: bookmarkHighlights } = await client.GET(
+      "/bookmarks/{bookmarkId}/highlights",
+      {
+        params: {
+          path: {
+            bookmarkId: createdBookmark!.id,
+          },
+        },
+      },
+    );
+
+    expect(bookmarkHighlights!.highlights.length).toBe(4);
+    expect(bookmarkHighlights!.highlights.map((h) => h.color)).toContain(
+      "yellow",
+    );
+    expect(bookmarkHighlights!.highlights.map((h) => h.color)).toContain("red");
+    expect(bookmarkHighlights!.highlights.map((h) => h.color)).toContain(
+      "green",
+    );
+    expect(bookmarkHighlights!.highlights.map((h) => h.color)).toContain(
+      "blue",
+    );
+
+    // Test updating highlight colors
+    const firstHighlight = createdHighlights[0];
+    const { data: updatedHighlight } = await client.PATCH(
+      "/highlights/{highlightId}",
+      {
+        params: {
+          path: {
+            highlightId: firstHighlight.id,
+          },
+        },
+        body: {
+          color: "blue",
+        },
+      },
+    );
+
+    expect(updatedHighlight!.color).toBe("blue");
+
+    // Test deleting highlights
+    for (const highlight of createdHighlights) {
+      const { response } = await client.DELETE("/highlights/{highlightId}", {
+        params: {
+          path: {
+            highlightId: highlight.id,
+          },
+        },
+      });
+      expect(response.status).toBe(200);
+    }
+
+    // Verify highlights are deleted
+    const { data: emptyHighlights } = await client.GET(
+      "/bookmarks/{bookmarkId}/highlights",
+      {
+        params: {
+          path: {
+            bookmarkId: createdBookmark!.id,
+          },
+        },
+      },
+    );
+
+    expect(emptyHighlights!.highlights.length).toBe(0);
+  });
+
+  it("should handle overlapping highlights correctly", async () => {
+    // Create a text bookmark
+    const { data: createdBookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "text",
+        title: "Overlapping Highlights Test",
+        text: "This is a test sentence with overlapping words to highlight.",
+      },
+    });
+
+    // Create overlapping highlights
+    const { data: highlight1 } = await client.POST("/highlights", {
+      body: {
+        bookmarkId: createdBookmark!.id,
+        startOffset: 5,
+        endOffset: 15, // "is a test"
+        text: "is a test",
+        color: "yellow",
+        note: "First overlap",
+      },
+    });
+
+    const { data: highlight2 } = await client.POST("/highlights", {
+      body: {
+        bookmarkId: createdBookmark!.id,
+        startOffset: 10,
+        endOffset: 20, // "test sent"
+        text: "test sent",
+        color: "red",
+        note: "Second overlap",
+      },
+    });
+
+    expect(highlight1).toBeDefined();
+    expect(highlight2).toBeDefined();
+
+    // Verify both highlights exist
+    const { data: highlights } = await client.GET(
+      "/bookmarks/{bookmarkId}/highlights",
+      {
+        params: {
+          path: {
+            bookmarkId: createdBookmark!.id,
+          },
+        },
+      },
+    );
+
+    expect(highlights!.highlights.length).toBe(2);
+  });
+
+  it("should handle highlights with special characters and unicode", async () => {
+    // Create a text bookmark with special characters
+    const { data: createdBookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "text",
+        title: "Unicode Test",
+        text: 'This text contains émojis 🎉, special characters like ñ and ü, and quotes "like this".',
+      },
+    });
+
+    // Create highlight on emoji
+    const { data: emojiHighlight } = await client.POST("/highlights", {
+      body: {
+        bookmarkId: createdBookmark!.id,
+        startOffset: 27,
+        endOffset: 29, // "🎉"
+        text: "🎉",
+        color: "yellow",
+        note: "Emoji highlight",
+      },
+    });
+
+    // Create highlight on special characters
+    const { data: specialCharHighlight } = await client.POST("/highlights", {
+      body: {
+        bookmarkId: createdBookmark!.id,
+        startOffset: 55,
+        endOffset: 61, // "ñ and ü"
+        text: "ñ and ü",
+        color: "blue",
+        note: "Special chars",
+      },
+    });
+
+    expect(emojiHighlight).toBeDefined();
+    expect(emojiHighlight?.text).toBe("🎉");
+    expect(specialCharHighlight).toBeDefined();
+    expect(specialCharHighlight?.text).toBe("ñ and ü");
+
+    // Verify highlights are correctly stored
+    const { data: highlights } = await client.GET(
+      "/bookmarks/{bookmarkId}/highlights",
+      {
+        params: {
+          path: {
+            bookmarkId: createdBookmark!.id,
+          },
+        },
+      },
+    );
+
+    expect(highlights!.highlights.length).toBe(2);
+    expect(highlights!.highlights.find((h) => h.text === "🎉")).toBeDefined();
+    expect(
+      highlights!.highlights.find((h) => h.text === "ñ and ü"),
+    ).toBeDefined();
+  });
+
+  it("should validate highlight offsets are within text bounds", async () => {
+    // Create a text bookmark
+    const { data: createdBookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "text",
+        title: "Offset Validation Test",
+        text: "Short text",
+      },
+    });
+
+    // Try to create highlight with invalid offsets (beyond text length)
+    const { response } = await client.POST("/highlights", {
+      body: {
+        bookmarkId: createdBookmark!.id,
+        startOffset: 15,
+        endOffset: 25,
+        text: "Invalid",
+        color: "yellow",
+        note: "Invalid range",
+      },
+    });
+
+    // Should fail with bad request
+    expect(response.status).toBe(400);
+  });
+
+  it("should handle empty or whitespace-only selections", async () => {
+    // Create a text bookmark
+    const { data: createdBookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "text",
+        title: "Whitespace Test",
+        text: "Word1    Word2    Word3",
+      },
+    });
+
+    // Try to highlight only spaces
+    const { data: spaceHighlight } = await client.POST("/highlights", {
+      body: {
+        bookmarkId: createdBookmark!.id,
+        startOffset: 5,
+        endOffset: 9, // "    " (spaces)
+        text: "    ",
+        color: "yellow",
+        note: "Whitespace only",
+      },
+    });
+
+    expect(spaceHighlight).toBeDefined();
+    expect(spaceHighlight?.text).toBe("    ");
+  });
+});


### PR DESCRIPTION
Allow users to highlight text within note bookmarks, extending the existing highlighting functionality to markdown content. Users can now select text in notes and apply colored highlights (yellow, red, green, blue) with the same interface used for link content.

This feature addresses the need to emphasize specific parts of copied text from sources like ChatGPT or Claude, improving the research note-taking experience by making content more navigable and emphasizable.

The implementation reuses the existing highlight database schema and tRPC routes, ensuring consistency with link highlighting while adding comprehensive test coverage for text-specific scenarios including unicode characters, overlapping highlights, and edge cases.

Fixes #1342