### PR TITLE
fix(extension): constrain height to prevent viewport overflow (#1580)

### DIFF
--- a/apps/browser-extension/src/components/ListsSelector.tsx
+++ b/apps/browser-extension/src/components/ListsSelector.tsx
@@ -67,7 +67,7 @@ export function ListsSelector({ bookmarkId }: { bookmarkId: string }) {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[320px] p-0">
+      <PopoverContent className="h-[var(--radix-popover-content-available-height)] w-[320px] p-0">
         <Command>
           <CommandInput placeholder="Search Lists ..." />
           <CommandList>

--- a/apps/browser-extension/src/components/ListsSelector.tsx
+++ b/apps/browser-extension/src/components/ListsSelector.tsx
@@ -19,7 +19,8 @@ import {
   CommandItem,
   CommandList,
 } from "./ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { DynamicPopoverContent } from "./ui/dynamic-popover";
+import { Popover, PopoverTrigger } from "./ui/popover";
 
 export function ListsSelector({ bookmarkId }: { bookmarkId: string }) {
   const currentlyUpdating = useSet<string>();
@@ -67,7 +68,7 @@ export function ListsSelector({ bookmarkId }: { bookmarkId: string }) {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="h-[var(--radix-popover-content-available-height)] w-[320px] p-0">
+      <DynamicPopoverContent className="w-[320px] p-0">
         <Command>
           <CommandInput placeholder="Search Lists ..." />
           <CommandList>
@@ -101,7 +102,7 @@ export function ListsSelector({ bookmarkId }: { bookmarkId: string }) {
             </CommandGroup>
           </CommandList>
         </Command>
-      </PopoverContent>
+      </DynamicPopoverContent>
     </Popover>
   );
 }

--- a/apps/browser-extension/src/components/TagsSelector.tsx
+++ b/apps/browser-extension/src/components/TagsSelector.tsx
@@ -64,7 +64,7 @@ export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[320px] p-0">
+      <PopoverContent className="h-[var(--radix-popover-content-available-height)] w-[320px] p-0">
         <Command>
           <CommandInput
             value={input}

--- a/apps/browser-extension/src/components/TagsSelector.tsx
+++ b/apps/browser-extension/src/components/TagsSelector.tsx
@@ -16,6 +16,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "./ui/command";
 import { DynamicPopoverContent } from "./ui/dynamic-popover";
 import { Popover, PopoverTrigger } from "./ui/popover";
@@ -74,6 +75,21 @@ export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
           />
           <CommandList>
             <CommandGroup>
+              <CommandItem
+                onSelect={() =>
+                  mutate({
+                    bookmarkId,
+                    attach: [{ tagName: input }],
+                    detach: [],
+                  })
+                }
+              >
+                <Plus className="mr-2 size-4" />
+                Create &quot;{input}&quot; ...
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
               {allTags?.tags
                 .sort((a, b) => a.name.localeCompare(b.name))
                 .map((tag) => (
@@ -95,20 +111,6 @@ export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
                     {tag.name}
                   </CommandItem>
                 ))}
-            </CommandGroup>
-            <CommandGroup>
-              <CommandItem
-                onSelect={() =>
-                  mutate({
-                    bookmarkId,
-                    attach: [{ tagName: input }],
-                    detach: [],
-                  })
-                }
-              >
-                <Plus className="mr-2 size-4" />
-                Create &quot;{input}&quot; ...
-              </CommandItem>
             </CommandGroup>
           </CommandList>
         </Command>

--- a/apps/browser-extension/src/components/TagsSelector.tsx
+++ b/apps/browser-extension/src/components/TagsSelector.tsx
@@ -17,7 +17,8 @@ import {
   CommandItem,
   CommandList,
 } from "./ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { DynamicPopoverContent } from "./ui/dynamic-popover";
+import { Popover, PopoverTrigger } from "./ui/popover";
 
 export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
   const { data: allTags } = api.tags.list.useQuery();
@@ -64,7 +65,7 @@ export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="h-[var(--radix-popover-content-available-height)] w-[320px] p-0">
+      <DynamicPopoverContent className="w-[320px] p-0">
         <Command>
           <CommandInput
             value={input}
@@ -111,7 +112,7 @@ export function TagsSelector({ bookmarkId }: { bookmarkId: string }) {
             </CommandGroup>
           </CommandList>
         </Command>
-      </PopoverContent>
+      </DynamicPopoverContent>
     </Popover>
   );
 }

--- a/apps/browser-extension/src/components/ui/dynamic-popover.tsx
+++ b/apps/browser-extension/src/components/ui/dynamic-popover.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "../../utils/css";
+
+interface DynamicPopoverContentProps
+  extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> {
+  /**
+   * If true, will use max-h when content fits in viewport, otherwise h
+   * If false, will always use h-[var(--radix-popover-content-available-height)]
+   */
+  dynamicHeight?: boolean;
+}
+
+const DynamicPopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  DynamicPopoverContentProps
+>(
+  (
+    {
+      className,
+      align = "center",
+      sideOffset = 4,
+      dynamicHeight = true,
+      ...props
+    },
+    ref,
+  ) => {
+    const contentRef = React.useRef<HTMLDivElement>(null);
+    const [heightClass, setHeightClass] = React.useState<string>("");
+
+    React.useEffect(() => {
+      if (!dynamicHeight || !contentRef.current) return;
+
+      // Get the available height from CSS variable provided by Radix UI
+      const availableHeight =
+        parseInt(
+          getComputedStyle(contentRef.current).getPropertyValue(
+            "--radix-popover-content-available-height",
+          ),
+        ) || window.innerHeight;
+
+      // Measure the content height
+      const contentHeight = contentRef.current.scrollHeight;
+
+      // If content height exceeds available height, use fixed height
+      // Otherwise, use max-height to allow natural sizing
+      if (contentHeight > availableHeight) {
+        setHeightClass("h-[var(--radix-popover-content-available-height)]");
+      } else {
+        setHeightClass("max-h-[var(--radix-popover-content-available-height)]");
+      }
+    }, [dynamicHeight, props.children]);
+
+    // If dynamicHeight is false, use the original behavior
+    const heightClasses = dynamicHeight
+      ? heightClass
+      : "h-[var(--radix-popover-content-available-height)]";
+
+    return (
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          ref={(node) => {
+            if (typeof ref === "function") {
+              ref(node);
+            } else if (ref) {
+              ref.current = node;
+            }
+            contentRef.current = node;
+          }}
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            heightClasses,
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Portal>
+    );
+  },
+);
+DynamicPopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { DynamicPopoverContent };

--- a/apps/browser-extension/src/components/ui/dynamic-popover.tsx
+++ b/apps/browser-extension/src/components/ui/dynamic-popover.tsx
@@ -6,10 +6,69 @@ import { cn } from "../../utils/css";
 interface DynamicPopoverContentProps
   extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> {
   /**
-   * If true, will use max-h when content fits in viewport, otherwise h
-   * If false, will always use h-[var(--radix-popover-content-available-height)]
+   * Whether to enable dynamic height adjustment
+   * If true, use max-h when content can fit the viewport, otherwise use fixed height
+   * If false, always use h-[var(--radix-popover-content-available-height)]
    */
   dynamicHeight?: boolean;
+
+  /**
+   * Debounce delay for height adjustment (milliseconds)
+   * Used to optimize performance and avoid frequent recalculations
+   */
+  debounceMs?: number;
+}
+
+/**
+ * Custom Hook for debouncing
+ */
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState<T>(value);
+
+  React.useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+/**
+ * Utility function to get available height
+ */
+function getAvailableHeight(element: HTMLElement): number {
+  try {
+    const cssValue = getComputedStyle(element).getPropertyValue(
+      "--radix-popover-content-available-height",
+    );
+
+    const parsedValue = parseInt(cssValue, 10);
+
+    // If CSS variable value cannot be obtained, fallback to 80% of viewport height
+    return !isNaN(parsedValue) && parsedValue > 0
+      ? parsedValue
+      : Math.floor(window.innerHeight * 0.8);
+  } catch (error) {
+    console.warn("Failed to get available height from CSS variable:", error);
+    return Math.floor(window.innerHeight * 0.8);
+  }
+}
+
+/**
+ * Utility function to calculate content height
+ */
+function getContentHeight(element: HTMLElement): number {
+  try {
+    return element.scrollHeight;
+  } catch (error) {
+    console.warn("Failed to get content height:", error);
+    return 0;
+  }
 }
 
 const DynamicPopoverContent = React.forwardRef<
@@ -22,65 +81,118 @@ const DynamicPopoverContent = React.forwardRef<
       align = "center",
       sideOffset = 4,
       dynamicHeight = true,
+      debounceMs = 100,
+      children,
       ...props
     },
     ref,
   ) => {
     const contentRef = React.useRef<HTMLDivElement>(null);
+
+    // Use state to manage height class name
     const [heightClass, setHeightClass] = React.useState<string>(
       "max-h-[var(--radix-popover-content-available-height)]",
     );
 
-    React.useLayoutEffect(() => {
-      if (!dynamicHeight || !contentRef.current) return;
+    // Create a dependency to trigger recalculation
+    const [childrenKey, setChildrenKey] = React.useState(0);
 
-      // Get the available height from CSS variable provided by Radix UI
-      const availableHeight =
-        parseInt(
-          getComputedStyle(contentRef.current).getPropertyValue(
-            "--radix-popover-content-available-height",
-          ),
-        ) || window.innerHeight;
+    // Use debounce to optimize performance
+    const debouncedChildrenKey = useDebounce(childrenKey, debounceMs);
 
-      // Measure the content height
-      const contentHeight = contentRef.current.scrollHeight;
+    // Listen for children changes
+    React.useEffect(() => {
+      setChildrenKey((prev) => prev + 1);
+    }, [children]);
 
-      // If content height exceeds available height, use fixed height
-      // Otherwise, use max-height to allow natural sizing
-      if (contentHeight > availableHeight) {
-        setHeightClass("h-[var(--radix-popover-content-available-height)]");
+    // Utility function to merge refs
+    const setRefs = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        // Set internal ref
+        contentRef.current = node;
+
+        // Set external ref
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref],
+    );
+
+    // Core logic for calculating height
+    const calculateHeight = React.useCallback(() => {
+      if (!dynamicHeight || !contentRef.current) {
+        return;
       }
-    }, [dynamicHeight, props.children]);
 
-    // If dynamicHeight is false, use the original behavior
-    const heightClasses = dynamicHeight
-      ? heightClass
-      : "h-[var(--radix-popover-content-available-height)]";
+      const element = contentRef.current;
+      const availableHeight = getAvailableHeight(element);
+      const contentHeight = getContentHeight(element);
+
+      // Add some buffer to avoid edge cases
+      const BUFFER = 10;
+
+      if (contentHeight + BUFFER > availableHeight) {
+        setHeightClass("h-[var(--radix-popover-content-available-height)]");
+      } else {
+        setHeightClass("max-h-[var(--radix-popover-content-available-height)]");
+      }
+    }, [dynamicHeight]);
+
+    // Use useLayoutEffect to avoid layout flickering
+    React.useLayoutEffect(() => {
+      calculateHeight();
+    }, [calculateHeight, debouncedChildrenKey]);
+
+    // Handle window resize
+    React.useEffect(() => {
+      if (!dynamicHeight) return;
+
+      const handleResize = () => {
+        calculateHeight();
+      };
+
+      window.addEventListener("resize", handleResize);
+      return () => {
+        window.removeEventListener("resize", handleResize);
+      };
+    }, [calculateHeight, dynamicHeight]);
+
+    // Define all styles as a single constant for better performance and simplicity
+    const POPOVER_STYLES =
+      "z-50 w-72 overflow-y-auto rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2";
+
+    // Determine final height class name
+    const finalHeightClass = React.useMemo(() => {
+      return dynamicHeight
+        ? heightClass
+        : "h-[var(--radix-popover-content-available-height)]";
+    }, [dynamicHeight, heightClass]);
+
+    // Memoize the complete class name for performance
+    const popoverClassName = React.useMemo(
+      () => cn(POPOVER_STYLES, finalHeightClass, className),
+      [finalHeightClass, className],
+    );
 
     return (
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
-          ref={(node) => {
-            if (typeof ref === "function") {
-              ref(node);
-            } else if (ref) {
-              ref.current = node;
-            }
-            contentRef.current = node;
-          }}
+          ref={setRefs}
           align={align}
           sideOffset={sideOffset}
-          className={cn(
-            "z-50 w-72 overflow-y-auto rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out  data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            heightClasses,
-            className,
-          )}
+          className={popoverClassName}
           {...props}
-        />
+        >
+          {children}
+        </PopoverPrimitive.Content>
       </PopoverPrimitive.Portal>
     );
   },
 );
