### PR TITLE
feat: #1541 adding search history

### DIFF
--- a/apps/mobile/app/dashboard/search.tsx
+++ b/apps/mobile/app/dashboard/search.tsx
@@ -1,11 +1,19 @@
-import { useState } from "react";
-import { Pressable, Text, View } from "react-native";
+import { useMemo, useRef, useState } from "react";
+import {
+  FlatList,
+  Keyboard,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { router } from "expo-router";
 import BookmarkList from "@/components/bookmarks/BookmarkList";
 import FullPageError from "@/components/FullPageError";
 import CustomSafeAreaView from "@/components/ui/CustomSafeAreaView";
 import FullPageSpinner from "@/components/ui/FullPageSpinner";
 import { Input } from "@/components/ui/Input";
+import { useSearchHistory } from "@/lib/hooks";
 import { api } from "@/lib/trpc";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useDebounce } from "use-debounce";
@@ -14,32 +22,87 @@ export default function Search() {
   const [search, setSearch] = useState("");
 
   const [query] = useDebounce(search, 10);
+  const inputRef = useRef<TextInput>(null);
+
+  const [isInputFocused, setIsInputFocused] = useState(true);
+  const { history, addTerm, clearHistory } = useSearchHistory();
 
   const onRefresh = api.useUtils().bookmarks.searchBookmarks.invalidate;
 
-  const { data, error, refetch, isPending, fetchNextPage, isFetchingNextPage } =
-    api.bookmarks.searchBookmarks.useInfiniteQuery(
-      { text: query },
-      {
-        placeholderData: keepPreviousData,
-        gcTime: 0,
-        initialCursor: null,
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
-      },
+  const {
+    data,
+    error,
+    refetch,
+    isPending,
+    isFetching,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = api.bookmarks.searchBookmarks.useInfiniteQuery(
+    { text: query },
+    {
+      placeholderData: keepPreviousData,
+      gcTime: 0,
+      initialCursor: null,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    },
+  );
+
+  const filteredHistory = useMemo(() => {
+    if (search.trim().length === 0) {
+      return history;
+    }
+    return history.filter((item) =>
+      item.toLowerCase().includes(search.toLowerCase()),
     );
+  }, [search, history]);
 
   if (error) {
     return <FullPageError error={error.message} onRetry={() => refetch()} />;
   }
 
+  const handleSearchSubmit = (searchTerm: string) => {
+    const term = searchTerm.trim();
+    if (term.length > 0) {
+      addTerm(term);
+      setSearch(term);
+    }
+    inputRef.current?.blur();
+    Keyboard.dismiss();
+  };
+
+  const renderHistoryItem = ({ item }: { item: string }) => (
+    <Pressable
+      onPress={() => handleSearchSubmit(item)}
+      className="border-b border-gray-200 p-3"
+    >
+      <Text className="text-foreground">{item}</Text>
+    </Pressable>
+  );
+
+  const handleOnFocus = () => {
+    setIsInputFocused(true);
+  };
+
+  const handleOnBlur = () => {
+    setIsInputFocused(false);
+    if (search.trim().length > 0) {
+      addTerm(search);
+    }
+  };
+
   return (
     <CustomSafeAreaView>
       <View className="flex flex-row items-center gap-3 p-3">
         <Input
+          ref={inputRef}
           placeholder="Search"
           className="flex-1"
           value={search}
           onChangeText={setSearch}
+          onFocus={handleOnFocus}
+          onBlur={handleOnBlur}
+          onSubmitEditing={() => handleSearchSubmit(search)}
+          returnKeyType="search"
           autoFocus
           autoCapitalize="none"
         />
@@ -47,8 +110,34 @@ export default function Search() {
           <Text className="text-foreground">Cancel</Text>
         </Pressable>
       </View>
-      {!data && <FullPageSpinner />}
-      {data && (
+
+      {isInputFocused ? (
+        <FlatList
+          data={filteredHistory}
+          renderItem={renderHistoryItem}
+          keyExtractor={(item, index) => `${item}-${index}`}
+          ListHeaderComponent={
+            <View className="flex-row items-center justify-between p-3">
+              <Text className="text-sm font-bold text-gray-500">
+                Recent Searches
+              </Text>
+              {history.length > 0 && (
+                <Pressable onPress={clearHistory}>
+                  <Text className="text-sm text-blue-500">Clear</Text>
+                </Pressable>
+              )}
+            </View>
+          }
+          ListEmptyComponent={
+            <Text className="p-3 text-center text-gray-500">
+              No matching searches.
+            </Text>
+          }
+          keyboardShouldPersistTaps="handled"
+        />
+      ) : isFetching && query.length > 0 ? (
+        <FullPageSpinner />
+      ) : data && query.length > 0 ? (
         <BookmarkList
           bookmarks={data.pages.flatMap((p) => p.bookmarks)}
           fetchNextPage={fetchNextPage}
@@ -56,6 +145,8 @@ export default function Search() {
           onRefresh={onRefresh}
           isRefreshing={isPending}
         />
+      ) : (
+        <View />
       )}
     </CustomSafeAreaView>
   );

--- a/apps/mobile/lib/hooks.ts
+++ b/apps/mobile/lib/hooks.ts
@@ -1,4 +1,10 @@
+import { useCallback, useEffect, useState } from "react";
 import { ImageURISource } from "react-native";
+import {
+  addSearchTermToHistory,
+  clearSearchHistory,
+  getSearchHistory,
+} from "@/lib/searchHistory";
 
 import useAppSettings from "./settings";
 
@@ -10,4 +16,31 @@ export function useAssetUrl(assetId: string): ImageURISource {
       Authorization: `Bearer ${settings.apiKey}`,
     },
   };
+}
+
+export function useSearchHistory() {
+  const [history, setHistory] = useState<string[]>([]);
+
+  const loadHistory = useCallback(async () => {
+    const storedHistory = await getSearchHistory();
+    setHistory(storedHistory);
+  }, []);
+
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  const addTerm = useCallback(
+    async (term: string) => {
+      await addSearchTermToHistory(term);
+      await loadHistory();
+    },
+    [loadHistory],
+  );
+  const clearHistory = useCallback(async () => {
+    await clearSearchHistory();
+    setHistory([]);
+  }, []);
+
+  return { history, addTerm, clearHistory, refreshHistory: loadHistory };
 }

--- a/apps/mobile/lib/searchHistory.tsx
+++ b/apps/mobile/lib/searchHistory.tsx
@@ -1,0 +1,51 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const BOOKMARK_SEARCH_HISTORY_KEY = "karakeep_search_history";
+const MAX_HISTORY_ITEMS = 5;
+
+export async function getSearchHistory(): Promise<string[]> {
+  try {
+    const rawHistory = await AsyncStorage.getItem(BOOKMARK_SEARCH_HISTORY_KEY);
+    if (rawHistory) {
+      const parsed = JSON.parse(rawHistory) as string[];
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === "string")
+      ) {
+        return parsed;
+      }
+    }
+    return [];
+  } catch (error) {
+    console.error("Failed to parse search history:", error);
+    return [];
+  }
+}
+
+export async function addSearchTermToHistory(term: string) {
+  if (!term || term.trim().length === 0) {
+    return;
+  }
+  try {
+    const currentHistory = await getSearchHistory();
+    const filteredHistory = currentHistory.filter(
+      (item) => item.toLowerCase() !== term.toLowerCase(),
+    );
+    const newHistory = [term, ...filteredHistory];
+    const finalHistory = newHistory.slice(0, MAX_HISTORY_ITEMS);
+    await AsyncStorage.setItem(
+      BOOKMARK_SEARCH_HISTORY_KEY,
+      JSON.stringify(finalHistory),
+    );
+  } catch (error) {
+    console.error("Failed to save search history:", error);
+  }
+}
+
+export async function clearSearchHistory(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(BOOKMARK_SEARCH_HISTORY_KEY);
+  } catch (error) {
+    console.error("Failed to clear search history:", error);
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
     "@karakeep/shared": "workspace:^0.1.0",
     "@karakeep/shared-react": "workspace:^0.1.0",
     "@karakeep/trpc": "workspace:^0.1.0",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-menu/menu": "^1.1.6",
     "@tanstack/react-query": "^5.69.0",
     "class-variance-authority": "^0.7.0",

--- a/apps/web/components/dashboard/search/SearchAutocomplete.tsx
+++ b/apps/web/components/dashboard/search/SearchAutocomplete.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { useSearchHistory } from "@/lib/hooks/useSearchHistory";
+import { cn } from "@/lib/utils";
+import { History } from "lucide-react";
+
+interface SearchHistoryAutocompleteProps {
+  searchQuery: string;
+  onSelect: (searchTerm: string) => void;
+  className?: string;
+}
+
+export function SearchAutocomplete({
+  searchQuery,
+  onSelect,
+  className,
+}: SearchHistoryAutocompleteProps) {
+  const { history } = useSearchHistory();
+
+  const filteredHistory = searchQuery
+    ? history.filter((term) =>
+        term.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
+    : history;
+
+  if (history.length === 0) {
+    return (
+      <div className="p-4 text-center text-sm text-muted-foreground">
+        Search your bookmarks...
+      </div>
+    );
+  }
+
+  return (
+    <Command shouldFilter={false} className={cn(className)}>
+      <CommandList>
+        <CommandEmpty>No matching recent searches.</CommandEmpty>
+        <CommandGroup heading="Recent Searches">
+          {filteredHistory.map((term) => (
+            <CommandItem
+              key={term}
+              value={term}
+              onSelect={() => onSelect(term)}
+              className="cursor-pointer"
+            >
+              <History className="mr-2 h-4 w-4" />
+              <span>{term}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}

--- a/apps/web/components/dashboard/search/SearchInput.tsx
+++ b/apps/web/components/dashboard/search/SearchInput.tsx
@@ -3,17 +3,25 @@
 import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useDoBookmarkSearch } from "@/lib/hooks/bookmark-search";
+import { useSearchHistory } from "@/lib/hooks/useSearchHistory";
 import { useTranslation } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
 import { SearchIcon } from "lucide-react";
 
 import { EditListModal } from "../lists/EditListModal";
 import QueryExplainerTooltip from "./QueryExplainerTooltip";
+import { SearchAutocomplete } from "./SearchAutocomplete";
 
 function useFocusSearchOnKeyPress(
   inputRef: React.RefObject<HTMLInputElement>,
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void,
+  setPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>,
 ) {
   useEffect(() => {
     function handleKeyPress(e: KeyboardEvent) {
@@ -26,6 +34,7 @@ function useFocusSearchOnKeyPress(
         // Move the cursor to the end of the input field, so you can continue typing
         const length = inputRef.current.value.length;
         inputRef.current.setSelectionRange(length, length);
+        setPopoverOpen(true);
       }
       if (
         e.code === "Escape" &&
@@ -53,18 +62,35 @@ const SearchInput = React.forwardRef<
   React.HTMLAttributes<HTMLInputElement> & { loading?: boolean }
 >(({ className, ...props }, ref) => {
   const { t } = useTranslation();
-  const { debounceSearch, searchQuery, parsedSearchQuery, isInSearchPage } =
-    useDoBookmarkSearch();
+  const {
+    debounceSearch,
+    searchQuery,
+    doSearch,
+    parsedSearchQuery,
+    isInSearchPage,
+  } = useDoBookmarkSearch();
+  const { addTerm } = useSearchHistory();
 
   const [value, setValue] = React.useState(searchQuery);
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef(false);
+
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
     debounceSearch(e.target.value);
   };
 
-  useFocusSearchOnKeyPress(inputRef, onChange);
+  const handleHistorySelect = (term: string) => {
+    setValue(term);
+    doSearch(term);
+    addTerm(term);
+    setPopoverOpen(false);
+    inputRef.current?.blur();
+  };
+
+  useFocusSearchOnKeyPress(inputRef, onChange, setPopoverOpen);
   useImperativeHandle(ref, () => inputRef.current!);
   const [newNestedListModalOpen, setNewNestedListModalOpen] = useState(false);
 
@@ -74,39 +100,77 @@ const SearchInput = React.forwardRef<
     }
   }, [isInSearchPage]);
 
+  const handleBlur = () => {
+    if (popoverRef.current) {
+      // blur caused by select history
+      return;
+    }
+    if (value) {
+      addTerm(value);
+    }
+    setPopoverOpen(false);
+  };
+
+  const handleFocus = () => {
+    popoverRef.current = false;
+    setPopoverOpen(true);
+  };
+
   return (
     <div className={cn("relative flex-1", className)}>
-      <EditListModal
-        open={newNestedListModalOpen}
-        setOpen={setNewNestedListModalOpen}
-        prefill={{
-          type: "smart",
-          query: value,
-        }}
-      />
-      <QueryExplainerTooltip
-        className="-translate-1/2 absolute right-1.5 top-2 stroke-foreground p-0.5"
-        parsedSearchQuery={parsedSearchQuery}
-      />
-      {parsedSearchQuery.result === "full" &&
-        parsedSearchQuery.text.length == 0 && (
-          <Button
-            onClick={() => setNewNestedListModalOpen(true)}
-            size="none"
-            variant="secondary"
-            className="absolute right-9 top-2 z-50 px-2 py-1 text-xs"
-          >
-            {t("actions.save")}
-          </Button>
-        )}
-      <Input
-        startIcon={<SearchIcon size={18} className="text-muted-foreground" />}
-        ref={inputRef}
-        value={value}
-        onChange={onChange}
-        placeholder={t("common.search")}
-        {...props}
-      />
+      <Popover open={popoverOpen}>
+        <EditListModal
+          open={newNestedListModalOpen}
+          setOpen={setNewNestedListModalOpen}
+          prefill={{
+            type: "smart",
+            query: value,
+          }}
+        />
+        <QueryExplainerTooltip
+          className="-translate-1/2 absolute right-1.5 top-2 stroke-foreground p-0.5"
+          parsedSearchQuery={parsedSearchQuery}
+        />
+        {parsedSearchQuery.result === "full" &&
+          parsedSearchQuery.text.length == 0 && (
+            <Button
+              onClick={() => setNewNestedListModalOpen(true)}
+              size="none"
+              variant="secondary"
+              className="absolute right-9 top-2 z-50 px-2 py-1 text-xs"
+            >
+              {t("actions.save")}
+            </Button>
+          )}
+        <PopoverTrigger asChild>
+          <Input
+            startIcon={
+              <SearchIcon size={18} className="text-muted-foreground" />
+            }
+            ref={inputRef}
+            type="text"
+            value={value}
+            onChange={onChange}
+            placeholder={t("common.search")}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            {...props}
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[--radix-popover-trigger-width] p-0"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onMouseDown={() => {
+            popoverRef.current = true;
+          }}
+        >
+          <SearchAutocomplete
+            searchQuery={value}
+            onSelect={handleHistorySelect}
+          />
+        </PopoverContent>
+      </Popover>
     </div>
   );
 });

--- a/apps/web/lib/hooks/bookmark-search.ts
+++ b/apps/web/lib/hooks/bookmark-search.ts
@@ -45,7 +45,7 @@ export function useDoBookmarkSearch() {
     }
     const id = setTimeout(() => {
       doSearch(val);
-    }, 10);
+    }, 200);
     setTimeoutId(id);
   };
 

--- a/apps/web/lib/hooks/useSearchHistory.ts
+++ b/apps/web/lib/hooks/useSearchHistory.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect, useState } from "react";
+import { addSearchTermToHistory, getSearchHistory } from "@/lib/searchHistory";
+
+export function useSearchHistory() {
+  const [history, setHistory] = useState<string[]>([]);
+
+  useEffect(() => {
+    setHistory(getSearchHistory());
+  }, []);
+
+  const addTerm = useCallback((term: string) => {
+    addSearchTermToHistory(term);
+    setHistory(getSearchHistory());
+  }, []);
+
+  return { history, addTerm };
+}

--- a/apps/web/lib/searchHistory.tsx
+++ b/apps/web/lib/searchHistory.tsx
@@ -1,0 +1,37 @@
+const BOOKMARK_SEARCH_HISTORY_KEY = "karakeep_search_history";
+const MAX_HISTORY_ITEMS = 5;
+
+export function getSearchHistory(): string[] {
+  try {
+    const rawHistory = localStorage.getItem(BOOKMARK_SEARCH_HISTORY_KEY);
+    if (rawHistory) {
+      const parsed = JSON.parse(rawHistory) as string[];
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === "string")
+      ) {
+        return parsed;
+      }
+    }
+    return [];
+  } catch (error) {
+    console.error("Failed to parse search history:", error);
+    return [];
+  }
+}
+
+export function addSearchTermToHistory(term: string) {
+  if (!term || term.trim().length === 0) {
+    return;
+  }
+  const currentHistory = getSearchHistory();
+  const filteredHistory = currentHistory.filter(
+    (item) => item.toLowerCase() !== term.toLowerCase(),
+  );
+  const newHistory = [term, ...filteredHistory];
+  const finalHistory = newHistory.slice(0, MAX_HISTORY_ITEMS);
+  localStorage.setItem(
+    BOOKMARK_SEARCH_HISTORY_KEY,
+    JSON.stringify(finalHistory),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       '@karakeep/trpc':
         specifier: workspace:^0.1.0
         version: link:../../packages/trpc
+      '@react-native-async-storage/async-storage':
+        specifier: 1.23.1
+        version: 1.23.1(react-native@0.76.9(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1))
       '@react-native-menu/menu':
         specifier: ^1.1.6
         version: 1.1.6(react-native@0.76.9(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -1210,7 +1213,7 @@ importers:
         version: 18.3.1
       react-native:
         specifier: ^0.76.3
-        version: 0.76.9(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1)
+        version: 0.76.9(@babel/core@7.27.4)(@babel/preset-env@7.27.2(@babel/core@7.27.4))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1)
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
@@ -4315,6 +4318,11 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@react-native-async-storage/async-storage@1.23.1':
+    resolution: {integrity: sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==}
+    peerDependencies:
+      react-native: ^0.0.0-0 || >=0.60 <1.0
 
   '@react-native-menu/menu@1.1.6':
     resolution: {integrity: sha512-KRPBqa9jmYDFoacUxw8z1ucpbvmdlPuRO8tsFt2jM8JMC2s+YQwTtISG73PeqH9KD7BV+8igD/nizPfcipOmhQ==}
@@ -9068,6 +9076,10 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
   is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
     engines: {node: '>=10'}
@@ -9978,6 +9990,10 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge-options@3.0.4:
+    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
+    engines: {node: '>=10'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -19330,6 +19346,11 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-native-async-storage/async-storage@1.23.1(react-native@0.76.9(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.76.9(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1)
+
   '@react-native-menu/menu@1.1.6(react-native@0.76.9(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.12)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -25093,6 +25114,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-plain-obj@2.1.0: {}
+
   is-plain-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -26295,6 +26318,10 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge-options@3.0.4:
+    dependencies:
+      is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
 


### PR DESCRIPTION
### Changes

#### Add search history for web
Use local storage to store last 5 search history,
The popover showing search history will appear when input is focused.
According to the current search query implementation, history will only be saved to local storage after the input is blur, to prevent unintended saving.

#### Add search history for mobile
Use react-native async-storage to store last 5 search history,
Because we are showing user search history now in the search screen, user need to hit return to submit a search.
(Please refer to the demo video)

### Demo video

web: https://drive.google.com/file/d/1VCfapgyx8nqwxw7JajyC8HlXiJYvjNR7/view?usp=sharing
mobile: https://drive.google.com/file/d/1b5Xj5ekeFxb6IrzoWVUmZpMLWBHpCnBk/view?usp=sharing
