### PR TITLE
fix(workers): video downloader should log yt-dlp errors

### DIFF
--- a/apps/workers/workers/videoWorker.ts
+++ b/apps/workers/workers/videoWorker.ts
@@ -127,9 +127,12 @@ async function runWorker(job: DequeuedJob<ZVideoRequest>) {
       );
       return;
     }
-    logger.error(
-      `[VideoCrawler][${jobId}] Failed to download a file from "${url}" to "${assetPath}"`,
-    );
+    const genericError = `[VideoCrawler][${jobId}] Failed to download a file from "${url}" to "${assetPath}"`;
+    if ("stderr" in err) {
+      logger.error(`${genericError}: ${err.stderr}`);
+    } else {
+      logger.error(genericError);
+    }
     await deleteLeftOverAssetFile(jobId, videoAssetId);
     return;
   }


### PR DESCRIPTION
In the event that yt-dlp errors out, the error details should be logged.
This can be helpful in deciding if and what extra arguments need to be passed via `CRAWLER_YTDLP_ARGS`.
yt-dlp prints out the error message to stderr.