### PR TITLE
fix: remove incorrect array destructuring in mobile search

### DIFF
--- a/apps/mobile/app/dashboard/search.tsx
+++ b/apps/mobile/app/dashboard/search.tsx
@@ -19,7 +19,7 @@ const MAX_DISPLAY_SUGGESTIONS = 5;
 export default function Search() {
   const [search, setSearch] = useState("");
 
-  const [query] = useDebounce(search, 10);
+  const query = useDebounce(search, 10);
   const inputRef = useRef<TextInput>(null);
 
   const [isInputFocused, setIsInputFocused] = useState(true);


### PR DESCRIPTION
The search was crashing because of incorrect array destructuring on
the useDebounce hook return value. useDebounce returns a string, not
an array, so using `const [query] = useDebounce(...)` caused query
to be undefined when the search string was empty.

This resulted in passing { text: undefined } to the tRPC endpoint,
which failed Zod validation expecting a string.

Fixed by removing the array destructuring: const query = useDebounce(...)