### PR TITLE
feat(mobile): add reader view by default to bookmark detail view

### DIFF
--- a/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
@@ -155,6 +155,67 @@ function BookmarkLinkView({ bookmark }: { bookmark: ZBookmark }) {
   if (bookmark.content.type !== BookmarkTypes.LINK) {
     throw new Error("Wrong content type rendered");
   }
+
+  if (bookmark.content.htmlContent) {
+    return (
+      <View className="flex-1 bg-background">
+        <WebView
+          originWhitelist={["*"]}
+          source={{
+            html: `
+              <!DOCTYPE html>
+              <html>
+                <head>
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                  <style>
+                    body {
+                      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+                      line-height: 1.6;
+                      color: #374151;
+                      margin: 0;
+                      padding: 16px;
+                      background: transparent;
+                    }
+                    @media (prefers-color-scheme: dark) {
+                      body { color: #e5e7eb; }
+                    }
+                    p { margin: 0 0 1em 0; }
+                    h1, h2, h3, h4, h5, h6 { margin: 1.5em 0 0.5em 0; line-height: 1.2; }
+                    img { max-width: 100%; height: auto; border-radius: 8px; }
+                    a { color: #3b82f6; text-decoration: none; }
+                    a:hover { text-decoration: underline; }
+                    blockquote { 
+                      border-left: 4px solid #e5e7eb; 
+                      margin: 1em 0; 
+                      padding-left: 1em; 
+                      color: #6b7280; 
+                    }
+                    pre { 
+                      background: #f3f4f6; 
+                      padding: 1em; 
+                      border-radius: 6px; 
+                      overflow-x: auto; 
+                    }
+                    @media (prefers-color-scheme: dark) {
+                      blockquote { border-left-color: #374151; color: #9ca3af; }
+                      pre { background: #1f2937; }
+                    }
+                  </style>
+                </head>
+                <body>
+                  ${bookmark.content.htmlContent}
+                </body>
+              </html>
+            `,
+          }}
+          style={{ flex: 1 }}
+          showsVerticalScrollIndicator={false}
+          showsHorizontalScrollIndicator={false}
+        />
+      </View>
+    );
+  }
+
   return (
     <WebView
       startInLoadingState={true}
@@ -265,7 +326,10 @@ export default function ListView() {
     data: bookmark,
     error,
     refetch,
-  } = api.bookmarks.getBookmark.useQuery({ bookmarkId: slug });
+  } = api.bookmarks.getBookmark.useQuery({
+    bookmarkId: slug,
+    includeContent: true,
+  });
 
   if (error) {
     return <FullPageError error={error.message} onRetry={refetch} />;

--- a/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
@@ -22,6 +22,7 @@ import { useToast } from "@/components/ui/Toast";
 import { useAssetUrl } from "@/lib/hooks";
 import { api } from "@/lib/trpc";
 import { ClipboardList, Globe, Info, Tag, Trash2 } from "lucide-react-native";
+import { useColorScheme } from "nativewind";
 
 import {
   useDeleteBookmark,
@@ -152,11 +153,15 @@ function BottomActions({ bookmark }: { bookmark: ZBookmark }) {
 }
 
 function BookmarkLinkView({ bookmark }: { bookmark: ZBookmark }) {
+  const { colorScheme } = useColorScheme();
+
   if (bookmark.content.type !== BookmarkTypes.LINK) {
     throw new Error("Wrong content type rendered");
   }
 
   if (bookmark.content.htmlContent) {
+    const isDark = colorScheme === "dark";
+
     return (
       <View className="flex-1 bg-background">
         <WebView
@@ -171,13 +176,10 @@ function BookmarkLinkView({ bookmark }: { bookmark: ZBookmark }) {
                     body {
                       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
                       line-height: 1.6;
-                      color: #374151;
+                      color: ${isDark ? "#e5e7eb" : "#374151"};
                       margin: 0;
                       padding: 16px;
-                      background: transparent;
-                    }
-                    @media (prefers-color-scheme: dark) {
-                      body { color: #e5e7eb; }
+                      background: ${isDark ? "#000000" : "#ffffff"};
                     }
                     p { margin: 0 0 1em 0; }
                     h1, h2, h3, h4, h5, h6 { margin: 1.5em 0 0.5em 0; line-height: 1.2; }
@@ -185,20 +187,16 @@ function BookmarkLinkView({ bookmark }: { bookmark: ZBookmark }) {
                     a { color: #3b82f6; text-decoration: none; }
                     a:hover { text-decoration: underline; }
                     blockquote { 
-                      border-left: 4px solid #e5e7eb; 
+                      border-left: 4px solid ${isDark ? "#374151" : "#e5e7eb"}; 
                       margin: 1em 0; 
                       padding-left: 1em; 
-                      color: #6b7280; 
+                      color: ${isDark ? "#9ca3af" : "#6b7280"}; 
                     }
                     pre { 
-                      background: #f3f4f6; 
+                      background: ${isDark ? "#1f2937" : "#f3f4f6"}; 
                       padding: 1em; 
                       border-radius: 6px; 
                       overflow-x: auto; 
-                    }
-                    @media (prefers-color-scheme: dark) {
-                      blockquote { border-left-color: #374151; color: #9ca3af; }
-                      pre { background: #1f2937; }
                     }
                   </style>
                 </head>
@@ -208,7 +206,10 @@ function BookmarkLinkView({ bookmark }: { bookmark: ZBookmark }) {
               </html>
             `,
           }}
-          style={{ flex: 1 }}
+          style={{
+            flex: 1,
+            backgroundColor: isDark ? "#000000" : "#ffffff",
+          }}
           showsVerticalScrollIndicator={false}
           showsHorizontalScrollIndicator={false}
         />
@@ -318,6 +319,8 @@ function BookmarkAssetView({ bookmark }: { bookmark: ZBookmark }) {
 
 export default function ListView() {
   const { slug } = useLocalSearchParams();
+  const { colorScheme } = useColorScheme();
+
   if (typeof slug !== "string") {
     throw new Error("Unexpected param type");
   }
@@ -362,6 +365,10 @@ export default function ListView() {
           headerTitle: title ?? "",
           headerBackTitle: "Back",
           headerTransparent: false,
+          headerTintColor: colorScheme === "dark" ? "#ffffff" : undefined,
+          headerStyle: {
+            backgroundColor: colorScheme === "dark" ? "#000000" : undefined,
+          },
         }}
       />
       <View className="flex h-full">

--- a/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import ImageView from "react-native-image-viewing";
+import WebView from "react-native-webview";
+import { WebViewSourceUri } from "react-native-webview/lib/WebViewTypes";
+import { useAssetUrl } from "@/lib/hooks";
+import { api } from "@/lib/trpc";
+import { useColorScheme } from "nativewind";
+
+import { BookmarkTypes, ZBookmark } from "@karakeep/shared/types/bookmarks";
+
+import FullPageError from "../FullPageError";
+import FullPageSpinner from "../ui/FullPageSpinner";
+import BookmarkAssetImage from "./BookmarkAssetImage";
+
+export function BookmarkLinkBrowserPreview({
+  bookmark,
+}: {
+  bookmark: ZBookmark;
+}) {
+  if (bookmark.content.type !== BookmarkTypes.LINK) {
+    throw new Error("Wrong content type rendered");
+  }
+
+  return (
+    <WebView
+      startInLoadingState={true}
+      mediaPlaybackRequiresUserAction={true}
+      source={{ uri: bookmark.content.url }}
+    />
+  );
+}
+
+export function BookmarkLinkReaderPreview({
+  bookmark,
+}: {
+  bookmark: ZBookmark;
+}) {
+  const { colorScheme } = useColorScheme();
+
+  const {
+    data: bookmarkWithContent,
+    error,
+    isLoading,
+    refetch,
+  } = api.bookmarks.getBookmark.useQuery({
+    bookmarkId: bookmark.id,
+    includeContent: true,
+  });
+
+  if (isLoading) {
+    return <FullPageSpinner />;
+  }
+
+  if (error) {
+    return <FullPageError error={error.message} onRetry={refetch} />;
+  }
+
+  if (bookmarkWithContent?.content.type !== BookmarkTypes.LINK) {
+    throw new Error("Wrong content type rendered");
+  }
+
+  const isDark = colorScheme === "dark";
+
+  return (
+    <View className="flex-1 bg-background">
+      <WebView
+        originWhitelist={["*"]}
+        source={{
+          html: `
+              <!DOCTYPE html>
+              <html>
+                <head>
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                  <style>
+                    body {
+                      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+                      line-height: 1.6;
+                      color: ${isDark ? "#e5e7eb" : "#374151"};
+                      margin: 0;
+                      padding: 16px;
+                      background: ${isDark ? "#000000" : "#ffffff"};
+                    }
+                    p { margin: 0 0 1em 0; }
+                    h1, h2, h3, h4, h5, h6 { margin: 1.5em 0 0.5em 0; line-height: 1.2; }
+                    img { max-width: 100%; height: auto; border-radius: 8px; }
+                    a { color: #3b82f6; text-decoration: none; }
+                    a:hover { text-decoration: underline; }
+                    blockquote { 
+                      border-left: 4px solid ${isDark ? "#374151" : "#e5e7eb"}; 
+                      margin: 1em 0; 
+                      padding-left: 1em; 
+                      color: ${isDark ? "#9ca3af" : "#6b7280"}; 
+                    }
+                    pre { 
+                      background: ${isDark ? "#1f2937" : "#f3f4f6"}; 
+                      padding: 1em; 
+                      border-radius: 6px; 
+                      overflow-x: auto; 
+                    }
+                  </style>
+                </head>
+                <body>
+                  ${bookmarkWithContent.content.htmlContent}
+                </body>
+              </html>
+            `,
+        }}
+        style={{
+          flex: 1,
+          backgroundColor: isDark ? "#000000" : "#ffffff",
+        }}
+        showsVerticalScrollIndicator={false}
+        showsHorizontalScrollIndicator={false}
+      />
+    </View>
+  );
+}
+
+export function BookmarkLinkArchivePreview({
+  bookmark,
+}: {
+  bookmark: ZBookmark;
+}) {
+  const asset =
+    bookmark.assets.find((r) => r.assetType == "precrawledArchive") ??
+    bookmark.assets.find((r) => r.assetType == "fullPageArchive");
+
+  const assetSource = useAssetUrl(asset?.id ?? "");
+
+  if (!asset) {
+    return (
+      <View className="flex-1 bg-background">Asset has no offline archive</View>
+    );
+  }
+
+  const webViewUri: WebViewSourceUri = {
+    uri: assetSource.uri!,
+    headers: assetSource.headers,
+  };
+  return (
+    <WebView
+      startInLoadingState={true}
+      mediaPlaybackRequiresUserAction={true}
+      source={webViewUri}
+    />
+  );
+}
+
+export function BookmarkLinkScreenshotPreview({
+  bookmark,
+}: {
+  bookmark: ZBookmark;
+}) {
+  const asset = bookmark.assets.find((r) => r.assetType == "screenshot");
+
+  const assetSource = useAssetUrl(asset?.id ?? "");
+  const [imageZoom, setImageZoom] = useState(false);
+
+  if (!asset) {
+    return (
+      <View className="flex-1 bg-background">Asset has no screenshot</View>
+    );
+  }
+
+  return (
+    <View className="flex flex-1 gap-2">
+      <ImageView
+        visible={imageZoom}
+        imageIndex={0}
+        onRequestClose={() => setImageZoom(false)}
+        doubleTapToZoomEnabled={true}
+        images={[assetSource]}
+      />
+      <Pressable onPress={() => setImageZoom(true)}>
+        <BookmarkAssetImage
+          assetId={asset.id}
+          className="h-full w-full object-contain"
+        />
+      </Pressable>
+    </View>
+  );
+}


### PR DESCRIPTION
Creates a new reader view as the default display for bookmarked articles (links) when list items are tapped, i.e. the bookmark detail view.

## Description

When a link bookmark was successfully scraped from a web page source (likely an article) HTML will be available on request as `bookmark.content.htmlContent`. This PR makes the change firstly to request this by setting request flag `includeContent`, and then if content is present, to display it in-line in the app. If no content is available, the link will fallback to the previous behaviour of using an embedded

Note:
- the usage of `bookmark.content.htmlContent` is assumed safe and depends on any previous efforts to clean this at the time the bookmark was added and processed
- users may still access the original link using the link/globe icon in the app footer nav bar (right-most icon, see screenshot below)

## Testing

This change was tested on Android only. I was unable to get my iOS build environment configured yet so it would be good if someone could test this as an iOS build. I would be very confident it will work just as well on iOS.

## Related tickets

Implements: https://github.com/karakeep-app/karakeep/issues/536 basic implementation. Also mentioned is caching and screenshot view, which is not implemented here. Local DB storage of readable article content is out of scope for this PR but a good idea for another PR

See also:
- partially delivers https://github.com/karakeep-app/karakeep/issues/1068, adding the reader view but not any options to customise behaviour. This PR assumes that the most desired case is for reader view when readable text could be scraped. An additional PR could add customisation to what this PR delivers, if required
- https://github.com/karakeep-app/karakeep/issues/221 and https://github.com/karakeep-app/karakeep/issues/662 where the broad request for reader mode was mentioned (web has already implemented, this PR will now implement for mobile)

## Screenshots and video

Note, all media is from Android testing.

_Link bookmark detail view, reader view_

![bookmark_link_reader](https://github.com/user-attachments/assets/5e6f37fb-51ac-4bcf-8f10-cc871684a877)

_Link bookmark detail view, fallback to WebView_

![bookmark_link_webview](https://github.com/user-attachments/assets/1495a58d-48bb-4a0a-be03-b45e55fe72df)

_Complete user journey, video_

https://github.com/user-attachments/assets/8f52be77-bedd-42c0-9d77-51276788ad44



