### PR TITLE
bump s6-overlay version to v3.2.1.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ EXPOSE 3000
 ######################
 # Prepare s6-overlay
 ######################
-ARG S6_OVERLAY_VERSION=3.2.0.0
+ARG S6_OVERLAY_VERSION=3.2.1.0
 ARG TARGETARCH
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp


### PR DESCRIPTION
Update s6-overlay to catch a fix for kubernetes readonly fs.
Ref to this [issue](https://github.com/just-containers/s6-overlay/issues/600) 