### PR TITLE
fix: prometheus add karakeep prefix to metrics

### DIFF
--- a/packages/trpc/stats.ts
+++ b/packages/trpc/stats.ts
@@ -15,6 +15,7 @@ import {
   WebhookQueue,
 } from "@karakeep/shared/queues";
 
+// Queue metrics
 const queuePendingJobsGauge = new Gauge({
   name: "karakeep_queue_jobs",
   help: "Number of jobs in each background queue",
@@ -55,6 +56,7 @@ const queuePendingJobsGauge = new Gauge({
   },
 });
 
+// User metrics
 const totalUsersGauge = new Gauge({
   name: "karakeep_total_users",
   help: "Total number of users in the system",
@@ -69,6 +71,7 @@ const totalUsersGauge = new Gauge({
   },
 });
 
+// Asset metrics
 const totalAssetSizeGauge = new Gauge({
   name: "karakeep_total_asset_size_bytes",
   help: "Total size of all assets in bytes",
@@ -85,6 +88,7 @@ const totalAssetSizeGauge = new Gauge({
   },
 });
 
+// Bookmark metrics
 const totalBookmarksGauge = new Gauge({
   name: "karakeep_total_bookmarks",
   help: "Total number of bookmarks in the system",
@@ -99,6 +103,7 @@ const totalBookmarksGauge = new Gauge({
   },
 });
 
+// Api metrics
 const apiRequestsTotalCounter = new Counter({
   name: "karakeep_trpc_requests_total",
   help: "Total number of API requests",
@@ -117,6 +122,7 @@ const apiRequestDurationSummary = new Summary({
   labelNames: ["type", "path"],
 });
 
+// Register all metrics
 register.registerMetric(queuePendingJobsGauge);
 register.registerMetric(totalUsersGauge);
 register.registerMetric(totalAssetSizeGauge);

--- a/packages/trpc/stats.ts
+++ b/packages/trpc/stats.ts
@@ -15,9 +15,8 @@ import {
   WebhookQueue,
 } from "@karakeep/shared/queues";
 
-// Queue metrics
 const queuePendingJobsGauge = new Gauge({
-  name: "queue_jobs",
+  name: "karakeep_queue_jobs",
   help: "Number of jobs in each background queue",
   labelNames: ["queue_name", "status"],
   async collect() {
@@ -56,9 +55,8 @@ const queuePendingJobsGauge = new Gauge({
   },
 });
 
-// User metrics
 const totalUsersGauge = new Gauge({
-  name: "total_users",
+  name: "karakeep_total_users",
   help: "Total number of users in the system",
   async collect() {
     try {
@@ -71,9 +69,8 @@ const totalUsersGauge = new Gauge({
   },
 });
 
-// Asset metrics
 const totalAssetSizeGauge = new Gauge({
-  name: "total_asset_size_bytes",
+  name: "karakeep_total_asset_size_bytes",
   help: "Total size of all assets in bytes",
   async collect() {
     try {
@@ -88,9 +85,8 @@ const totalAssetSizeGauge = new Gauge({
   },
 });
 
-// Bookmark metrics
 const totalBookmarksGauge = new Gauge({
-  name: "total_bookmarks",
+  name: "karakeep_total_bookmarks",
   help: "Total number of bookmarks in the system",
   async collect() {
     try {
@@ -103,26 +99,24 @@ const totalBookmarksGauge = new Gauge({
   },
 });
 
-// Api metrics
 const apiRequestsTotalCounter = new Counter({
-  name: "trpc_requests_total",
+  name: "karakeep_trpc_requests_total",
   help: "Total number of API requests",
   labelNames: ["type", "path", "is_error"],
 });
 
 const apiErrorsTotalCounter = new Counter({
-  name: "trpc_errors_total",
+  name: "karakeep_trpc_errors_total",
   help: "Total number of API requests",
   labelNames: ["type", "path", "code"],
 });
 
 const apiRequestDurationSummary = new Summary({
-  name: "trpc_request_duration_seconds",
+  name: "karakeep_trpc_request_duration_seconds",
   help: "Duration of tRPC requests in seconds",
   labelNames: ["type", "path"],
 });
 
-// Register all metrics
 register.registerMetric(queuePendingJobsGauge);
 register.registerMetric(totalUsersGauge);
 register.registerMetric(totalAssetSizeGauge);


### PR DESCRIPTION
Hi,

Thanks for the prometheus metrics.

Many of my apps all list a prefix of their app name in prometheus, karakeep does not so, if another app would have the same metrics name, I guess there may be a conflict?

So to be sure this PR adds a prefix for karakeep too.

