### PR TITLE
UI Fix: Immediately visible search bar in tags list

### DIFF
--- a/apps/mobile/app/dashboard/bookmarks/[slug]/manage_tags.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/manage_tags.tsx
@@ -129,6 +129,7 @@ const ListPickerPage = () => {
             placeholder: "Search Tags",
             onChangeText: (event) => setSearch(event.nativeEvent.text),
             autoCapitalize: "none",
+            hideWhenScrolling: false,
           },
         }}
       />


### PR DESCRIPTION
Having the search bar hidden in tags list makes no sense, this makes sure it's always visible.