### PR TITLE
OpenShift 4  / OKD 4 compatibility and some small improvements in kubernetes rollout

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,6 +110,9 @@ RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/init-db-migration \
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
 
+# make /run for group root writable (this is required to start containers with random uid in OpenShift / OKD 4)
+RUN chmod -R g+w /run
+
 ################# The web container ##############
 
 FROM aio_builder AS web
@@ -120,6 +123,9 @@ ENV USING_LEGACY_SEPARATE_CONTAINERS=true
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
 
+# make /run for group root writable (this is required to start containers with random uid in OpenShift / OKD 4)
+RUN chmod -R g+w /run
+
 ################# The workers container ##############
 
 FROM aio_builder AS workers
@@ -129,6 +135,9 @@ FROM aio_builder AS workers
 RUN rm /etc/s6-overlay/s6-rc.d/svc-workers/dependencies.d/init-db-migration \
     && touch /etc/s6-overlay/s6-rc.d/user/contents.d/svc-workers
 ENV USING_LEGACY_SEPARATE_CONTAINERS=true
+
+# make /run for group root writable (this is required to start containers with random uid in OpenShift / OKD 4)
+RUN chmod -R g+w /run
 
 ################# The cli ##############
 
@@ -143,6 +152,9 @@ WORKDIR /app/apps/cli
 ARG SERVER_VERSION=nightly
 ENV SERVER_VERSION=${SERVER_VERSION}
 
+# make /run for group root writable (this is required to start containers with random uid in OpenShift / OKD 4)
+RUN chmod -R g+w /run
+
 ENTRYPOINT ["node", "index.mjs"]
 
 ################# MCP server ##############
@@ -154,5 +166,8 @@ WORKDIR /app
 COPY --from=base /app/apps/mcp/dist/index.js apps/mcp/index.js
 
 WORKDIR /app/apps/mcp
+
+# make /run for group root writable (this is required to start containers with random uid in OpenShift / OKD 4)
+RUN chmod -R g+w /run
 
 ENTRYPOINT ["node", "index.js"]

--- a/kubernetes/.env_sample
+++ b/kubernetes/.env_sample
@@ -1,3 +1,14 @@
 # Put your configuration options here
+# put the ingress hostname here if you're using it
 NEXTAUTH_URL=http://localhost:3000
 KARAKEEP_VERSION=release
+# if your using namePrefix and nameSuffix in kustomize, you have to rewrite the service names for
+# meili 
+MEILI_ADDR=http://meilisearch:7700
+# and chrome!
+BROWSER_WEB_URL=http://chrome:9222
+# Disable signups? (use this after first person registered)
+DISABLE_SIGNUPS=false
+# if you're using oauth you might disable local login
+DISABLE_PASSWORD_AUTH=false
+# OAUTH section is in .secrets

--- a/kubernetes/.secrets_sample
+++ b/kubernetes/.secrets_sample
@@ -2,3 +2,10 @@
 NEXTAUTH_SECRET=generated_secret
 MEILI_MASTER_KEY=generated_secret
 NEXT_PUBLIC_SECRET="my-super-duper-secret-string"
+# oauth login is configured here (look at https://docs.karakeep.app/configuration/)
+# OAUTH_CLIENT_SECRET=
+# OAUTH_CLIENT_ID=
+# OAUTH_SCOPE=
+# OAUTH_PROVIDER_NAME=
+# OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING=false
+# OAUTH_TIMEOUT=3600

--- a/kubernetes/web-deployment.yaml
+++ b/kubernetes/web-deployment.yaml
@@ -19,10 +19,6 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            - name: MEILI_ADDR
-              value: http://meilisearch:7700
-            - name: BROWSER_WEB_URL
-              value: http://chrome:9222
             - name: DATA_DIR
               value: /data
             # Add OPENAI_API_KEY to the ConfigMap if necessary


### PR DESCRIPTION
Hi,

in Openshift or OKD 4 every container is started with a random generated UID and GUID root. This is for security reasons.

- If you want to run karakeep in such an environment you have to give the group root the write right in `/run`
- I've changed a small amount of parameters (better parameter placing) in the kubernetes rollout. Though it's easier to customize your rollout in gitops style ;-)

