### PR TITLE
fix: webhook job failure due to bookmark id not found

### DIFF
--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -646,8 +646,8 @@ export const bookmarksAppRouter = router({
           ),
         );
       await triggerSearchDeletion(input.bookmarkId);
-      await triggerWebhook(input.bookmarkId, "deleted");
       if (deleted.changes > 0 && bookmark) {
+        await triggerWebhook(bookmark.id, "deleted");
         await cleanupAssetForBookmark({
           asset: bookmark.asset,
           userId: ctx.user.id,


### PR DESCRIPTION
Fix the `error: [webhook][<jobId>] webhook job failed: Error: [webhook][<jobId>] bookmark with id <bookmarkId> was not found`. Relates to #1464.