+
 DynamicPopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { DynamicPopoverContent };

--- a/apps/browser-extension/src/components/ui/dynamic-popover.tsx
+++ b/apps/browser-extension/src/components/ui/dynamic-popover.tsx
@@ -31,7 +31,7 @@ const DynamicPopoverContent = React.forwardRef<
       "max-h-[var(--radix-popover-content-available-height)]",
     );
 
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
       if (!dynamicHeight || !contentRef.current) return;
 
       // Get the available height from CSS variable provided by Radix UI

--- a/apps/browser-extension/src/components/ui/dynamic-popover.tsx
+++ b/apps/browser-extension/src/components/ui/dynamic-popover.tsx
@@ -27,7 +27,9 @@ const DynamicPopoverContent = React.forwardRef<
     ref,
   ) => {
     const contentRef = React.useRef<HTMLDivElement>(null);
-    const [heightClass, setHeightClass] = React.useState<string>("");
+    const [heightClass, setHeightClass] = React.useState<string>(
+      "max-h-[var(--radix-popover-content-available-height)]",
+    );
 
     React.useEffect(() => {
       if (!dynamicHeight || !contentRef.current) return;
@@ -47,8 +49,6 @@ const DynamicPopoverContent = React.forwardRef<
       // Otherwise, use max-height to allow natural sizing
       if (contentHeight > availableHeight) {
         setHeightClass("h-[var(--radix-popover-content-available-height)]");
-      } else {
-        setHeightClass("max-h-[var(--radix-popover-content-available-height)]");
       }
     }, [dynamicHeight, props.children]);
 
@@ -71,7 +71,7 @@ const DynamicPopoverContent = React.forwardRef<
           align={align}
           sideOffset={sideOffset}
           className={cn(
-            "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "z-50 w-72 overflow-y-auto rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out  data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             heightClasses,
             className,
           )}

--- a/apps/browser-extension/src/components/ui/popover.tsx
+++ b/apps/browser-extension/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 h-[var(--radix-popover-content-available-height)] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/apps/browser-extension/src/components/ui/popover.tsx
+++ b/apps/browser-extension/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 h-[var(--radix-popover-content-available-height)] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}


### PR DESCRIPTION
# fix: Chrome Extension - Fix popover placement for list selector

**Related Issue**: 
#1580
#1840 

## Summary
This PR addresses an issue with the expanded list picker placement in the Chrome extension, making it difficult or impossible to choose the first lists when there are many lists. The fix ensures the popover content adapts to the available viewport height, preventing overflow issues.

## Key Changes

### 🐛 **Popover Height Fix**
- **Problem**: The list selector popover was not properly handling viewport constraints, causing the first items to be hidden when opened near the bottom of the screen
- **Solution**: Added `h-[var(--radix-popover-content-available-height)]` class to the PopoverContent component to dynamically adjust height based on available space
- **Impact**: Users can now access all list items regardless of popover position


## User Experience Improvements

### Before
- Users with over 15 lists experienced difficulty accessing the first list items
- Popover would overflow the viewport when opened near the bottom of the screen
- No visual indication of additional hidden items

### After
- Popover automatically adjusts to available viewport height
- All list items are accessible regardless of screen position
- Improved usability for users with many lists
