### PR TITLE
feat(extension): add a keyboard shortcut to save page

### DIFF
--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -30,7 +30,9 @@
   },
   "background": {
     "service_worker": "src/background/background.ts",
-    "scripts": ["src/background/background.ts"]
+    "scripts": [
+      "src/background/background.ts"
+    ]
   },
   "options_ui": {
     "page": "index.html#options",
@@ -44,5 +46,17 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
-  "permissions": ["storage", "tabs", "contextMenus"]
+  "permissions": [
+    "storage",
+    "tabs",
+    "contextMenus"
+  ],
+  "commands": {
+    "add-link": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+E"
+      },
+      "description": "Send the current page URL to Karakeep."
+    }
+  }
 }


### PR DESCRIPTION
# Description

This PR adds a new keyboard shortcut (`Ctrl/Cmd+Shift+E` by default) that allows users to save the current page to Karakeep without needing to use the context menu or click the extension icon (which is often hidden).

Closes #1058.

# Method

When triggered, the background script captures the current tab's URL, stores it in session storage, and then opens the extension popup to complete the save flow. This mirrors the behavior of the context menu option. The context menu handler was refactored to reuse the same logic.

# Testing

To test, download and install the appropriate `.zip` file below:

- [test-chrome.zip](https://github.com/user-attachments/files/20618135/test-chrome.zip)
- [test-firefox.zip](https://github.com/user-attachments/files/20618137/test-firefox.zip)

**For Firefox (and Firefox-based browsers like Zen):**  
Go to `about:debugging`, click `This Firefox` in the left sidebar, then click `Load Temporary Add-on`. Select the `.zip` file to install.

**For Chrome (and Chromium-based browsers):**  
Go to `chrome://extensions`, enable **Developer mode**, extract the `.zip` file, and drag the extracted folder onto the tab to install.

# Notes

To change the keyboard shortcut:

- **Firefox**: Follow the steps here: [Manage extension shortcuts in Firefox](https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox)
- **Chrome**: Visit `chrome://extensions/shortcuts` and change as desired