### PR TITLE
docs: Add Azure configuration details for OpenAI-compatible API

### DIFF
--- a/docs/docs/14-guides/05-different-ai-providers.md
+++ b/docs/docs/14-guides/05-different-ai-providers.md
@@ -69,7 +69,7 @@ INFERENCE_IMAGE_MODEL: sonar-pro
 
 Azure has an OpenAI-compatible API.
 
-You can get your API key from the Overview page of Azure the AI Foundry Portal or via "Keys + Endpoints" on the resource in the Azure Portal.
+You can get your API key from the Overview page of the Azure AI Foundry Portal or via "Keys + Endpoints" on the resource in the Azure Portal.
 
 :::warning
 The [model name is the deployment name](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/switching-endpoints#keyword-argument-for-model) you specified when deploying the model, which may differ from the base model name.


### PR DESCRIPTION
This PR adds documentation for using Azure as an OpenAI-compatible API provider. The update clarifies how to configure the API key, base URL, and model deployment name when integrating with Azure services.

Helps with issues like #137 and #462