### PR TITLE
Fatal typo in docker-compose.yml for meilisearch container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     env_file:
       - .env
     environment:
-      MEILI_NO_ANALYTICS: "true"
+      MEILI_NO_ANALYTICS:true
     volumes:
       - meilisearch:/meili_data
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     env_file:
       - .env
     environment:
-      MEILI_NO_ANALYTICS:true
+      MEILI_NO_ANALYTICS: true
     volumes:
       - meilisearch:/meili_data
 


### PR DESCRIPTION
the blueprint fort he compose contains

    environment:
      - MEILI_NO_ANALYTICS="true"

This should be a boolean, but is formatted as string. 

Leads to: 

error: invalid value '"true"' for '--no-analytics'
  [possible values: true, false]

and breaks the container at startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the search service’s telemetry is reliably disabled in container deployments by correcting a configuration value to the expected boolean.
  * Prevents intermittent analytics pings that could occur due to a mis-typed configuration, improving user privacy and compliance.
  * Aligns runtime configuration with the service’s expected types to avoid environment-specific inconsistencies (local, CI, staging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->