### PR TITLE
feat(cleanups): add clean unused tags to the cleanups menu

### DIFF
--- a/apps/web/app/dashboard/cleanups/page.tsx
+++ b/apps/web/app/dashboard/cleanups/page.tsx
@@ -1,25 +1,8 @@
-import { TagDuplicationDetection } from "@/components/dashboard/cleanups/TagDuplicationDetention";
-import { Separator } from "@/components/ui/separator";
-import { useTranslation } from "@/lib/i18n/server";
-import { Paintbrush, Tags } from "lucide-react";
+import { Cleanups } from "@/components/dashboard/cleanups/Cleanups";
+import { api } from "@/server/api/client";
 
-export default async function Cleanups() {
-  // oxlint-disable-next-line rules-of-hooks
-  const { t } = await useTranslation();
+export default async function CleanupsPage() {
+  const allTags = (await api.tags.list()).tags;
 
-  return (
-    <div className="flex flex-col gap-y-4 rounded-md border bg-background p-4">
-      <span className="flex items-center gap-1 text-2xl">
-        <Paintbrush />
-        {t("cleanups.cleanups")}
-      </span>
-      <Separator />
-      <span className="flex items-center gap-1 text-xl">
-        <Tags />
-        {t("cleanups.duplicate_tags.title")}
-      </span>
-      <Separator />
-      <TagDuplicationDetection />
-    </div>
-  );
+  return <Cleanups initialData={allTags} />;
 }

--- a/apps/web/components/dashboard/cleanups/Cleanups.tsx
+++ b/apps/web/components/dashboard/cleanups/Cleanups.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import useBulkTagActionsStore from "@/lib/bulkTagActions";
+import { api } from "@/lib/trpc";
+import { Separator } from "@radix-ui/react-select";
+import { Paintbrush } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { ZGetTagResponse, ZTagBasic } from "@karakeep/shared/types/tags";
+
+import { DeleteAllUnusedTags } from "../tags/DeleteAllUnusedTags";
+import DeleteTagConfirmationDialog from "../tags/DeleteTagConfirmationDialog";
+import { DuplicateTags } from "./DuplicateTags";
+
+export function Cleanups({ initialData }: { initialData: ZGetTagResponse[] }) {
+  const { t } = useTranslation();
+  const { isBulkEditEnabled } = useBulkTagActionsStore();
+  const { data } = api.tags.list.useQuery(undefined, {
+    initialData: { tags: initialData },
+  });
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [selectedTag, setSelectedTag] = useState<ZTagBasic | null>(null);
+
+  const handleOpenDialog = (tag: ZTagBasic) => {
+    setSelectedTag(tag);
+    setIsDialogOpen(true);
+  };
+
+  const allTags = data.tags;
+
+  const emptyTags = allTags.filter((t) => t.numBookmarks === 0);
+
+  return (
+    <div className="flex flex-col gap-y-4 rounded-md border bg-background p-4">
+      {selectedTag && (
+        <DeleteTagConfirmationDialog
+          tag={selectedTag}
+          open={isDialogOpen}
+          setOpen={(isOpen) => {
+            if (!isOpen) {
+              setSelectedTag(null);
+            }
+            setIsDialogOpen(isOpen);
+          }}
+        />
+      )}
+      <span className="flex items-center gap-1 text-2xl">
+        <Paintbrush />
+        {t("cleanups.cleanups")}
+      </span>
+      <Separator />
+      <DuplicateTags allTags={allTags} />
+      <DeleteAllUnusedTags
+        emptyTags={emptyTags}
+        isBulkEditEnabled={isBulkEditEnabled}
+        draggingEnabled={false}
+        handleOpenDialog={handleOpenDialog}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/cleanups/DuplicateTags.tsx
+++ b/apps/web/components/dashboard/cleanups/DuplicateTags.tsx
@@ -6,12 +6,12 @@ import { ActionButton } from "@/components/ui/action-button";
 import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
 import { badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import LoadingSpinner from "@/components/ui/spinner";
 import {
   Table,
   TableBody,
@@ -22,12 +22,13 @@ import {
 } from "@/components/ui/table";
 import { toast } from "@/components/ui/use-toast";
 import { useTranslation } from "@/lib/i18n/client";
-import { api } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { distance } from "fastest-levenshtein";
+import { t } from "i18next";
 import { Check, Combine, X } from "lucide-react";
 
 import { useMergeTag } from "@karakeep/shared-react/hooks/tags";
+import { ZGetTagResponse } from "@karakeep/shared/types/tags";
 
 interface Suggestion {
   mergeIntoId: string;
@@ -198,18 +199,14 @@ function SuggestionRow({
   );
 }
 
-export function TagDuplicationDetection() {
+export function DuplicateTags({ allTags }: { allTags: ZGetTagResponse[] }) {
   const [expanded, setExpanded] = useState(false);
-  let { data: allTags } = api.tags.list.useQuery(undefined, {
-    refetchOnWindowFocus: false,
-  });
 
   const { suggestions, updateMergeInto, setSuggestions, deleteSuggestion } =
     useSuggestions();
 
   useEffect(() => {
-    allTags = allTags ?? { tags: [] };
-    const sortedTags = allTags.tags.sort((a, b) =>
+    const sortedTags = allTags.sort((a, b) =>
       normalizeTag(a.name).localeCompare(normalizeTag(b.name)),
     );
 
@@ -236,48 +233,51 @@ export function TagDuplicationDetection() {
     setSuggestions(initialSuggestions);
   }, [allTags]);
 
-  if (!allTags) {
-    return <LoadingSpinner />;
-  }
-
   return (
-    <Collapsible open={expanded} onOpenChange={setExpanded}>
-      You have {suggestions.length} suggestions for tag merging.
-      {suggestions.length > 0 && (
-        <CollapsibleTrigger asChild>
-          <Button variant="link" size="sm">
-            {expanded ? "Hide All" : "Show All"}
-          </Button>
-        </CollapsibleTrigger>
-      )}
-      <CollapsibleContent>
-        <p className="text-sm italic text-muted-foreground">
-          For every suggestion, select the tag that you want to keep and other
-          tags will be merged into it.
-        </p>
-        {suggestions.length > 0 && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Tags</TableHead>
-                <TableHead className="text-center">
-                  <ApplyAllButton suggestions={suggestions} />
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {suggestions.map((suggestion) => (
-                <SuggestionRow
-                  key={suggestion.mergeIntoId}
-                  suggestion={suggestion}
-                  updateMergeInto={updateMergeInto}
-                  deleteSuggestion={deleteSuggestion}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </CollapsibleContent>
-    </Collapsible>
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("cleanups.duplicate_tags.title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Collapsible open={expanded} onOpenChange={setExpanded}>
+          You have {suggestions.length} suggestions for tag merging.
+          {suggestions.length > 0 && (
+            <CollapsibleTrigger asChild>
+              <Button variant="link" size="sm">
+                {expanded ? "Hide All" : "Show All"}
+              </Button>
+            </CollapsibleTrigger>
+          )}
+          <CollapsibleContent>
+            <p className="text-sm italic text-muted-foreground">
+              For every suggestion, select the tag that you want to keep and
+              other tags will be merged into it.
+            </p>
+            {suggestions.length > 0 && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Tags</TableHead>
+                    <TableHead className="text-center">
+                      <ApplyAllButton suggestions={suggestions} />
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {suggestions.map((suggestion) => (
+                    <SuggestionRow
+                      key={suggestion.mergeIntoId}
+                      suggestion={suggestion}
+                      updateMergeInto={updateMergeInto}
+                      deleteSuggestion={deleteSuggestion}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/components/dashboard/tags/DeleteAllUnusedTags.tsx
+++ b/apps/web/components/dashboard/tags/DeleteAllUnusedTags.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { ActionButton } from "@/components/ui/action-button";
+import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { toast } from "@/components/ui/use-toast";
+import { useTranslation } from "@/lib/i18n/client";
+
+import type { ZGetTagResponse, ZTagBasic } from "@karakeep/shared/types/tags";
+import { useDeleteUnusedTags } from "@karakeep/shared-react/hooks/tags";
+
+import { tagsToPill } from "./AllTagsView";
+
+export const DeleteAllUnusedTags = ({
+  emptyTags,
+  isBulkEditEnabled,
+  draggingEnabled,
+  handleOpenDialog,
+}: {
+  emptyTags: ZGetTagResponse[];
+  isBulkEditEnabled: boolean;
+  draggingEnabled: boolean;
+  handleOpenDialog: (tag: ZTagBasic) => void;
+}) => {
+  const { t } = useTranslation();
+  const { mutate, isPending } = useDeleteUnusedTags({
+    onSuccess: () => {
+      toast({
+        description: `Deleted all ${emptyTags.length} unused tags`,
+      });
+    },
+    onError: () => {
+      toast({
+        description: "Something went wrong",
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("tags.unused_tags")}</CardTitle>
+        <CardDescription>{t("tags.unused_tags_info")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Collapsible>
+          <div className="space-x-1 pb-2">
+            <CollapsibleTrigger asChild>
+              <Button variant="secondary" disabled={emptyTags.length == 0}>
+                {emptyTags.length > 0
+                  ? `Show ${emptyTags.length} unused tags`
+                  : "You don't have any unused tags"}
+              </Button>
+            </CollapsibleTrigger>
+            {emptyTags.length > 0 && (
+              <ActionConfirmingDialog
+                title={t("tags.delete_all_unused_tags")}
+                description={`Are you sure you want to delete the ${emptyTags.length} unused tags?`}
+                actionButton={() => (
+                  <ActionButton
+                    variant="destructive"
+                    loading={isPending}
+                    onClick={() => mutate()}
+                  >
+                    DELETE THEM ALL
+                  </ActionButton>
+                )}
+              >
+                <Button variant="destructive" disabled={emptyTags.length == 0}>
+                  {t("tags.delete_all_unused_tags")}
+                </Button>
+              </ActionConfirmingDialog>
+            )}
+          </div>
+          <CollapsibleContent>
+            {tagsToPill(
+              emptyTags,
+              isBulkEditEnabled,
+              draggingEnabled,
+              handleOpenDialog,
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      </CardContent>
+    </Card>
+  );
+};

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   web:
     build:
@@ -65,9 +64,9 @@ services:
       - data:/data
       - ..:/app
     command:
-     - /bin/sh
-     - -c
-     - "pnpm install --frozen-lockfile && pnpm run db:migrate"
+      - /bin/sh
+      - -c
+      - "pnpm install --frozen-lockfile && pnpm run db:migrate"
 
 volumes:
   meilisearch:


### PR DESCRIPTION
# Summary

- Fixes #1747 by adding the "delete all unused tags" action to the "Cleanups" page as well
- Extracts deleting logic to a new `DeleteAllUnusedTags` component that's used in the "Cleanups" and "All Tags" pages
- Remove obsolete `version` declaration from `docker/docker-compose.dev.yml`

# Screenshots

## All Tags Page
<img width="2880" height="1900" alt="All Tags Page" src="https://github.com/user-attachments/assets/2cc2577e-61cd-4f18-a17f-968d25ef9662" />

## Cleanups Page

<img width="2880" height="1900" alt="Cleanups Page" src="https://github.com/user-attachments/assets/abb8c87a-2aef-47ef-b92f-925a89398079" />
