### PR TITLE
Updated chrome image / alpine-chrome (fork)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # If you want to mount a custom directory, change the volume mapping above instead.
       DATA_DIR: /data # DON'T CHANGE THIS
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:123
+    image: ghcr.io/zoobdude/alpine-chrome:latest
     restart: unless-stopped
     command:
       - --no-sandbox


### PR DESCRIPTION
I have switched to another image which is regular updated. The security is also improved in a more recent version.

image: ghcr.io/zoobdude/alpine-chrome:latest

https://github.com/Zoobdude/alpine-chrome

alpine-chrome (fork)

Chrome running in headless mode in a tiny Alpine image

Thank you to the original alpine-chrome team for all the heavy lifting! This repository simply continues regular builds of the original project (with more recent Chrome versions) as the original is no longer maintained.

It would be nice if you accept the change.

Thank you.