### PR TITLE
Docs: Update 02-unraid.md

### DIFF
--- a/docs/docs/02-installation/02-unraid.md
+++ b/docs/docs/02-installation/02-unraid.md
@@ -20,16 +20,19 @@ Here's a high level overview of the services you'll need:
   - The **chrome** app (sgraaf's repo) uses the alpine-chrome image by zenika, which is used in Karakeep's official docker compose
 - **MeiliSearch** ([Support post](https://forums.unraid.net/topic/164847-support-collectathon-meilisearch/)): The search engine used by Karakeep. It's optional but highly recommended. If you don't have it set up, search will be disabled.
 
-### Simple install of Karakeep with the chrome app (sgraaf's repo)
-1. Install **chrome** (sgraaf's repo) and **meilisearch** (optional)
+### Quick install of Karakeep with the chrome app (sgraaf's repo)
+This quick install guide assumes that you're installing Karakeep locally (i.e. behind a firewall).
+
+1. Install `chrome` (by [zenika](https://hub.docker.com/r/zenika/alpine-chrome/) in sgraaf's Repository) and [meilisearch](https://forums.unraid.net/topic/164847-support-collectathon-meilisearch/) (optional) via Community Apps
 2. Install Karakeep:
-   - Remove all Container Variables referencing **browserless**, specifically `BROWSER_WEBSOCKET_URL` and `BROWSER_CONNECT_ONDEMAND` (click `Show more settings ...`, may require Advanced View toggle)
+   - Network Type: If you want to use Docker's built-in container name resolution (e.g. `http://chrome:9222`), then Karakeep and Chrome need to be on the same bridge network (preferably use `docker network create YOUR_CUSTOM_NETWORK_NAME` in the terminal)
+   - Remove all Container Variables referencing `browserless`, specifically `BROWSER_WEBSOCKET_URL` and `BROWSER_CONNECT_ONDEMAND` (click `Show more settings ...`, may require Advanced View toggle)
    - Add another Variable:
      - Name: `BROWSER_WEB_URL`
      - Key: `BROWSER_WEB_URL`
-     - Value: `http://YOUR_SERVER_IP:9222`
+     - Value: `http://chrome:9222`
    - Configure the required Container Variables:
-     - You may need to set the value for `NEXTAUTH_URL` to `http://YOUR_SERVER_IP:3000`
+     - You may need to set the value for `NEXTAUTH_URL` to `http://YOUR_SERVER_LAN_IP:3000`
      - Generate a string for `NEXTAUTH_SECRET` using `openssl rand -base64 36` in the terminal
-   - Configure or remove the optional Container Variables to your preference (e.g. the Meili and OpenAI variables)
+   - Configure or remove the optional Container Variables to your preference (e.g. the [Meili](https://docs.karakeep.app/configuration) and [OpenAI](https://docs.karakeep.app/configuration#inference-configs-for-automatic-tagging) variables)
    - Consider reading through the [Configuration docs](https://docs.karakeep.app/configuration) for additional Environment Variables that you may want to use


### PR DESCRIPTION
- Update high level overview to include browserless and chrome (alpine-chrome image by zenika)
  - chrome was added to the Community Apps on Apr 8, 2025 by sgraaf
- Simple installation guide for using the chrome app instead of browserless, since official Karakeep Docker Compose uses alpine-chrome

_(this is my first PR, any help or advice would be appreciated if I didn't do something correctly, thanks!)_