### PR TITLE
feat: Support video uploads and attachments

### DIFF
--- a/packages/shared/assetdb.ts
+++ b/packages/shared/assetdb.ts
@@ -26,8 +26,17 @@ export const enum ASSET_TYPES {
   IMAGE_WEBP = "image/webp",
   APPLICATION_PDF = "application/pdf",
   TEXT_HTML = "text/html",
+
   VIDEO_MP4 = "video/mp4",
+  VIDEO_WEBM = "video/webm",
+  VIDEO_MKV = "video/x-matroska",
 }
+
+export const VIDEO_ASSET_TYPES: Set<string> = new Set<string>([
+  ASSET_TYPES.VIDEO_MP4,
+  ASSET_TYPES.VIDEO_WEBM,
+  ASSET_TYPES.VIDEO_MKV,
+]);
 
 export const IMAGE_ASSET_TYPES: Set<string> = new Set<string>([
   ASSET_TYPES.IMAGE_JPEG,
@@ -38,6 +47,7 @@ export const IMAGE_ASSET_TYPES: Set<string> = new Set<string>([
 // The assets that we allow the users to upload
 export const SUPPORTED_UPLOAD_ASSET_TYPES: Set<string> = new Set<string>([
   ...IMAGE_ASSET_TYPES,
+  ...VIDEO_ASSET_TYPES,
   ASSET_TYPES.TEXT_HTML,
   ASSET_TYPES.APPLICATION_PDF,
 ]);

--- a/packages/trpc/lib/attachments.ts
+++ b/packages/trpc/lib/attachments.ts
@@ -60,7 +60,7 @@ export function isAllowedToAttachAsset(type: ZAssetType) {
     fullPageArchive: false,
     precrawledArchive: true,
     bannerImage: true,
-    video: false,
+    video: true,
     bookmarkAsset: false,
     linkHtmlContent: false,
     unknown: false,


### PR DESCRIPTION
This commit allows the following mime types to be uploaded and attached as video assets on bookmarks.

- video/mp4
- video/webm
- video/x-matroska


This seems to be the minimal diff that adds the functionality in my dev environment. This change only adds the functionality to the API and makes no UI facing changes. Videos uploaded and attached using the API appear on the related bookmark similar to a video added using the native yt-dlp functionality.

I'm happy to make any changes needed to help land this.

Thanks for the amazing app!