### PR TITLE
Fix list: filter to include smart lists in search queries

### DIFF
--- a/apps/web/components/ui/markdown/markdown-readonly.tsx
+++ b/apps/web/components/ui/markdown/markdown-readonly.tsx
@@ -85,11 +85,13 @@ export function MarkdownReadonly({
         },
         code({ className, children, ...props }) {
           const match = /language-(\w+)/.exec(className ?? "");
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+          const { ref, ...rest } = props as any;
           return match ? (
             <SyntaxHighlighter
               PreTag="div"
               language={match[1]}
-              {...props}
+              {...rest}
               style={dracula}
             >
               {String(children).replace(/\n$/, "")}

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -395,6 +395,8 @@ export const bookmarkLists = sqliteTable(
   },
   (bl) => [
     index("bookmarkLists_userId_idx").on(bl.userId),
+    // Helps queries that lookup lists by (userId, name)
+    index("bookmarkLists_userId_name_idx").on(bl.userId, bl.name),
     unique("bookmarkLists_userId_id_idx").on(bl.userId, bl.id),
   ],
 );

--- a/packages/trpc/lib/search.ts
+++ b/packages/trpc/lib/search.ts
@@ -186,8 +186,10 @@ async function getIds(
         ? db
             .selectDistinct({ id: bookmarksInLists.bookmarkId })
             .from(bookmarksInLists)
+            .innerJoin(bookmarks, eq(bookmarksInLists.bookmarkId, bookmarks.id))
             .where(
               and(
+                eq(bookmarks.userId, userId),
                 // user scoping ensured by lists query; membership rows imply same user via listId
                 // Fetch all bookmarks that are in any of the manual lists with this name
                 inArray(bookmarksInLists.listId, manualListIds),

--- a/packages/trpc/lib/search.ts
+++ b/packages/trpc/lib/search.ts
@@ -424,13 +424,17 @@ async function getIds(
     }
     case "and": {
       const vals = await Promise.all(
-        matcher.matchers.map((m) => getIds(db, userId, m, new Set(visitedListNames))),
+        matcher.matchers.map((m) =>
+          getIds(db, userId, m, new Set(visitedListNames)),
+        ),
       );
       return intersect(vals);
     }
     case "or": {
       const vals = await Promise.all(
-        matcher.matchers.map((m) => getIds(db, userId, m, new Set(visitedListNames))),
+        matcher.matchers.map((m) =>
+          getIds(db, userId, m, new Set(visitedListNames)),
+        ),
       );
       return union(vals);
     }


### PR DESCRIPTION
- Update getIds function to handle both manual and smart lists when filtering by list name
- Smart lists are resolved by evaluating their stored query recursively
- Add cycle detection to prevent infinite recursion in nested smart list queries
- Maintain backward compatibility with existing manual list filtering

Fixes #1669