### PR TITLE
WIP: fix(workers): improve video download reliability

### DIFF
--- a/apps/workers/workers/videoWorker.ts
+++ b/apps/workers/workers/videoWorker.ts
@@ -111,7 +111,7 @@ async function runWorker(job: DequeuedJob<ZVideoRequest>) {
     const downloadPath = await findAssetFile(videoAssetId);
     if (!downloadPath) {
       logger.info(
-        "[VideoCrawler][${jobId}] yt-dlp didn't download anything. Skipping ...",
+        `[VideoCrawler][${jobId}] yt-dlp didn't download anything. Skipping ...`,
       );
       return;
     }
@@ -130,6 +130,12 @@ async function runWorker(job: DequeuedJob<ZVideoRequest>) {
     logger.error(
       `[VideoCrawler][${jobId}] Failed to download a file from "${url}" to "${assetPath}"`,
     );
+    if ("command" in err) {
+      logger.debug(`[VideoCrawler][${jobId}] yt-dlp command: "${err.command}"`);
+    }
+    if ("stderr" in err) {
+      logger.debug(`[VideoCrawler][${jobId}] yt-dlp error: "${err.stderr}"`);
+    }
     await deleteLeftOverAssetFile(jobId, videoAssetId);
     return;
   }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,10 @@ COPY --chmod=755 ./docker/root/etc/s6-overlay /etc/s6-overlay
 ######################
 # Install runtime deps
 ######################
-RUN apk add --no-cache monolith yt-dlp graphicsmagick ghostscript
+# pipx needed to customize yt-dlp
+RUN apk add --no-cache monolith pipx graphicsmagick ghostscript
+# Install yt-dlp including curl-cffi in /usr/bin
+RUN PIPX_BIN_DIR=/usr/bin pipx install "yt-dlp[default,curl-cffi]"
 
 ######################
 # Prepare the web app


### PR DESCRIPTION
#### Context

In some cases video downloads fail due to TLS challenge. In the log we can see that the download failed, but not why it failed. In a test environment yt-dlp outputs the error to stderr, but that doesn't get logged.
```
ERROR: [generic] Got HTTP Error 403 caused by Cloudflare anti-bot challenge; try again with  --extractor-args "generic:impersonate"
```
Adding the extractor arguments fails differently, indicating that the installed version of yt-dl is missing a dependency. Per https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#impersonation the suggested dependency is curl-cffi.

#### Fix

* Replace the binary version of yt-dlp with a version that includes curl-cffi.
* Include the actual yt-dlp error in the log. That detail is logged at the debug level.

**Note:** for the fix to take effect, manually including the extractor arguments in CRAWLER_YTDLP_ARGS is still required.