### PR TITLE
fix(auth): Ensure user role is saved on creation OIDC Bug Fix

### DIFF
--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -86,6 +86,7 @@ const CustomProvider = (): Adapter => {
         name: user.name ?? "",
         email: user.email,
         emailVerified: user.emailVerified,
+        role: user.role,
       });
     },
   };


### PR DESCRIPTION
Problem:                                                                               

When a new user registers using an OIDC/OAuth provider, their role was not being saved 
to the database. This caused a TRPCError: User settings not found on subsequent        
operations, as the logic to create default settings for a new user was failing. This   
effectively broke the sign-up flow for new users.                                      

Solution:                                                                              

This change updates the custom createUser function in the next-auth adapter            
configuration (apps/web/server/auth.ts). It now correctly passes the role from the user
profile object to the function responsible for creating the user record in the         
database. This ensures the user is created with a role, allowing default settings to be
generated and resolving the error.  