### PR TITLE
feat: bookmark reminder

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -12,6 +12,7 @@ import { TFunction } from "i18next";
 import {
   Archive,
   ClipboardList,
+  Clock,
   Highlighter,
   Home,
   Search,
@@ -79,6 +80,11 @@ export default async function Dashboard({
         name: t("common.highlights"),
         icon: <Highlighter size={18} />,
         path: "/dashboard/highlights",
+      },
+      {
+        name: "Reminders", // TODO: Add translation key
+        icon: <Clock size={18} />,
+        path: "/dashboard/reminders",
       },
       {
         name: t("common.archive"),

--- a/apps/web/app/dashboard/reminders/page.tsx
+++ b/apps/web/app/dashboard/reminders/page.tsx
@@ -1,0 +1,5 @@
+import RemindersPage from "@/components/dashboard/reminders/RemindersPage";
+
+export default async function RemindersPageRoute() {
+  return <RemindersPage />;
+}

--- a/apps/web/components/dashboard/bookmarks/AssetCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/AssetCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { BookmarksLayoutTypes } from "@/lib/userLocalSettings/types";
 import { cn } from "@/lib/utils";
 import { FileText } from "lucide-react";
 
@@ -67,9 +68,11 @@ function AssetImage({
 
 export default function AssetCard({
   bookmark: bookmarkedAsset,
+  fixedLayout,
   className,
 }: {
   bookmark: ZBookmarkTypeAsset;
+  fixedLayout?: BookmarksLayoutTypes;
   className?: string;
 }) {
   return (
@@ -80,6 +83,7 @@ export default function AssetCard({
           <FooterLinkURL url={getSourceUrl(bookmarkedAsset)} />
         )
       }
+      fixedLayout={fixedLayout}
       bookmark={bookmarkedAsset}
       className={className}
       wrapTags={true}

--- a/apps/web/components/dashboard/bookmarks/BookmarkActionBar.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkActionBar.tsx
@@ -1,18 +1,25 @@
+"use client";
+
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Maximize2 } from "lucide-react";
+import { useSession } from "next-auth/react";
 
 import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
 
 import BookmarkOptions from "./BookmarkOptions";
 import { FavouritedActionIcon } from "./icons";
+import RemindMeButton from "./RemindMeButton";
 
 export default function BookmarkActionBar({
   bookmark,
 }: {
   bookmark: ZBookmark;
 }) {
+  const { data: session } = useSession();
+  const isOwner = session?.user?.id === bookmark.userId;
+
   return (
     <div className="flex text-gray-500">
       {bookmark.favourited && (
@@ -24,6 +31,7 @@ export default function BookmarkActionBar({
       >
         <Maximize2 size={16} />
       </Link>
+      {isOwner && <RemindMeButton bookmark={bookmark} />}
       <BookmarkOptions bookmark={bookmark} />
     </div>
   );

--- a/apps/web/components/dashboard/bookmarks/BookmarkCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarkCard.tsx
@@ -1,4 +1,5 @@
 import { api } from "@/lib/trpc";
+import { BookmarksLayoutTypes } from "@/lib/userLocalSettings/types";
 
 import { BookmarkTypes, ZBookmark } from "@karakeep/shared/types/bookmarks";
 import { getBookmarkRefreshInterval } from "@karakeep/shared/utils/bookmarkUtils";
@@ -10,14 +11,19 @@ import UnknownCard from "./UnknownCard";
 
 export default function BookmarkCard({
   bookmark: initialData,
+  fixedLayout,
   className,
+  includeContent = false,
 }: {
   bookmark: ZBookmark;
+  fixedLayout?: BookmarksLayoutTypes;
   className?: string;
+  includeContent?: boolean;
 }) {
   const { data: bookmark } = api.bookmarks.getBookmark.useQuery(
     {
       bookmarkId: initialData.id,
+      includeContent,
     },
     {
       initialData,
@@ -36,6 +42,7 @@ export default function BookmarkCard({
       return (
         <LinkCard
           className={className}
+          fixedLayout={fixedLayout}
           bookmark={{ ...bookmark, content: bookmark.content }}
         />
       );
@@ -43,6 +50,7 @@ export default function BookmarkCard({
       return (
         <TextCard
           className={className}
+          fixedLayout={fixedLayout}
           bookmark={{ ...bookmark, content: bookmark.content }}
         />
       );
@@ -50,10 +58,17 @@ export default function BookmarkCard({
       return (
         <AssetCard
           className={className}
+          fixedLayout={fixedLayout}
           bookmark={{ ...bookmark, content: bookmark.content }}
         />
       );
     case BookmarkTypes.UNKNOWN:
-      return <UnknownCard className={className} bookmark={bookmark} />;
+      return (
+        <UnknownCard
+          className={className}
+          fixedLayout={fixedLayout}
+          bookmark={bookmark}
+        />
+      );
   }
 }

--- a/apps/web/components/dashboard/bookmarks/BookmarksGrid.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarksGrid.tsx
@@ -8,6 +8,7 @@ import {
   useBookmarkLayout,
   useGridColumns,
 } from "@/lib/userLocalSettings/bookmarksLayout";
+import { cn } from "@/lib/utils";
 import tailwindConfig from "@/tailwind.config";
 import { Slot } from "@radix-ui/react-slot";
 import { ErrorBoundary } from "react-error-boundary";
@@ -16,14 +17,36 @@ import Masonry from "react-masonry-css";
 import resolveConfig from "tailwindcss/resolveConfig";
 
 import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
+import {
+  getReminderTheme,
+  getReminderType,
+} from "@karakeep/shared/utils/reminderThemeUtils";
 
 import BookmarkCard from "./BookmarkCard";
 import EditorCard from "./EditorCard";
 import UnknownCard from "./UnknownCard";
 
-function StyledBookmarkCard({ children }: { children: React.ReactNode }) {
+function StyledBookmarkCard({
+  bookmark,
+  children,
+}: {
+  bookmark?: ZBookmark;
+  children: React.ReactNode;
+}) {
+  const reminderTheme =
+    bookmark?.reminder && bookmark.reminder.status !== "dismissed"
+      ? getReminderTheme(getReminderType(bookmark.reminder))
+      : null;
+
   return (
-    <Slot className="mb-4 border border-border bg-card duration-300 ease-in hover:shadow-lg hover:transition-all">
+    <Slot
+      className={cn(
+        "mb-4 border duration-300 ease-in hover:shadow-lg hover:transition-all",
+        reminderTheme
+          ? [reminderTheme.cardBg, reminderTheme.cardBorder]
+          : ["border-border", "bg-card"],
+      )}
+    >
       {children}
     </Slot>
   );
@@ -102,7 +125,7 @@ export default function BookmarksGrid({
     ),
     ...bookmarks.map((b) => (
       <ErrorBoundary key={b.id} fallback={<UnknownCard bookmark={b} />}>
-        <StyledBookmarkCard>
+        <StyledBookmarkCard bookmark={b}>
           <BookmarkCard bookmark={b} />
         </StyledBookmarkCard>
       </ErrorBoundary>

--- a/apps/web/components/dashboard/bookmarks/LinkCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/LinkCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { BookmarksLayoutTypes } from "@/lib/userLocalSettings/types";
 import { useUserSettings } from "@/lib/userSettings";
 
 import type { ZBookmarkTypeLink } from "@karakeep/shared/types/bookmarks";
@@ -89,15 +90,18 @@ function LinkImage({
 
 export default function LinkCard({
   bookmark: bookmarkLink,
+  fixedLayout,
   className,
 }: {
   bookmark: ZBookmarkTypeLink;
+  fixedLayout?: BookmarksLayoutTypes;
   className?: string;
 }) {
   return (
     <BookmarkLayoutAdaptingCard
       title={<LinkTitle bookmark={bookmarkLink} />}
       footer={<FooterLinkURL url={getSourceUrl(bookmarkLink)} />}
+      fixedLayout={fixedLayout}
       bookmark={bookmarkLink}
       wrapTags={false}
       image={(_layout, className) => (

--- a/apps/web/components/dashboard/bookmarks/RemindMeButton.tsx
+++ b/apps/web/components/dashboard/bookmarks/RemindMeButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
+import { api } from "@/lib/trpc";
+import { Clock } from "lucide-react";
+
+import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
+import {
+  getNextReminderDescription,
+  getNextReminderTime,
+} from "@karakeep/shared/utils/reminderTimeslotsUtils";
+
+export default function RemindMeButton({ bookmark }: { bookmark: ZBookmark }) {
+  const utils = api.useUtils();
+
+  const setReminderMutation = api.reminders.setReminder.useMutation({
+    onSuccess: () => {
+      const nextTime = getNextReminderDescription();
+      toast({
+        description: `Reminder set for ${nextTime}`,
+      });
+      // Invalidate queries to refresh the UI
+      utils.bookmarks.invalidate();
+      utils.reminders.invalidate();
+    },
+    onError: (error) => {
+      toast({
+        description: `Failed to set reminder: ${error.message}`,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleRemindMe = () => {
+    // Set reminder for the next logical time slot
+    const reminderTime = getNextReminderTime();
+
+    setReminderMutation.mutate({
+      bookmarkId: bookmark.id,
+      remindAt: reminderTime,
+    });
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="px-2 text-gray-500 hover:text-gray-700"
+      onClick={handleRemindMe}
+      disabled={setReminderMutation.isPending}
+      title={`Remind me ${getNextReminderDescription()}`}
+    >
+      <Clock size={16} />
+    </Button>
+  );
+}

--- a/apps/web/components/dashboard/bookmarks/TextCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/TextCard.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { BookmarkMarkdownComponent } from "@/components/dashboard/bookmarks/BookmarkMarkdownComponent";
 import { bookmarkLayoutSwitch } from "@/lib/userLocalSettings/bookmarksLayout";
+import { BookmarksLayoutTypes } from "@/lib/userLocalSettings/types";
 import { cn } from "@/lib/utils";
 
 import type { ZBookmarkTypeText } from "@karakeep/shared/types/bookmarks";
@@ -15,9 +16,11 @@ import FooterLinkURL from "./FooterLinkURL";
 
 export default function TextCard({
   bookmark,
+  fixedLayout,
   className,
 }: {
   bookmark: ZBookmarkTypeText;
+  fixedLayout?: BookmarksLayoutTypes;
   className?: string;
 }) {
   const banner = bookmark.assets.find((a) => a.assetType == "bannerImage");
@@ -36,6 +39,7 @@ export default function TextCard({
           )
         }
         wrapTags={true}
+        fixedLayout={fixedLayout}
         bookmark={bookmark}
         className={className}
         fitHeight={true}

--- a/apps/web/components/dashboard/bookmarks/UnknownCard.tsx
+++ b/apps/web/components/dashboard/bookmarks/UnknownCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslation } from "@/lib/i18n/client";
+import { BookmarksLayoutTypes } from "@/lib/userLocalSettings/types";
 import { AlertCircle } from "lucide-react";
 
 import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
@@ -9,15 +10,18 @@ import { BookmarkLayoutAdaptingCard } from "./BookmarkLayoutAdaptingCard";
 
 export default function UnknownCard({
   bookmark,
+  fixedLayout,
   className,
 }: {
   bookmark: ZBookmark;
+  fixedLayout?: BookmarksLayoutTypes;
   className?: string;
 }) {
   const { t } = useTranslation();
   return (
     <BookmarkLayoutAdaptingCard
       title={bookmark.title}
+      fixedLayout={fixedLayout}
       bookmark={bookmark}
       className={className}
       wrapTags={false}

--- a/apps/web/components/dashboard/reminders/RemindersList.tsx
+++ b/apps/web/components/dashboard/reminders/RemindersList.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { api } from "@/lib/trpc";
+import { cn } from "@/lib/utils";
+import { Clock } from "lucide-react";
+import { ErrorBoundary } from "react-error-boundary";
+
+import type {
+  ZGetRemindersRequest,
+  ZReminder,
+} from "@karakeep/shared/types/reminders";
+import { getReminderTheme } from "@karakeep/shared/utils/reminderThemeUtils";
+
+import BookmarkCard from "../bookmarks/BookmarkCard";
+import UnknownCard from "../bookmarks/UnknownCard";
+
+interface ReminderBookmarkCardProps {
+  reminder: ZReminder;
+  reminderType: NonNullable<ZGetRemindersRequest["reminderType"]>;
+}
+
+function ReminderBookmarkCard({
+  reminder,
+  reminderType,
+}: ReminderBookmarkCardProps) {
+  // Fetch the full bookmark data
+  const { data: bookmark, isLoading } = api.bookmarks.getBookmark.useQuery({
+    bookmarkId: reminder.bookmarkId,
+    includeContent: true,
+  });
+
+  if (isLoading) {
+    return (
+      <Card className="mb-4 animate-pulse">
+        <div className="p-4">
+          <div className="mb-2 h-20 rounded bg-muted"></div>
+          <div className="mb-2 h-4 w-3/4 rounded bg-muted"></div>
+          <div className="h-3 w-1/2 rounded bg-muted"></div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (!bookmark) {
+    const theme = getReminderTheme(reminderType);
+    if (!theme) {
+      return (
+        <Card className="mb-4">
+          <div className="p-4">
+            <p className="mb-4 text-red-600">Bookmark not found or deleted</p>
+          </div>
+        </Card>
+      );
+    }
+    return (
+      <Card className={cn("mb-4", theme.cardBorder)}>
+        <div className="p-4">
+          <p className="mb-4 text-red-600">Bookmark not found or deleted</p>
+        </div>
+      </Card>
+    );
+  }
+
+  const theme = getReminderTheme(reminderType);
+
+  return (
+    <div className="mb-4">
+      <div
+        className={cn(
+          "overflow-hidden rounded-lg border",
+          theme?.cardBg,
+          theme?.cardBorder,
+        )}
+      >
+        <div className="flex">
+          <ErrorBoundary
+            key={bookmark.id}
+            fallback={<UnknownCard bookmark={bookmark} />}
+          >
+            <BookmarkCard
+              fixedLayout="list"
+              bookmark={bookmark}
+              includeContent
+              className="mb-0 w-full border-0 bg-transparent duration-300 ease-in hover:shadow-lg hover:transition-all"
+            />
+          </ErrorBoundary>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface RemindersListProps {
+  reminderType: NonNullable<ZGetRemindersRequest["reminderType"]>;
+  reminders: ZReminder[];
+  isLoading: boolean;
+}
+
+export default function RemindersList({
+  reminderType,
+  reminders,
+  isLoading,
+}: RemindersListProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {[...Array(3)].map((_, i) => (
+          <Card key={i} className="animate-pulse">
+            <CardContent className="p-4">
+              <div className="mb-2 h-20 rounded bg-muted"></div>
+              <div className="mb-2 h-4 w-3/4 rounded bg-muted"></div>
+              <div className="h-3 w-1/2 rounded bg-muted"></div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (reminders.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-8 text-center">
+          <Clock className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+          <h3 className="mb-2 text-lg font-medium">
+            No {reminderType} reminders
+          </h3>
+          <p className="text-muted-foreground">
+            {reminderType === "due" &&
+              "You're all caught up! No overdue reminders."}
+            {reminderType === "upcoming" && "No upcoming reminders scheduled."}
+            {reminderType === "dismissed" && "No dismissed reminders yet."}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {reminders.map((reminder) => (
+        <ReminderBookmarkCard
+          key={reminder.id}
+          reminder={reminder}
+          reminderType={reminderType}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/reminders/RemindersPage.tsx
+++ b/apps/web/components/dashboard/reminders/RemindersPage.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { api } from "@/lib/trpc";
+
+import RemindersList from "./RemindersList";
+
+export default function RemindersPage() {
+  const clientTimestamp = useMemo(() => Date.now(), []);
+
+  // Fetch all reminders once
+  const { data: allRemindersData, isLoading } =
+    api.reminders.getReminders.useQuery({
+      clientTimestamp,
+    });
+
+  const { data: groupedReminders } = api.reminders.getRemindersCounts.useQuery({
+    clientTimestamp,
+  });
+
+  // Filter reminders client-side for each tab
+  const allReminders = allRemindersData?.reminders || [];
+  const now = new Date(clientTimestamp);
+
+  const dueReminders = useMemo(
+    () =>
+      allReminders.filter(
+        (r) => r.status === "active" && new Date(r.remindAt) <= now,
+      ),
+    [allReminders, now],
+  );
+
+  const upcomingReminders = useMemo(
+    () =>
+      allReminders.filter(
+        (r) => r.status === "active" && new Date(r.remindAt) > now,
+      ),
+    [allReminders, now],
+  );
+
+  const dismissedReminders = useMemo(
+    () => allReminders.filter((r) => r.status === "dismissed"),
+    [allReminders],
+  );
+
+  const dueCount = groupedReminders?.dueCount || 0;
+  const upcomingCount = groupedReminders?.upcomingCount || 0;
+  const dismissedCount = groupedReminders?.dismissedCount || 0;
+
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold tracking-tight">Reminders</h1>
+      </div>
+
+      <Tabs defaultValue="due" className="w-full">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="due" className="flex items-center gap-2">
+            Due
+            {dueCount > 0 && (
+              <Badge variant="destructive" className="ml-1">
+                {dueCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="upcoming" className="flex items-center gap-2">
+            Upcoming
+            {upcomingCount > 0 && (
+              <Badge variant="secondary" className="ml-1">
+                {upcomingCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="dismissed" className="flex items-center gap-2">
+            Dismissed
+            {/* TODO: Seeking feedback - should we show count for dismissed reminders? */}
+            {dismissedCount > 0 && (
+              <Badge variant="outline" className="ml-1">
+                {dismissedCount}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="due" className="mt-6">
+          <div className="mb-4">
+            <p className="text-sm text-muted-foreground">
+              These reminders are past their scheduled time
+            </p>
+          </div>
+          <RemindersList
+            reminderType="due"
+            reminders={dueReminders}
+            isLoading={isLoading}
+          />
+        </TabsContent>
+
+        <TabsContent value="upcoming" className="mt-6">
+          <div className="mb-4">
+            <p className="text-sm text-muted-foreground">
+              These reminders are scheduled for the future
+            </p>
+          </div>
+          <RemindersList
+            reminderType="upcoming"
+            reminders={upcomingReminders}
+            isLoading={isLoading}
+          />
+        </TabsContent>
+
+        <TabsContent value="dismissed" className="mt-6">
+          <div className="mb-4">
+            <p className="text-sm text-muted-foreground">
+              These reminders have been marked as complete
+            </p>
+          </div>
+          <RemindersList
+            reminderType="dismissed"
+            reminders={dismissedReminders}
+            isLoading={isLoading}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/components/shared/ReminderBanner.tsx
+++ b/apps/web/components/shared/ReminderBanner.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+import { formatDistanceToNow } from "date-fns";
+
+import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
+import {
+  getReminderEmoji,
+  getReminderTheme,
+  getReminderType,
+} from "@karakeep/shared/utils/reminderThemeUtils";
+
+interface ReminderBannerProps {
+  bookmark?: ZBookmark;
+  compact?: boolean;
+  clientTimestamp?: number;
+}
+
+export default function ReminderBanner({
+  bookmark,
+  compact,
+  clientTimestamp,
+}: ReminderBannerProps) {
+  const reminder = bookmark?.reminder;
+
+  if (!reminder || reminder.status === "dismissed") {
+    return null;
+  }
+
+  const reminderType = getReminderType(reminder, clientTimestamp);
+  const theme = getReminderTheme(reminderType);
+
+  // If no theme (shouldn't happen with valid reminder), don't render
+  if (!theme) {
+    return null;
+  }
+
+  const isPast =
+    new Date(reminder.remindAt) < new Date(clientTimestamp ?? Date.now());
+  const timeText = isPast
+    ? `${formatDistanceToNow(new Date(reminder.remindAt))} ago`
+    : `in ${formatDistanceToNow(new Date(reminder.remindAt))}`;
+
+  const getTimeText = () => {
+    if (reminderType === "dismissed") {
+      return `Was due ${timeText}`;
+    }
+    return `Due ${timeText}`;
+  };
+
+  const emoji = getReminderEmoji(reminderType);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between text-sm",
+        theme.bannerBg,
+        compact ? "rounded-t-lg px-2 py-1" : "px-3 py-1.5",
+      )}
+    >
+      <div className={cn("flex items-center gap-2", theme.textPrimary)}>
+        <span className="text-base">{emoji}</span>
+        <span className={theme.textSecondary}>{getTimeText()}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/date-time-picker.tsx
+++ b/apps/web/components/ui/date-time-picker.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { format } from "date-fns";
+import { CalendarIcon, Clock } from "lucide-react";
+
+interface DateTimePickerProps {
+  date?: Date | null;
+  onDateChange?: (date: Date | null) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function DateTimePicker({
+  date,
+  onDateChange,
+  placeholder = "Pick a date and time",
+  disabled = false,
+  className,
+}: DateTimePickerProps) {
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(
+    date ?? undefined,
+  );
+  const [hour, setHour] = useState<string>(date ? format(date, "HH") : "09");
+  const [minute, setMinute] = useState<string>(
+    date ? format(date, "mm") : "00",
+  );
+
+  useEffect(() => {
+    if (date) {
+      setSelectedDate(date);
+      setHour(format(date, "HH"));
+      setMinute(format(date, "mm"));
+    }
+  }, [date]);
+
+  const handleDateSelect = (newDate: Date | undefined) => {
+    setSelectedDate(newDate);
+    if (newDate) {
+      const updatedDate = new Date(newDate);
+      updatedDate.setHours(parseInt(hour), parseInt(minute), 0, 0);
+      onDateChange?.(updatedDate);
+    } else {
+      onDateChange?.(null);
+    }
+  };
+
+  const handleTimeChange = (newHour: string, newMinute: string) => {
+    setHour(newHour);
+    setMinute(newMinute);
+    if (selectedDate) {
+      const updatedDate = new Date(selectedDate);
+      updatedDate.setHours(parseInt(newHour), parseInt(newMinute), 0, 0);
+      onDateChange?.(updatedDate);
+    }
+  };
+
+  const displayValue = selectedDate
+    ? `${format(selectedDate, "PPP")} at ${hour}:${minute}`
+    : placeholder;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "justify-start text-left font-normal",
+            !selectedDate && "text-muted-foreground",
+            className,
+          )}
+          disabled={disabled}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {displayValue}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <div className="p-3">
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={handleDateSelect}
+            disabled={(date) =>
+              date < new Date(new Date().setHours(0, 0, 0, 0))
+            }
+          />
+          <div className="mt-3 border-t pt-3">
+            <div className="flex items-center space-x-2">
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              <div className="flex items-center space-x-1">
+                <Input
+                  type="number"
+                  min="0"
+                  max="23"
+                  value={hour}
+                  onChange={(e) => {
+                    const val = e.target.value.padStart(2, "0");
+                    if (parseInt(val) >= 0 && parseInt(val) <= 23) {
+                      handleTimeChange(val, minute);
+                    }
+                  }}
+                  className="w-[4.8rem] text-center"
+                  placeholder="HH"
+                />
+                <span className="text-muted-foreground">:</span>
+                <Input
+                  type="number"
+                  min="0"
+                  max="59"
+                  value={minute}
+                  onChange={(e) => {
+                    const val = e.target.value.padStart(2, "0");
+                    if (parseInt(val) >= 0 && parseInt(val) <= 59) {
+                      handleTimeChange(hour, val);
+                    }
+                  }}
+                  className="w-[4.8rem] text-center"
+                  placeholder="MM"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/db/drizzle/0066_bookmark_reminders.sql
+++ b/packages/db/drizzle/0066_bookmark_reminders.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `bookmarkReminders` (
+	`id` text PRIMARY KEY NOT NULL,
+	`bookmarkId` text NOT NULL,
+	`remindAt` integer NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`createdAt` integer NOT NULL,
+	`modifiedAt` integer,
+	FOREIGN KEY (`bookmarkId`) REFERENCES `bookmarks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `bookmarkReminders_bookmarkId_unique` ON `bookmarkReminders` (`bookmarkId`);--> statement-breakpoint
+CREATE INDEX `bookmarkReminders_remindAt_idx` ON `bookmarkReminders` (`remindAt`);--> statement-breakpoint
+CREATE INDEX `bookmarkReminders_status_idx` ON `bookmarkReminders` (`status`);

--- a/packages/db/drizzle/meta/0066_snapshot.json
+++ b/packages/db/drizzle/meta/0066_snapshot.json
@@ -1,0 +1,2728 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cdcadeb3-8003-4c6b-8832-3d914379e3f4",
+  "prevId": "f14d2087-e465-4cb5-81bc-accff017ee02",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyId": {
+          "name": "keyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apiKey_keyId_unique": {
+          "name": "apiKey_keyId_unique",
+          "columns": [
+            "keyId"
+          ],
+          "isUnique": true
+        },
+        "apiKey_name_userId_unique": {
+          "name": "apiKey_name_userId_unique",
+          "columns": [
+            "name",
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "apiKey_userId_user_id_fk": {
+          "name": "apiKey_userId_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assets": {
+      "name": "assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetType": {
+          "name": "assetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assets_bookmarkId_idx": {
+          "name": "assets_bookmarkId_idx",
+          "columns": [
+            "bookmarkId"
+          ],
+          "isUnique": false
+        },
+        "assets_assetType_idx": {
+          "name": "assets_assetType_idx",
+          "columns": [
+            "assetType"
+          ],
+          "isUnique": false
+        },
+        "assets_userId_idx": {
+          "name": "assets_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assets_bookmarkId_bookmarks_id_fk": {
+          "name": "assets_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_userId_user_id_fk": {
+          "name": "assets_userId_user_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarkAssets": {
+      "name": "bookmarkAssets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetType": {
+          "name": "assetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookmarkAssets_id_bookmarks_id_fk": {
+          "name": "bookmarkAssets_id_bookmarks_id_fk",
+          "tableFrom": "bookmarkAssets",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarkLinks": {
+      "name": "bookmarkLinks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "datePublished": {
+          "name": "datePublished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dateModified": {
+          "name": "dateModified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "htmlContent": {
+          "name": "htmlContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contentAssetId": {
+          "name": "contentAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawledAt": {
+          "name": "crawledAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawlStatus": {
+          "name": "crawlStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "crawlStatusCode": {
+          "name": "crawlStatusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 200
+        }
+      },
+      "indexes": {
+        "bookmarkLinks_url_idx": {
+          "name": "bookmarkLinks_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bookmarkLinks_id_bookmarks_id_fk": {
+          "name": "bookmarkLinks_id_bookmarks_id_fk",
+          "tableFrom": "bookmarkLinks",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarkLists": {
+      "name": "bookmarkLists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rssToken": {
+          "name": "rssToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "bookmarkLists_userId_idx": {
+          "name": "bookmarkLists_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "bookmarkLists_userId_id_idx": {
+          "name": "bookmarkLists_userId_id_idx",
+          "columns": [
+            "userId",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarkLists_userId_user_id_fk": {
+          "name": "bookmarkLists_userId_user_id_fk",
+          "tableFrom": "bookmarkLists",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarkLists_parentId_bookmarkLists_id_fk": {
+          "name": "bookmarkLists_parentId_bookmarkLists_id_fk",
+          "tableFrom": "bookmarkLists",
+          "tableTo": "bookmarkLists",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarkReminders": {
+      "name": "bookmarkReminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remindAt": {
+          "name": "remindAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modifiedAt": {
+          "name": "modifiedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bookmarkReminders_bookmarkId_unique": {
+          "name": "bookmarkReminders_bookmarkId_unique",
+          "columns": [
+            "bookmarkId"
+          ],
+          "isUnique": true
+        },
+        "bookmarkReminders_remindAt_idx": {
+          "name": "bookmarkReminders_remindAt_idx",
+          "columns": [
+            "remindAt"
+          ],
+          "isUnique": false
+        },
+        "bookmarkReminders_status_idx": {
+          "name": "bookmarkReminders_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bookmarkReminders_bookmarkId_bookmarks_id_fk": {
+          "name": "bookmarkReminders_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "bookmarkReminders",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarkTags": {
+      "name": "bookmarkTags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bookmarkTags_name_idx": {
+          "name": "bookmarkTags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "bookmarkTags_userId_idx": {
+          "name": "bookmarkTags_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "bookmarkTags_userId_name_unique": {
+          "name": "bookmarkTags_userId_name_unique",
+          "columns": [
+            "userId",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "bookmarkTags_userId_id_idx": {
+          "name": "bookmarkTags_userId_id_idx",
+          "columns": [
+            "userId",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarkTags_userId_user_id_fk": {
+          "name": "bookmarkTags_userId_user_id_fk",
+          "tableFrom": "bookmarkTags",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarkTexts": {
+      "name": "bookmarkTexts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookmarkTexts_id_bookmarks_id_fk": {
+          "name": "bookmarkTexts_id_bookmarks_id_fk",
+          "tableFrom": "bookmarkTexts",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modifiedAt": {
+          "name": "modifiedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "favourited": {
+          "name": "favourited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "taggingStatus": {
+          "name": "taggingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "summarizationStatus": {
+          "name": "summarizationStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bookmarks_userId_idx": {
+          "name": "bookmarks_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "bookmarks_archived_idx": {
+          "name": "bookmarks_archived_idx",
+          "columns": [
+            "archived"
+          ],
+          "isUnique": false
+        },
+        "bookmarks_favourited_idx": {
+          "name": "bookmarks_favourited_idx",
+          "columns": [
+            "favourited"
+          ],
+          "isUnique": false
+        },
+        "bookmarks_createdAt_idx": {
+          "name": "bookmarks_createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_userId_user_id_fk": {
+          "name": "bookmarks_userId_user_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarksInLists": {
+      "name": "bookmarksInLists",
+      "columns": {
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listMembershipId": {
+          "name": "listMembershipId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bookmarksInLists_bookmarkId_idx": {
+          "name": "bookmarksInLists_bookmarkId_idx",
+          "columns": [
+            "bookmarkId"
+          ],
+          "isUnique": false
+        },
+        "bookmarksInLists_listId_idx": {
+          "name": "bookmarksInLists_listId_idx",
+          "columns": [
+            "listId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bookmarksInLists_bookmarkId_bookmarks_id_fk": {
+          "name": "bookmarksInLists_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "bookmarksInLists",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarksInLists_listId_bookmarkLists_id_fk": {
+          "name": "bookmarksInLists_listId_bookmarkLists_id_fk",
+          "tableFrom": "bookmarksInLists",
+          "tableTo": "bookmarkLists",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarksInLists_listMembershipId_listCollaborators_id_fk": {
+          "name": "bookmarksInLists_listMembershipId_listCollaborators_id_fk",
+          "tableFrom": "bookmarksInLists",
+          "tableTo": "listCollaborators",
+          "columnsFrom": [
+            "listMembershipId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarksInLists_bookmarkId_listId_pk": {
+          "columns": [
+            "bookmarkId",
+            "listId"
+          ],
+          "name": "bookmarksInLists_bookmarkId_listId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "customPrompts": {
+      "name": "customPrompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appliesTo": {
+          "name": "appliesTo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "customPrompts_userId_idx": {
+          "name": "customPrompts_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "customPrompts_userId_user_id_fk": {
+          "name": "customPrompts_userId_user_id_fk",
+          "tableFrom": "customPrompts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "highlights": {
+      "name": "highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startOffset": {
+          "name": "startOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endOffset": {
+          "name": "endOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'yellow'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "highlights_bookmarkId_idx": {
+          "name": "highlights_bookmarkId_idx",
+          "columns": [
+            "bookmarkId"
+          ],
+          "isUnique": false
+        },
+        "highlights_userId_idx": {
+          "name": "highlights_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "highlights_bookmarkId_bookmarks_id_fk": {
+          "name": "highlights_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "highlights",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "highlights_userId_user_id_fk": {
+          "name": "highlights_userId_user_id_fk",
+          "tableFrom": "highlights",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "importSessionBookmarks": {
+      "name": "importSessionBookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "importSessionId": {
+          "name": "importSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "importSessionBookmarks_sessionId_idx": {
+          "name": "importSessionBookmarks_sessionId_idx",
+          "columns": [
+            "importSessionId"
+          ],
+          "isUnique": false
+        },
+        "importSessionBookmarks_bookmarkId_idx": {
+          "name": "importSessionBookmarks_bookmarkId_idx",
+          "columns": [
+            "bookmarkId"
+          ],
+          "isUnique": false
+        },
+        "importSessionBookmarks_importSessionId_bookmarkId_unique": {
+          "name": "importSessionBookmarks_importSessionId_bookmarkId_unique",
+          "columns": [
+            "importSessionId",
+            "bookmarkId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "importSessionBookmarks_importSessionId_importSessions_id_fk": {
+          "name": "importSessionBookmarks_importSessionId_importSessions_id_fk",
+          "tableFrom": "importSessionBookmarks",
+          "tableTo": "importSessions",
+          "columnsFrom": [
+            "importSessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "importSessionBookmarks_bookmarkId_bookmarks_id_fk": {
+          "name": "importSessionBookmarks_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "importSessionBookmarks",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "importSessions": {
+      "name": "importSessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rootListId": {
+          "name": "rootListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modifiedAt": {
+          "name": "modifiedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "importSessions_userId_idx": {
+          "name": "importSessions_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "importSessions_userId_user_id_fk": {
+          "name": "importSessions_userId_user_id_fk",
+          "tableFrom": "importSessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "importSessions_rootListId_bookmarkLists_id_fk": {
+          "name": "importSessions_rootListId_bookmarkLists_id_fk",
+          "tableFrom": "importSessions",
+          "tableTo": "bookmarkLists",
+          "columnsFrom": [
+            "rootListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invites_token_unique": {
+          "name": "invites_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "invites_invitedBy_user_id_fk": {
+          "name": "invites_invitedBy_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "listCollaborators": {
+      "name": "listCollaborators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "listCollaborators_listId_idx": {
+          "name": "listCollaborators_listId_idx",
+          "columns": [
+            "listId"
+          ],
+          "isUnique": false
+        },
+        "listCollaborators_userId_idx": {
+          "name": "listCollaborators_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "listCollaborators_listId_userId_unique": {
+          "name": "listCollaborators_listId_userId_unique",
+          "columns": [
+            "listId",
+            "userId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "listCollaborators_listId_bookmarkLists_id_fk": {
+          "name": "listCollaborators_listId_bookmarkLists_id_fk",
+          "tableFrom": "listCollaborators",
+          "tableTo": "bookmarkLists",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listCollaborators_userId_user_id_fk": {
+          "name": "listCollaborators_userId_user_id_fk",
+          "tableFrom": "listCollaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listCollaborators_addedBy_user_id_fk": {
+          "name": "listCollaborators_addedBy_user_id_fk",
+          "tableFrom": "listCollaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passwordResetToken": {
+      "name": "passwordResetToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passwordResetToken_token_unique": {
+          "name": "passwordResetToken_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "passwordResetTokens_userId_idx": {
+          "name": "passwordResetTokens_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passwordResetToken_userId_user_id_fk": {
+          "name": "passwordResetToken_userId_user_id_fk",
+          "tableFrom": "passwordResetToken",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rssFeedImports": {
+      "name": "rssFeedImports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entryId": {
+          "name": "entryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rssFeedId": {
+          "name": "rssFeedId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rssFeedImports_feedIdIdx_idx": {
+          "name": "rssFeedImports_feedIdIdx_idx",
+          "columns": [
+            "rssFeedId"
+          ],
+          "isUnique": false
+        },
+        "rssFeedImports_entryIdIdx_idx": {
+          "name": "rssFeedImports_entryIdIdx_idx",
+          "columns": [
+            "entryId"
+          ],
+          "isUnique": false
+        },
+        "rssFeedImports_rssFeedId_entryId_unique": {
+          "name": "rssFeedImports_rssFeedId_entryId_unique",
+          "columns": [
+            "rssFeedId",
+            "entryId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rssFeedImports_rssFeedId_rssFeeds_id_fk": {
+          "name": "rssFeedImports_rssFeedId_rssFeeds_id_fk",
+          "tableFrom": "rssFeedImports",
+          "tableTo": "rssFeeds",
+          "columnsFrom": [
+            "rssFeedId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rssFeedImports_bookmarkId_bookmarks_id_fk": {
+          "name": "rssFeedImports_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "rssFeedImports",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rssFeeds": {
+      "name": "rssFeeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "importTags": {
+          "name": "importTags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastFetchedAt": {
+          "name": "lastFetchedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastFetchedStatus": {
+          "name": "lastFetchedStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rssFeeds_userId_idx": {
+          "name": "rssFeeds_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rssFeeds_userId_user_id_fk": {
+          "name": "rssFeeds_userId_user_id_fk",
+          "tableFrom": "rssFeeds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ruleEngineActions": {
+      "name": "ruleEngineActions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ruleId": {
+          "name": "ruleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ruleEngineActions_userId_idx": {
+          "name": "ruleEngineActions_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "ruleEngineActions_ruleId_idx": {
+          "name": "ruleEngineActions_ruleId_idx",
+          "columns": [
+            "ruleId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ruleEngineActions_userId_user_id_fk": {
+          "name": "ruleEngineActions_userId_user_id_fk",
+          "tableFrom": "ruleEngineActions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ruleEngineActions_ruleId_ruleEngineRules_id_fk": {
+          "name": "ruleEngineActions_ruleId_ruleEngineRules_id_fk",
+          "tableFrom": "ruleEngineActions",
+          "tableTo": "ruleEngineRules",
+          "columnsFrom": [
+            "ruleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ruleEngineActions_userId_tagId_fk": {
+          "name": "ruleEngineActions_userId_tagId_fk",
+          "tableFrom": "ruleEngineActions",
+          "tableTo": "bookmarkTags",
+          "columnsFrom": [
+            "userId",
+            "tagId"
+          ],
+          "columnsTo": [
+            "userId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ruleEngineActions_userId_listId_fk": {
+          "name": "ruleEngineActions_userId_listId_fk",
+          "tableFrom": "ruleEngineActions",
+          "tableTo": "bookmarkLists",
+          "columnsFrom": [
+            "userId",
+            "listId"
+          ],
+          "columnsTo": [
+            "userId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ruleEngineRules": {
+      "name": "ruleEngineRules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ruleEngine_userId_idx": {
+          "name": "ruleEngine_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ruleEngineRules_userId_user_id_fk": {
+          "name": "ruleEngineRules_userId_user_id_fk",
+          "tableFrom": "ruleEngineRules",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ruleEngineRules_userId_tagId_fk": {
+          "name": "ruleEngineRules_userId_tagId_fk",
+          "tableFrom": "ruleEngineRules",
+          "tableTo": "bookmarkTags",
+          "columnsFrom": [
+            "userId",
+            "tagId"
+          ],
+          "columnsTo": [
+            "userId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ruleEngineRules_userId_listId_fk": {
+          "name": "ruleEngineRules_userId_listId_fk",
+          "tableFrom": "ruleEngineRules",
+          "tableTo": "bookmarkLists",
+          "columnsFrom": [
+            "userId",
+            "listId"
+          ],
+          "columnsTo": [
+            "userId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "priceId": {
+          "name": "priceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modifiedAt": {
+          "name": "modifiedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_userId_unique": {
+          "name": "subscriptions_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_userId_idx": {
+          "name": "subscriptions_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "subscriptions_stripeCustomerId_idx": {
+          "name": "subscriptions_stripeCustomerId_idx",
+          "columns": [
+            "stripeCustomerId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_user_id_fk": {
+          "name": "subscriptions_userId_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tagsOnBookmarks": {
+      "name": "tagsOnBookmarks",
+      "columns": {
+        "bookmarkId": {
+          "name": "bookmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachedAt": {
+          "name": "attachedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachedBy": {
+          "name": "attachedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tagsOnBookmarks_tagId_idx": {
+          "name": "tagsOnBookmarks_tagId_idx",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        },
+        "tagsOnBookmarks_bookmarkId_idx": {
+          "name": "tagsOnBookmarks_bookmarkId_idx",
+          "columns": [
+            "bookmarkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tagsOnBookmarks_bookmarkId_bookmarks_id_fk": {
+          "name": "tagsOnBookmarks_bookmarkId_bookmarks_id_fk",
+          "tableFrom": "tagsOnBookmarks",
+          "tableTo": "bookmarks",
+          "columnsFrom": [
+            "bookmarkId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tagsOnBookmarks_tagId_bookmarkTags_id_fk": {
+          "name": "tagsOnBookmarks_tagId_bookmarkTags_id_fk",
+          "tableFrom": "tagsOnBookmarks",
+          "tableTo": "bookmarkTags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tagsOnBookmarks_bookmarkId_tagId_pk": {
+          "columns": [
+            "bookmarkId",
+            "tagId"
+          ],
+          "name": "tagsOnBookmarks_bookmarkId_tagId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "bookmarkQuota": {
+          "name": "bookmarkQuota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storageQuota": {
+          "name": "storageQuota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browserCrawlingEnabled": {
+          "name": "browserCrawlingEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmarkClickAction": {
+          "name": "bookmarkClickAction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open_original_link'"
+        },
+        "archiveDisplayBehaviour": {
+          "name": "archiveDisplayBehaviour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'show'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'UTC'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhooks_userId_idx": {
+          "name": "webhooks_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhooks_userId_user_id_fk": {
+          "name": "webhooks_userId_user_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1763335572156,
       "tag": "0065_collaborative_lists",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "6",
+      "when": 1763388032326,
+      "tag": "0066_bookmark_reminders",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -752,6 +752,10 @@ export const bookmarkRelations = relations(bookmarks, ({ many, one }) => ({
     fields: [bookmarks.id],
     references: [bookmarkAssets.id],
   }),
+  reminder: one(bookmarkReminders, {
+    fields: [bookmarks.id],
+    references: [bookmarkReminders.bookmarkId],
+  }),
   tagsOnBookmarks: many(tagsOnBookmarks),
   bookmarksInLists: many(bookmarksInLists),
   assets: many(assets),
@@ -932,6 +936,40 @@ export const importSessionBookmarksRelations = relations(
     }),
     bookmark: one(bookmarks, {
       fields: [importSessionBookmarks.bookmarkId],
+      references: [bookmarks.id],
+    }),
+  }),
+);
+
+export const bookmarkReminders = sqliteTable(
+  "bookmarkReminders",
+  {
+    id: text("id")
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    bookmarkId: text("bookmarkId")
+      .notNull()
+      .unique() // Each bookmark can only have one reminder
+      .references(() => bookmarks.id, { onDelete: "cascade" }),
+    remindAt: integer("remindAt", { mode: "timestamp" }).notNull(),
+    status: text("status", { enum: ["active", "dismissed"] })
+      .notNull()
+      .default("active"),
+    createdAt: createdAtField(),
+    modifiedAt: modifiedAtField(),
+  },
+  (br) => [
+    index("bookmarkReminders_remindAt_idx").on(br.remindAt),
+    index("bookmarkReminders_status_idx").on(br.status),
+  ],
+);
+
+export const bookmarkRemindersRelations = relations(
+  bookmarkReminders,
+  ({ one }) => ({
+    bookmark: one(bookmarks, {
+      fields: [bookmarkReminders.bookmarkId],
       references: [bookmarks.id],
     }),
   }),

--- a/packages/open-api/karakeep-openapi-spec.json
+++ b/packages/open-api/karakeep-openapi-spec.json
@@ -334,6 +334,42 @@
                 "assetType"
               ]
             }
+          },
+          "reminder": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "bookmarkId": {
+                "type": "string"
+              },
+              "remindAt": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "dismissed"
+                ]
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "modifiedAt": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "id",
+              "bookmarkId",
+              "remindAt",
+              "status",
+              "createdAt",
+              "modifiedAt"
+            ]
           }
         },
         "required": [

--- a/packages/shared/types/bookmarks.ts
+++ b/packages/shared/types/bookmarks.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { zCursorV2 } from "./pagination";
+import { zReminderSchema } from "./reminders";
 import { zBookmarkTagSchema } from "./tags";
 
 export const MAX_BOOKMARK_TITLE_LENGTH = 1000;
@@ -117,6 +118,7 @@ export const zBookmarkSchema = zBareBookmarkSchema.merge(
     tags: z.array(zBookmarkTagSchema),
     content: zBookmarkContentSchema,
     assets: z.array(zAssetSchema),
+    reminder: zReminderSchema.optional(),
   }),
 );
 export type ZBookmark = z.infer<typeof zBookmarkSchema>;

--- a/packages/shared/types/reminders.ts
+++ b/packages/shared/types/reminders.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export const zReminderSchema = z.object({
+  id: z.string(),
+  bookmarkId: z.string(),
+  remindAt: z.date(),
+  status: z.enum(["active", "dismissed"]),
+  createdAt: z.date(),
+  modifiedAt: z.date().nullable(),
+});
+
+export type ZReminder = z.infer<typeof zReminderSchema>;
+
+export const zCreateReminderRequestSchema = z.object({
+  bookmarkId: z.string(),
+  remindAt: z.date(),
+});
+
+export type ZCreateReminderRequest = z.infer<
+  typeof zCreateReminderRequestSchema
+>;
+
+export const zUpdateReminderRequestSchema = z
+  .object({
+    reminderId: z.string(),
+    remindAt: z.date().optional(),
+    status: z.enum(["active", "dismissed"]).optional(),
+  })
+  .refine((data) => data.remindAt !== undefined || data.status !== undefined, {
+    message: "Must provide at least one field to update (remindAt or status)",
+  });
+
+export type ZUpdateReminderRequest = z.infer<
+  typeof zUpdateReminderRequestSchema
+>;
+
+export const zGetRemindersRequestSchema = z.object({
+  bookmarkId: z.string().optional(),
+  status: z.enum(["active", "dismissed"]).optional(),
+  reminderType: z.enum(["due", "upcoming", "dismissed"]).optional(),
+  clientTimestamp: z.number().int().min(0).optional(),
+});
+
+export type ZGetRemindersRequest = z.infer<typeof zGetRemindersRequestSchema>;
+
+export const zGetRemindersResponseSchema = z.object({
+  reminders: z.array(zReminderSchema),
+});
+
+export type ZGetRemindersResponse = z.infer<typeof zGetRemindersResponseSchema>;
+
+export const zGetRemindersCountsRequestSchema = z.object({
+  clientTimestamp: z.number().int().min(0).optional(),
+});
+
+export type ZGetRemindersCountsRequest = z.infer<
+  typeof zGetRemindersCountsRequestSchema
+>;
+
+export const zGetRemindersCountsResponseSchema = z.object({
+  dueCount: z.number(),
+  upcomingCount: z.number(),
+  dismissedCount: z.number(),
+});
+
+export type ZGetRemindersCountsResponse = z.infer<
+  typeof zGetRemindersCountsResponseSchema
+>;

--- a/packages/shared/utils/reminderThemeUtils.ts
+++ b/packages/shared/utils/reminderThemeUtils.ts
@@ -1,0 +1,83 @@
+// Color themes for different reminder states
+export function getReminderTheme(
+  reminderType: "due" | "upcoming" | "dismissed" | null,
+) {
+  if (!reminderType) {
+    return null;
+  }
+  switch (reminderType) {
+    case "due":
+      return {
+        // Red theme for urgent due reminders
+        cardBg: "bg-red-50 dark:bg-red-950/20",
+        cardBorder: "border-red-200 dark:border-red-900",
+        bannerBg: "bg-red-100/30 dark:bg-red-900/30",
+        dividerBorder: "border-red-200 dark:border-red-900/50",
+        textPrimary: "text-red-700 dark:text-red-300",
+        textSecondary: "text-red-600 dark:text-red-400",
+        buttonHover:
+          "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200",
+      };
+    case "upcoming":
+      return {
+        // Blue theme for scheduled upcoming reminders
+        cardBg: "bg-blue-50 dark:bg-blue-950/20",
+        cardBorder: "border-blue-200 dark:border-blue-900",
+        bannerBg: "bg-blue-100/30 dark:bg-blue-900/30",
+        dividerBorder: "border-blue-200 dark:border-blue-900/50",
+        textPrimary: "text-blue-700 dark:text-blue-300",
+        textSecondary: "text-blue-600 dark:text-blue-400",
+        buttonHover:
+          "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200",
+      };
+    case "dismissed":
+      return {
+        // Gray theme for dismissed/completed reminders
+        cardBg: "bg-gray-50 dark:bg-gray-950/20",
+        cardBorder: "border-gray-200 dark:border-gray-700",
+        bannerBg: "bg-gray-100/30 dark:bg-gray-800/30",
+        dividerBorder: "border-gray-200 dark:border-gray-700/50",
+        textPrimary: "text-gray-700 dark:text-gray-300",
+        textSecondary: "text-gray-600 dark:text-gray-400",
+        buttonHover:
+          "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200",
+      };
+  }
+}
+
+export function getReminderEmoji(
+  reminderType: "due" | "upcoming" | "dismissed" | null,
+) {
+  if (!reminderType) {
+    return "";
+  }
+  switch (reminderType) {
+    case "due":
+      return "🔥"; // Fire emoji for urgent
+    case "upcoming":
+      return "📌"; // Pin emoji for upcoming
+    case "dismissed":
+      return "✅"; // Check mark for completed
+  }
+}
+
+export function getReminderType(
+  reminder:
+    | { remindAt: Date; status: "active" | "dismissed" }
+    | null
+    | undefined,
+  clientTimestamp?: number,
+): "due" | "upcoming" | "dismissed" | null {
+  if (!reminder) {
+    return null;
+  }
+
+  if (reminder.status === "dismissed") {
+    return "dismissed";
+  }
+
+  const now = new Date(clientTimestamp ?? Date.now());
+  const remindAt = new Date(reminder.remindAt);
+
+  return remindAt <= now ? "due" : "upcoming";
+}

--- a/packages/shared/utils/reminderTimeslotsUtils.ts
+++ b/packages/shared/utils/reminderTimeslotsUtils.ts
@@ -1,0 +1,74 @@
+/**
+ * Utility functions for calculating reminder time slots
+ *
+ * Standard time slots: 9am (morning), 1pm (afternoon), 8pm (evening)
+ * Future: These will be customizable in user settings
+ */
+
+export const DEFAULT_TIME_SLOTS = {
+  morning: 9, // 9am
+  afternoon: 13, // 1pm
+  evening: 20, // 8pm
+} as const;
+
+export type TimeSlot = keyof typeof DEFAULT_TIME_SLOTS;
+
+/**
+ * Calculate the next logical reminder time based on current time
+ * Logic:
+ * - Before 9am: Next slot is 9am today
+ * - 9am-12:59pm: Next slot is 1pm today
+ * - 1pm-7:59pm: Next slot is 8pm today
+ * - After 8pm: Next slot is 9am tomorrow
+ */
+export function getNextReminderTime(currentTime: Date = new Date()): Date {
+  const now = new Date(currentTime);
+  const currentHour = now.getHours();
+
+  // Create a new date for the reminder time
+  const reminderTime = new Date(now);
+  reminderTime.setMinutes(0);
+  reminderTime.setSeconds(0);
+  reminderTime.setMilliseconds(0);
+
+  if (currentHour < DEFAULT_TIME_SLOTS.morning) {
+    // Before 9am: set to 9am today
+    reminderTime.setHours(DEFAULT_TIME_SLOTS.morning);
+  } else if (currentHour < DEFAULT_TIME_SLOTS.afternoon) {
+    // 9am-12:59pm: set to 1pm today
+    reminderTime.setHours(DEFAULT_TIME_SLOTS.afternoon);
+  } else if (currentHour < DEFAULT_TIME_SLOTS.evening) {
+    // 1pm-7:59pm: set to 8pm today
+    reminderTime.setHours(DEFAULT_TIME_SLOTS.evening);
+  } else {
+    // After 8pm: set to 9am tomorrow
+    reminderTime.setDate(reminderTime.getDate() + 1);
+    reminderTime.setHours(DEFAULT_TIME_SLOTS.morning);
+  }
+
+  return reminderTime;
+}
+
+/**
+ * Get a human-readable description of when the next reminder will be
+ */
+export function getNextReminderDescription(
+  currentTime: Date = new Date(),
+): string {
+  const now = new Date(currentTime);
+  const nextTime = getNextReminderTime(currentTime);
+  const currentHour = now.getHours();
+
+  const isToday = now.toDateString() === nextTime.toDateString();
+  const timePrefix = isToday ? "today" : "tomorrow";
+
+  if (currentHour < DEFAULT_TIME_SLOTS.morning) {
+    return `${timePrefix} morning`;
+  } else if (currentHour < DEFAULT_TIME_SLOTS.afternoon) {
+    return `${timePrefix} afternoon`;
+  } else if (currentHour < DEFAULT_TIME_SLOTS.evening) {
+    return `${timePrefix} evening`;
+  } else {
+    return "tomorrow morning";
+  }
+}

--- a/packages/trpc/models/bookmarks.ts
+++ b/packages/trpc/models/bookmarks.ts
@@ -22,6 +22,7 @@ import {
   bookmarkAssets,
   bookmarkLinks,
   bookmarkLists,
+  bookmarkReminders,
   bookmarks,
   bookmarksInLists,
   bookmarkTags,
@@ -70,6 +71,7 @@ async function dummyDrizzleReturnType() {
       text: true,
       asset: true,
       assets: true,
+      reminder: true,
     },
   });
   if (!x) {
@@ -151,7 +153,8 @@ export class Bookmark extends BareBookmark {
     bookmark: BookmarkQueryReturnType,
     includeContent: boolean,
   ): Promise<ZBookmark> {
-    const { tagsOnBookmarks, link, text, asset, assets, ...rest } = bookmark;
+    const { tagsOnBookmarks, link, text, asset, assets, reminder, ...rest } =
+      bookmark;
 
     let content: ZBookmarkContent = {
       type: BookmarkTypes.UNKNOWN,
@@ -223,6 +226,7 @@ export class Bookmark extends BareBookmark {
         assetType: mapDBAssetTypeToUserType(a.assetType),
         fileName: a.fileName,
       })),
+      reminder: reminder || undefined,
       ...rest,
     };
   }
@@ -244,6 +248,7 @@ export class Bookmark extends BareBookmark {
         text: true,
         asset: true,
         assets: true,
+        reminder: true,
       },
     });
 
@@ -417,6 +422,7 @@ export class Bookmark extends BareBookmark {
       .leftJoin(bookmarkTexts, eq(bookmarkTexts.id, sq.id))
       .leftJoin(bookmarkAssets, eq(bookmarkAssets.id, sq.id))
       .leftJoin(assets, eq(assets.bookmarkId, sq.id))
+      .leftJoin(bookmarkReminders, eq(bookmarkReminders.bookmarkId, sq.id))
       .orderBy(desc(sq.createdAt), desc(sq.id));
 
     const bookmarksRes = results.reduce<Record<string, ZBookmark>>(
@@ -472,6 +478,7 @@ export class Bookmark extends BareBookmark {
             content,
             tags: [],
             assets: [],
+            reminder: row.bookmarkReminders || undefined,
           };
         }
 

--- a/packages/trpc/routers/_app.ts
+++ b/packages/trpc/routers/_app.ts
@@ -10,6 +10,7 @@ import { invitesAppRouter } from "./invites";
 import { listsAppRouter } from "./lists";
 import { promptsAppRouter } from "./prompts";
 import { publicBookmarks } from "./publicBookmarks";
+import { remindersRouter } from "./reminders";
 import { rulesAppRouter } from "./rules";
 import { subscriptionsRouter } from "./subscriptions";
 import { tagsAppRouter } from "./tags";
@@ -33,6 +34,7 @@ export const appRouter = router({
   invites: invitesAppRouter,
   publicBookmarks: publicBookmarks,
   subscriptions: subscriptionsRouter,
+  reminders: remindersRouter,
 });
 // export type definition of API
 export type AppRouter = typeof appRouter;

--- a/packages/trpc/routers/reminders.ts
+++ b/packages/trpc/routers/reminders.ts
@@ -1,0 +1,353 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq, gt, lte } from "drizzle-orm";
+import { z } from "zod";
+
+import { bookmarkReminders, bookmarks } from "@karakeep/db/schema";
+import {
+  zCreateReminderRequestSchema,
+  zGetRemindersCountsRequestSchema,
+  zGetRemindersCountsResponseSchema,
+  zGetRemindersRequestSchema,
+  zReminderSchema,
+  zUpdateReminderRequestSchema,
+} from "@karakeep/shared/types/reminders";
+import { getNextReminderTime } from "@karakeep/shared/utils/reminderTimeslotsUtils";
+
+import { authedProcedure, router } from "../index";
+import { ensureBookmarkOwnership } from "./bookmarks";
+
+export const remindersRouter = router({
+  // Create or update a reminder for a bookmark (upsert behavior due to unique constraint)
+  setReminder: authedProcedure
+    .input(zCreateReminderRequestSchema)
+    .output(zReminderSchema)
+    .use(ensureBookmarkOwnership)
+    .mutation(async ({ input, ctx }) => {
+      // Check if user owns the bookmark
+      const bookmark = await ctx.db.query.bookmarks.findFirst({
+        where: and(
+          eq(bookmarks.id, input.bookmarkId),
+          eq(bookmarks.userId, ctx.user.id),
+        ),
+      });
+
+      if (!bookmark) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Bookmark not found",
+        });
+      }
+
+      // Atomic upsert: insert new or update existing reminder
+      const [upsertedReminder] = await ctx.db
+        .insert(bookmarkReminders)
+        .values({
+          bookmarkId: input.bookmarkId,
+          remindAt: input.remindAt,
+          status: "active",
+        })
+        .onConflictDoUpdate({
+          target: bookmarkReminders.bookmarkId,
+          set: {
+            remindAt: input.remindAt,
+            status: "active",
+          },
+        })
+        .returning();
+
+      return {
+        id: upsertedReminder.id,
+        bookmarkId: upsertedReminder.bookmarkId,
+        remindAt: upsertedReminder.remindAt,
+        status: upsertedReminder.status as "active" | "dismissed",
+        createdAt: upsertedReminder.createdAt,
+        modifiedAt: upsertedReminder.modifiedAt,
+      };
+    }),
+
+  // Update an existing reminder
+  updateReminder: authedProcedure
+    .input(zUpdateReminderRequestSchema)
+    .output(zReminderSchema)
+    .mutation(async ({ input, ctx }) => {
+      // First get the reminder and verify ownership through bookmark
+      const existingReminder = await ctx.db.query.bookmarkReminders.findFirst({
+        where: eq(bookmarkReminders.id, input.reminderId),
+        with: {
+          bookmark: true,
+        },
+      });
+
+      if (!existingReminder) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Reminder not found",
+        });
+      }
+
+      if (existingReminder.bookmark.userId !== ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "User is not allowed to access resource",
+        });
+      }
+
+      const updateData: Partial<{
+        remindAt: Date;
+        status: "active" | "dismissed";
+        modifiedAt: Date;
+      }> = {};
+
+      if (input.remindAt !== undefined) {
+        updateData.remindAt = input.remindAt;
+      }
+      if (input.status !== undefined) {
+        updateData.status = input.status;
+      }
+
+      // This should never happen due to schema validation, but be defensive
+      if (Object.keys(updateData).length === 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "No fields provided for update",
+        });
+      }
+
+      // Always update modifiedAt when making changes
+      updateData.modifiedAt = new Date();
+
+      const [updatedReminder] = await ctx.db
+        .update(bookmarkReminders)
+        .set(updateData)
+        .where(eq(bookmarkReminders.id, input.reminderId))
+        .returning();
+
+      return {
+        id: updatedReminder.id,
+        bookmarkId: updatedReminder.bookmarkId,
+        remindAt: updatedReminder.remindAt,
+        status: updatedReminder.status as "active" | "dismissed",
+        createdAt: updatedReminder.createdAt,
+        modifiedAt: updatedReminder.modifiedAt,
+      };
+    }),
+
+  // Delete a reminder
+  deleteReminder: authedProcedure
+    .input(z.object({ reminderId: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      // First get the reminder and verify ownership through bookmark
+      const existingReminder = await ctx.db.query.bookmarkReminders.findFirst({
+        where: eq(bookmarkReminders.id, input.reminderId),
+        with: {
+          bookmark: true,
+        },
+      });
+
+      if (!existingReminder) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Reminder not found",
+        });
+      }
+
+      if (existingReminder.bookmark.userId !== ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "User is not allowed to access resource",
+        });
+      }
+
+      await ctx.db
+        .delete(bookmarkReminders)
+        .where(eq(bookmarkReminders.id, input.reminderId));
+    }),
+
+  // Get reminders for current user
+  getReminders: authedProcedure
+    .input(zGetRemindersRequestSchema)
+    .output(
+      z.object({
+        reminders: z.array(zReminderSchema),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const conditions = [];
+
+      if (input.bookmarkId) {
+        conditions.push(eq(bookmarkReminders.bookmarkId, input.bookmarkId));
+      }
+
+      if (input.status) {
+        conditions.push(eq(bookmarkReminders.status, input.status));
+      }
+
+      // Handle reminder type filtering for reminders page tabs
+      if (input.reminderType) {
+        const now = input.clientTimestamp
+          ? new Date(input.clientTimestamp)
+          : new Date();
+        switch (input.reminderType) {
+          case "due":
+            conditions.push(eq(bookmarkReminders.status, "active"));
+            conditions.push(lte(bookmarkReminders.remindAt, now));
+            break;
+          case "upcoming":
+            conditions.push(eq(bookmarkReminders.status, "active"));
+            conditions.push(gt(bookmarkReminders.remindAt, now));
+            break;
+          case "dismissed":
+            conditions.push(eq(bookmarkReminders.status, "dismissed"));
+            break;
+        }
+      }
+
+      const reminders = await ctx.db
+        .select({
+          id: bookmarkReminders.id,
+          bookmarkId: bookmarkReminders.bookmarkId,
+          remindAt: bookmarkReminders.remindAt,
+          status: bookmarkReminders.status,
+          createdAt: bookmarkReminders.createdAt,
+          modifiedAt: bookmarkReminders.modifiedAt,
+        })
+        .from(bookmarkReminders)
+        .innerJoin(bookmarks, eq(bookmarks.id, bookmarkReminders.bookmarkId))
+        .where(
+          and(
+            eq(bookmarks.userId, ctx.user.id), // Ensure user owns the bookmark
+            ...conditions,
+          ),
+        )
+        .orderBy(bookmarkReminders.remindAt);
+
+      return {
+        reminders: reminders.map((r) => ({
+          id: r.id,
+          bookmarkId: r.bookmarkId,
+          remindAt: r.remindAt,
+          status: r.status as "active" | "dismissed",
+          createdAt: r.createdAt,
+          modifiedAt: r.modifiedAt,
+        })),
+      };
+    }),
+
+  // Get reminder for a specific bookmark (useful for UI to show if reminder exists)
+  getBookmarkReminder: authedProcedure
+    .input(z.object({ bookmarkId: z.string() }))
+    .output(zReminderSchema.nullable())
+    .use(ensureBookmarkOwnership)
+    .query(async ({ input, ctx }) => {
+      const reminder = await ctx.db.query.bookmarkReminders.findFirst({
+        where: eq(bookmarkReminders.bookmarkId, input.bookmarkId),
+      });
+
+      if (!reminder) {
+        return null;
+      }
+
+      return {
+        id: reminder.id,
+        bookmarkId: reminder.bookmarkId,
+        remindAt: reminder.remindAt,
+        status: reminder.status as "active" | "dismissed",
+        createdAt: reminder.createdAt,
+        modifiedAt: reminder.modifiedAt,
+      };
+    }),
+
+  // Snooze a reminder to the next logical time slot
+  snoozeReminder: authedProcedure
+    .input(
+      z.object({
+        reminderId: z.string(),
+        clientTimestamp: z.number().int().min(0), // Just ensure it's a positive integer timestamp
+      }),
+    )
+    .output(zReminderSchema)
+    .mutation(async ({ input, ctx }) => {
+      // First get the reminder and verify ownership through bookmark
+      const existingReminder = await ctx.db.query.bookmarkReminders.findFirst({
+        where: eq(bookmarkReminders.id, input.reminderId),
+        with: {
+          bookmark: true,
+        },
+      });
+
+      if (!existingReminder) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Reminder not found",
+        });
+      }
+
+      if (existingReminder.bookmark.userId !== ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "User is not allowed to access resource",
+        });
+      }
+
+      // Calculate the next logical reminder time using client timestamp
+      const clientTime = new Date(input.clientTimestamp);
+      const nextReminderTime = getNextReminderTime(clientTime);
+
+      const [updatedReminder] = await ctx.db
+        .update(bookmarkReminders)
+        .set({
+          remindAt: nextReminderTime,
+          status: "active", // Ensure it's active when snoozed
+        })
+        .where(eq(bookmarkReminders.id, input.reminderId))
+        .returning();
+
+      return {
+        id: updatedReminder.id,
+        bookmarkId: updatedReminder.bookmarkId,
+        remindAt: updatedReminder.remindAt,
+        status: updatedReminder.status as "active" | "dismissed",
+        createdAt: updatedReminder.createdAt,
+        modifiedAt: updatedReminder.modifiedAt,
+      };
+    }),
+
+  // Get all reminder counts in a single query
+  getRemindersCounts: authedProcedure
+    .input(zGetRemindersCountsRequestSchema)
+    .output(zGetRemindersCountsResponseSchema)
+    .query(async ({ input, ctx }) => {
+      const now = input.clientTimestamp
+        ? new Date(input.clientTimestamp)
+        : new Date();
+
+      // Fetch all reminders for the user with counts by category
+      const allReminders = await ctx.db
+        .select({
+          remindAt: bookmarkReminders.remindAt,
+          status: bookmarkReminders.status,
+        })
+        .from(bookmarkReminders)
+        .innerJoin(bookmarks, eq(bookmarks.id, bookmarkReminders.bookmarkId))
+        .where(eq(bookmarks.userId, ctx.user.id));
+
+      // Count reminders by type
+      const dueCount = allReminders.filter(
+        (r) => r.status === "active" && r.remindAt <= now,
+      ).length;
+
+      const upcomingCount = allReminders.filter(
+        (r) => r.status === "active" && r.remindAt > now,
+      ).length;
+
+      const dismissedCount = allReminders.filter(
+        (r) => r.status === "dismissed",
+      ).length;
+
+      return {
+        dueCount,
+        upcomingCount,
+        dismissedCount,
+      };
+    }),
+});


### PR DESCRIPTION
## Description

- [x] introduce bookmark RemindMeLater functionality to karakeep
- [x] added RemindMeButton to action bar for quick action
- [x] edit remindAt manually in bookmark edit modal
- [x] added `/dashboard/reminders` page with 3 tabs (due, upcoming, dismissed)

### TODOs

- [ ] extract translation strings
- [ ] handle for infinite scroll / pagination
  * im lazy, maybe we can implement this in a different PR lol

### Separate PRs maybe

- [ ] mobile implementation
- [ ] push notification in native app
  * im lazy, maybe we can implement this in a different PR lol
- [ ] optional "hide" in home behaviour that can be toggled in user settings when bookmark is set to "RemindMeLater"
  * i personally want this, but im lazy, maybe I will implement this in a different PR lol


fixes #705

> [!NOTE]  
> Even though the issue original request is for in-app notifications,
> it is not implemented yet, to first implement the groundwork (e.g. database schema)
> the web ui is implemented first so that there is a meaningful way to see and interact with the RemindMeLater feature to get some initial feedbacks

## Details

### RemindMeLater button sets reminder at one of 3 timeslots

Based on the intuition that we just want to quickly set a reminder, when clicking the action button in the BookmarkCard, I simply set the remindAt time to be either in the morning/afternoon/evening timeslot, based on current time, that I predefined as 9am, 1pm, 8pm.
I'm not sure if we like/want this idea yet, but if we do, we can extend this by allowing the users to add/remove/edit the timeslots for RemindMeLater.
We can also add incremental delay duration for bookmarks that have been snoozed multiple times.

However its not like we can't specify the remindAt datetime, I leave it to be user editable manually in the edit dialog. It's not implemented yet tho, wanted to get some (if any) feedback about the initial implementation and see how we want refine the direction how this feature should go.

### `/dashboard/reminders` bookmarks are hardcoded to render as `list` type

I've made the decision to make `/dashboard/reminders` render the BookmarkCard fixed as `list` view, instead of based on user setting. If anyone thinks that this page should also be dynamic based on the user setting, let's discuss about it more.

## Screenshots (latest commit is variant D)

Early impressions of the implementation. Open to feedbacks and suggestions on the final UX for the remind me feature.

### No reminders

<img width="1512" height="539" alt="image" src="https://github.com/user-attachments/assets/e6ee803a-317f-4f40-af51-cfb77eca143d" />

### Variant A (basic)

<img width="1512" height="557" alt="Image" src="https://github.com/user-attachments/assets/d08c547a-8488-4740-b7fa-2a118cf4e31a" />

### Variant B (slightly stylized + menu button)

<img width="1512" height="528" alt="image" src="https://github.com/user-attachments/assets/68e80021-f8c4-410d-8871-cffbb01c21c4" />

<img width="1512" height="520" alt="image" src="https://github.com/user-attachments/assets/6f14dbec-0e75-4c5a-a2bd-6cee9939dc3d" />

### Variant C (full card background color)

<img width="1512" height="520" alt="image" src="https://github.com/user-attachments/assets/9318da86-5ad9-4829-aa7a-960248711b37" />

<img width="1512" height="547" alt="image" src="https://github.com/user-attachments/assets/f90407fa-0b22-4fbe-b9dd-6c869fa5f8e9" />

<img width="1512" height="525" alt="image" src="https://github.com/user-attachments/assets/d981fde5-49df-4678-96a9-7176b13f1f13" />

### Variant D (less verbose)

<img width="1030" height="461" alt="image" src="https://github.com/user-attachments/assets/78ce3f63-7e51-4815-8e26-e2cf78cc7119" />

### Additional (conditional) Options 

<img width="363" height="384" alt="image" src="https://github.com/user-attachments/assets/67742e18-99f1-47cc-9c4d-c00c2d449938" />