### PR TITLE
Fix HTML import reusing existing lists

### DIFF
--- a/apps/web/lib/hooks/useBookmarkImport.ts
+++ b/apps/web/lib/hooks/useBookmarkImport.ts
@@ -13,6 +13,7 @@ import {
   useAddBookmarkToList,
   useCreateBookmarkList,
 } from "@karakeep/shared-react/hooks/lists";
+import { api } from "@karakeep/shared-react/trpc";
 import {
   importBookmarksFromFile,
   ImportSource,
@@ -42,6 +43,7 @@ export function useBookmarkImport() {
   const { mutateAsync: createList } = useCreateBookmarkList();
   const { mutateAsync: addToList } = useAddBookmarkToList();
   const { mutateAsync: updateTags } = useUpdateBookmarkTags();
+  const apiUtils = api.useUtils();
 
   const uploadBookmarkFileMutation = useMutation({
     mutationFn: async ({
@@ -51,6 +53,11 @@ export function useBookmarkImport() {
       file: File;
       source: ImportSource;
     }) => {
+      const existingListsResponse = await apiUtils.lists.list
+        .fetch()
+        .catch(() => null);
+      const existingLists = existingListsResponse?.lists ?? [];
+
       const result = await importBookmarksFromFile(
         {
           file,
@@ -59,6 +66,7 @@ export function useBookmarkImport() {
           deps: {
             createImportSession,
             createList,
+            getExistingLists: async () => existingLists,
             createBookmark: async (
               bookmark: ParsedBookmark,
               sessionId: string,


### PR DESCRIPTION
Summary

The previous upstream fix ([1bae66f7785](https://github.com/karakeep-app/karakeep/commit/1bae66f7785289818eba3249f651a320f497c6a4)￼) made the Netscape importer build a proper list tree, but it still recreated a new “Imported Bookmarks” hierarchy on every import.
This patch adds the missing reuse logic so that if a user re-imports, the existing root and its nested lists are reused instead of duplicated.

What’s changed
	•	packages/shared/import-export/importer.ts:
– fetches the current list tree before import
– reuses the existing Imported Bookmarks hierarchy
– only creates folders that don’t exist yet
	•	apps/web/lib/hooks/useBookmarkImport.ts: forwards cached list inventory to shared importer
	•	packages/shared/import-export/importer.test.ts: adds coverage for reuse behaviour
	
	Manual: import and re-import a large Raindrop/Netscape HTML export — verify that folders are reused, not duplicated.

Motivation

Fixes [#538](https://github.com/karakeep-app/karakeep/issues/538)￼
Relates to [#988](https://github.com/karakeep-app/karakeep/issues/988)￼