### PR TITLE
feat: Remember ignored duplicate tag suggestions

### DIFF
--- a/apps/web/app/dashboard/cleanups/page.tsx
+++ b/apps/web/app/dashboard/cleanups/page.tsx
@@ -1,7 +1,8 @@
+import { IgnoredTagPairs } from "@/components/dashboard/cleanups/IgnoredTagPairs";
 import { TagDuplicationDetection } from "@/components/dashboard/cleanups/TagDuplicationDetention";
 import { Separator } from "@/components/ui/separator";
 import { useTranslation } from "@/lib/i18n/server";
-import { Paintbrush, Tags } from "lucide-react";
+import { EyeOff, Paintbrush, Tags } from "lucide-react";
 
 export default async function Cleanups() {
   // oxlint-disable-next-line rules-of-hooks
@@ -20,6 +21,12 @@ export default async function Cleanups() {
       </span>
       <Separator />
       <TagDuplicationDetection />
+      <Separator />
+      <span className="flex items-center gap-1 text-lg">
+        <EyeOff />
+        Ignored Tag Pairs
+      </span>
+      <IgnoredTagPairs />
     </div>
   );
 }

--- a/apps/web/components/dashboard/cleanups/IgnoredTagPairs.tsx
+++ b/apps/web/components/dashboard/cleanups/IgnoredTagPairs.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ActionButton } from "@/components/ui/action-button";
+import { badgeVariants } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import LoadingSpinner from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "@/components/ui/use-toast";
+import { useTranslation } from "@/lib/i18n/client";
+import { api } from "@/lib/trpc";
+import { cn } from "@/lib/utils";
+import { Undo2 } from "lucide-react";
+
+export function IgnoredTagPairs() {
+  const [expanded, setExpanded] = useState(false);
+  const { t } = useTranslation();
+
+  const { data: ignoredPairs, isLoading } = api.tags.listIgnoredPairs.useQuery(
+    undefined,
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  const utils = api.useUtils();
+
+  const { mutate: unignorePair } = api.tags.unignorePair.useMutation({
+    onSuccess: () => {
+      toast({
+        description: "Tag pair unignored",
+      });
+      utils.tags.listIgnoredPairs.invalidate();
+      utils.tags.getIgnoredPairIds.invalidate();
+    },
+    onError: (e) => {
+      toast({
+        description: e.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  const pairs = ignoredPairs?.ignoredPairs ?? [];
+
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      You have {pairs.length} ignored tag pair{pairs.length !== 1 ? "s" : ""}.
+      {pairs.length > 0 && (
+        <CollapsibleTrigger asChild>
+          <Button variant="link" size="sm">
+            {expanded ? "Hide All" : "Show All"}
+          </Button>
+        </CollapsibleTrigger>
+      )}
+      <CollapsibleContent>
+        {pairs.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Tag Pairs</TableHead>
+                <TableHead className="text-center">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pairs.map((pair) => (
+                <TableRow key={pair.id}>
+                  <TableCell className="flex flex-wrap gap-1">
+                    <Link
+                      href={`/dashboard/tags/${pair.tag1.id}`}
+                      className={cn(
+                        badgeVariants({ variant: "outline" }),
+                        "text-sm",
+                      )}
+                    >
+                      {pair.tag1.name}
+                    </Link>
+                    <span className="text-muted-foreground">&</span>
+                    <Link
+                      href={`/dashboard/tags/${pair.tag2.id}`}
+                      className={cn(
+                        badgeVariants({ variant: "outline" }),
+                        "text-sm",
+                      )}
+                    >
+                      {pair.tag2.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <ActionButton
+                      variant="secondary"
+                      onClick={() => unignorePair({ pairId: pair.id })}
+                    >
+                      <Undo2 className="mr-2 size-4" />
+                      {t("actions.unignore")}
+                    </ActionButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/db/drizzle/0063_add_ignored_tag_pairs.sql
+++ b/packages/db/drizzle/0063_add_ignored_tag_pairs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `ignoredTagPairs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`tagId1` text NOT NULL,
+	`tagId2` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`tagId1`) REFERENCES `bookmarkTags`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`tagId2`) REFERENCES `bookmarkTags`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `ignoredTagPairs_userId_idx` ON `ignoredTagPairs` (`userId`);--> statement-breakpoint
+CREATE UNIQUE INDEX `ignoredTagPairs_userId_tagId1_tagId2_unique` ON `ignoredTagPairs` (`userId`,`tagId1`,`tagId2`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1759573697911,
       "tag": "0062_add_import_session",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "6",
+      "when": 1760000000000,
+      "tag": "0063_add_ignored_tag_pairs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/trpc/routers/tags.ts
+++ b/packages/trpc/routers/tags.ts
@@ -112,4 +112,53 @@ export const tagsAppRouter = router({
           : undefined,
       });
     }),
+  ignoreDuplicateSuggestion: authedProcedure
+    .input(
+      z.object({
+        tagId1: z.string(),
+        tagId2: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      return await Tag.ignoreDuplicateSuggestion(ctx, input);
+    }),
+  listIgnoredPairs: authedProcedure
+    .output(
+      z.object({
+        ignoredPairs: z.array(
+          z.object({
+            id: z.string(),
+            tag1: zTagBasicSchema,
+            tag2: zTagBasicSchema,
+            createdAt: z.date(),
+          }),
+        ),
+      }),
+    )
+    .query(async ({ ctx }) => {
+      return await Tag.listIgnoredPairs(ctx);
+    }),
+  unignorePair: authedProcedure
+    .input(
+      z.object({
+        pairId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      await Tag.unignorePair(ctx, input.pairId);
+    }),
+  getIgnoredPairIds: authedProcedure
+    .output(
+      z.object({
+        pairs: z.array(
+          z.object({
+            tagId1: z.string(),
+            tagId2: z.string(),
+          }),
+        ),
+      }),
+    )
+    .query(async ({ ctx }) => {
+      return await Tag.getIgnoredPairIds(ctx);
+    }),
 });


### PR DESCRIPTION
Fixes #1010

Adds persistent storage for ignored duplicate tag suggestions so users don't have to repeatedly ignore the same tag combinations.

## Changes
- Add `ignoredTagPairs` database table
- Implement tRPC procedures for managing ignored pairs
- Update duplicate detection UI to filter ignored pairs
- Add management UI to view/unignore pairs

🤖 Generated with [Claude Code](https://claude.ai/code)