### PR TITLE
fix: add empty params object to lists function in mcp

### DIFF
--- a/apps/mcp/src/lists.ts
+++ b/apps/mcp/src/lists.ts
@@ -8,7 +8,9 @@ mcpServer.tool(
   "get-lists",
   `Retrieves a list of lists.`,
   async (): Promise<CallToolResult> => {
-    const res = await karakeepClient.GET("/lists");
+    const res = await karakeepClient.GET("/lists", {
+      params: {},
+    });
     if (!res.data) {
       return toMcpToolError(res.error);
     }


### PR DESCRIPTION
Linked to [issues 1696](https://github.com/karakeep-app/karakeep/issues/1696)