### PR TITLE
feat: Clear all tags on mobile

### DIFF
--- a/apps/mobile/app/dashboard/bookmarks/[slug]/manage_tags.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/manage_tags.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo } from "react";
-import { Pressable, SectionList, Text, View } from "react-native";
+import {
+  Pressable,
+  SectionList,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { TailwindResolver } from "@/components/TailwindResolver";
 import CustomSafeAreaView from "@/components/ui/CustomSafeAreaView";
@@ -81,6 +87,19 @@ const ListPickerPage = () => {
     onError,
   });
 
+  const clearAllTags = () => {
+    if (optimisticTags.length === 0) return;
+
+    updateTags({
+      bookmarkId,
+      detach: optimisticTags.map((tag) => ({
+        tagId: tag.id,
+        tagName: tag.name,
+      })),
+      attach: [],
+    });
+  };
+
   const optimisticExistingTagIds = useMemo(() => {
     return new Set(optimisticTags?.map((t) => t.id) ?? []);
   }, [optimisticTags]);
@@ -117,6 +136,16 @@ const ListPickerPage = () => {
     return { filteredAllTags, filteredOptimisticTags };
   }, [search, allTags, optimisticTags, optimisticExistingTagIds]);
 
+  const ClearButton = () => (
+    <TouchableOpacity
+      onPress={clearAllTags}
+      disabled={optimisticTags.length === 0}
+      className={`mr-4 ${optimisticTags.length === 0 ? "opacity-50" : ""}`}
+    >
+      <Text className="text-base font-medium text-blue-500">Clear</Text>
+    </TouchableOpacity>
+  );
+
   if (isAllTagsPending) {
     return <FullPageSpinner />;
   }
@@ -130,6 +159,7 @@ const ListPickerPage = () => {
             onChangeText: (event) => setSearch(event.nativeEvent.text),
             autoCapitalize: "none",
           },
+          headerRight: () => <ClearButton />,
         }}
       />
       <SectionList


### PR DESCRIPTION
Added a "Clear All" button to the tag manager because AI often generates way too many tags and it's super annoying to remove them one by one. This makes it easier to clean everything up with a single tap.
