### PR TITLE
Fixed typo in FAQ

### DIFF
--- a/apps/landing/src/Pricing.tsx
+++ b/apps/landing/src/Pricing.tsx
@@ -156,7 +156,7 @@ function FAQ() {
       answer: "Yes, we offer a 7-day money-back guarantee for all paid plans.",
     },
     {
-      question: "How should I contant you if I have any questions?",
+      question: "How should I contact you if I have any questions?",
       answer: "You can reach us at support@karakeep.app",
     },
   ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in the Pricing page FAQ: “How should I contant you...” now reads “How should I contact you...”. This improves clarity and professionalism of the displayed content. No functional behavior, layouts, or interactions were changed, and there are no configuration or API impacts. Purely textual correction. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->