### PR TITLE
ui(mobile): Fix WebView deceleration rate on iOS

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
@@ -112,6 +112,7 @@ export function BookmarkLinkReaderPreview({
         }}
         showsVerticalScrollIndicator={false}
         showsHorizontalScrollIndicator={false}
+        decelerationRate="normal"
       />
     </View>
   );
@@ -145,6 +146,7 @@ export function BookmarkLinkArchivePreview({
       startInLoadingState={true}
       mediaPlaybackRequiresUserAction={true}
       source={webViewUri}
+      decelerationRate="normal"
     />
   );
 }


### PR DESCRIPTION
The mobile app uses a WebView to display the bookmark preview.
WebView on iOS has a `"fast"` deceleration rate by default, which doesn't match the rest of the app and makes scrolling through long articles tedious.
We should update it to `"normal"` to match the non-WebView screens in the app as well as Safari.

https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#decelerationrate

Issue: #1834

<table>
<tr>
<td>fast (old behavior)</td>
<td>normal (new behavior)</td
</tr>
<tr>
<td>
<video src=https://github.com/user-attachments/assets/7f594d06-2543-40ab-8e98-3b7a8e168ac9>
</td>
<td>
<video src=https://github.com/user-attachments/assets/e63bf131-fda9-498e-bd2d-bd458c987628>
</td>
</tr>
</table>