### PR TITLE
Render AI summary in markdown

### DIFF
--- a/apps/web/components/dashboard/bookmarks/SummarizeBookmarkArea.tsx
+++ b/apps/web/components/dashboard/bookmarks/SummarizeBookmarkArea.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { MarkdownReadonly } from "@/components/ui/markdown/markdown-readonly";
 import { ActionButton } from "@/components/ui/action-button";
+import { MarkdownReadonly } from "@/components/ui/markdown/markdown-readonly";
 import LoadingSpinner from "@/components/ui/spinner";
 import { toast } from "@/components/ui/use-toast";
 import { useClientConfig } from "@/lib/clientConfig";
@@ -53,11 +53,11 @@ function AISummary({
         onClick={() => !isExpanded && setIsExpanded(true)}
       >
         <div className="h-full rounded-lg bg-accent p-2">
-          <p
-            className={`text-sm text-gray-700 dark:text-gray-300 ${!isExpanded && "line-clamp-3"}`}
+          <MarkdownReadonly
+            className={`text-sm ${!isExpanded && "line-clamp-3"}`}
           >
-            <MarkdownReadonly>{summary}</MarkdownReadonly>
-          </p>
+            {summary}
+          </MarkdownReadonly>
           {isExpanded && (
             <span className="flex justify-end gap-2 pt-2">
               <ActionButton

--- a/apps/web/components/dashboard/bookmarks/SummarizeBookmarkArea.tsx
+++ b/apps/web/components/dashboard/bookmarks/SummarizeBookmarkArea.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { MarkdownReadonly } from "@/components/ui/markdown/markdown-readonly";
 import { ActionButton } from "@/components/ui/action-button";
 import LoadingSpinner from "@/components/ui/spinner";
 import { toast } from "@/components/ui/use-toast";
@@ -55,7 +56,7 @@ function AISummary({
           <p
             className={`text-sm text-gray-700 dark:text-gray-300 ${!isExpanded && "line-clamp-3"}`}
           >
-            {summary}
+            <MarkdownReadonly>{summary}</MarkdownReadonly>
           </p>
           {isExpanded && (
             <span className="flex justify-end gap-2 pt-2">

--- a/apps/web/components/ui/markdown/markdown-readonly.tsx
+++ b/apps/web/components/ui/markdown/markdown-readonly.tsx
@@ -22,11 +22,17 @@ function PreWithCopyBtn({ className, ...props }: React.ComponentProps<"pre">) {
   );
 }
 
-export function MarkdownReadonly({ children: markdown }: { children: string }) {
+export function MarkdownReadonly({
+  children: markdown,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
   return (
     <Markdown
       remarkPlugins={[remarkGfm, remarkBreaks]}
-      className="prose dark:prose-invert"
+      className={cn("prose dark:prose-invert", className)}
       components={{
         pre({ ...props }) {
           return <PreWithCopyBtn {...props} />;


### PR DESCRIPTION
Wrap bookmark summary with MarkdownReadonly component to render Markdown properly.

Indeed, LLM answer are mostly in Markdown.

So now, line break, lists, bold and so on will make the summary far more readable.