### PR TITLE
Ensure feed refresh jobs run once per hour

### DIFF
--- a/apps/workers/workers/feedWorker.ts
+++ b/apps/workers/workers/feedWorker.ts
@@ -26,13 +26,18 @@ export const FeedRefreshingWorker = cron.schedule(
         where: eq(rssFeedsTable.enabled, true),
       })
       .then((feeds) => {
+        const currentHour = new Date();
+        currentHour.setMinutes(0, 0, 0);
+        const hourlyWindow = currentHour.toISOString();
+
         for (const feed of feeds) {
+          const idempotencyKey = `${feed.id}-${hourlyWindow}`;
           FeedQueue.enqueue(
             {
               feedId: feed.id,
             },
             {
-              idempotencyKey: feed.id,
+              idempotencyKey,
             },
           );
         }


### PR DESCRIPTION
## Summary
- update the feed refreshing scheduler to derive an hourly idempotency key by rounding to the current hour
- ensure each feed refresh job can run once per feed per hour

## Testing
- `turbo run --no-daemon typecheck lint format`


------
https://chatgpt.com/codex/tasks/task_e_68e36a3014b0832cade28ef5e2ccb53f