### PR TITLE
add current tab title while saving from extension

### DIFF
--- a/apps/browser-extension/src/SavePage.tsx
+++ b/apps/browser-extension/src/SavePage.tsx
@@ -48,6 +48,7 @@ export default function SavePage() {
           newBookmarkRequest = {
             type: BookmarkTypes.LINK,
             url: currentTab.url,
+            title: currentTab.title,
           };
         } else {
           setError("Couldn't find the URL of the current tab");


### PR DESCRIPTION
Add current tab title while saving from extension.

Benefits:

1. Tab title shows the website's title which is meaningful and good to read.
2. Avoid empty title when sync bookmark to browser using Floccus.