### PR TITLE
feat: Add admin ability to mark user as email verified

### DIFF
--- a/apps/web/components/admin/UpdateUserDialog.tsx
+++ b/apps/web/components/admin/UpdateUserDialog.tsx
@@ -26,6 +26,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/use-toast";
 import { api } from "@/lib/trpc";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -42,6 +43,7 @@ interface UpdateUserDialogProps {
   currentRole: "user" | "admin";
   currentQuota: number | null;
   currentStorageQuota: number | null;
+  currentEmailVerified: number | null;
   children?: React.ReactNode;
 }
 export default function UpdateUserDialog({
@@ -49,6 +51,7 @@ export default function UpdateUserDialog({
   currentRole,
   currentQuota,
   currentStorageQuota,
+  currentEmailVerified,
   children,
 }: UpdateUserDialogProps) {
   const apiUtils = api.useUtils();
@@ -58,6 +61,7 @@ export default function UpdateUserDialog({
     role: currentRole,
     bookmarkQuota: currentQuota,
     storageQuota: currentStorageQuota,
+    emailVerified: currentEmailVerified !== null,
   };
   const form = useForm<UpdateUserSchema>({
     resolver: zodResolver(updateUserSchema),
@@ -170,6 +174,23 @@ export default function UpdateUserDialog({
                       />
                     </FormControl>
                     <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="emailVerified"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+                    <div className="space-y-0.5">
+                      <FormLabel>Email Verified</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
                   </FormItem>
                 )}
               />

--- a/apps/web/components/admin/UpdateUserDialog.tsx
+++ b/apps/web/components/admin/UpdateUserDialog.tsx
@@ -43,7 +43,7 @@ interface UpdateUserDialogProps {
   currentRole: "user" | "admin";
   currentQuota: number | null;
   currentStorageQuota: number | null;
-  currentEmailVerified: number | null;
+  currentEmailVerified: Date | null;
   children?: React.ReactNode;
 }
 export default function UpdateUserDialog({

--- a/apps/web/components/admin/UserList.tsx
+++ b/apps/web/components/admin/UserList.tsx
@@ -145,6 +145,7 @@ export default function UsersSection() {
                       currentRole={u.role!}
                       currentQuota={u.bookmarkQuota}
                       currentStorageQuota={u.storageQuota}
+                      currentEmailVerified={u.emailVerified}
                     >
                       <ButtonWithTooltip
                         tooltip="Edit User"

--- a/packages/open-api/karakeep-openapi-spec.json
+++ b/packages/open-api/karakeep-openapi-spec.json
@@ -3568,6 +3568,9 @@
                   "browserCrawlingEnabled": {
                     "type": "boolean",
                     "nullable": true
+                  },
+                  "emailVerified": {
+                    "type": "boolean"
                   }
                 },
                 "description": "User update data",

--- a/packages/shared/types/admin.ts
+++ b/packages/shared/types/admin.ts
@@ -14,6 +14,7 @@ export const updateUserSchema = z.object({
   bookmarkQuota: z.number().int().min(0).nullable().optional(),
   storageQuota: z.number().int().min(0).nullable().optional(),
   browserCrawlingEnabled: z.boolean().nullable().optional(),
+  emailVerified: z.boolean().optional(),
 });
 
 export const resetPasswordSchema = z

--- a/packages/trpc/routers/admin.ts
+++ b/packages/trpc/routers/admin.ts
@@ -370,7 +370,7 @@ export const adminAppRouter = router({
       }
 
       if (input.emailVerified !== undefined) {
-        updateData.emailVerified = input.emailVerified ? Date.now() : null;
+        updateData.emailVerified = input.emailVerified ? new Date() : null;
       }
 
       if (Object.keys(updateData).length === 0) {

--- a/packages/trpc/routers/admin.ts
+++ b/packages/trpc/routers/admin.ts
@@ -369,6 +369,10 @@ export const adminAppRouter = router({
         updateData.browserCrawlingEnabled = input.browserCrawlingEnabled;
       }
 
+      if (input.emailVerified !== undefined) {
+        updateData.emailVerified = input.emailVerified ? Date.now() : null;
+      }
+
       if (Object.keys(updateData).length === 0) {
         throw new TRPCError({
           code: "BAD_REQUEST",

--- a/packages/trpc/routers/users.ts
+++ b/packages/trpc/routers/users.ts
@@ -71,7 +71,7 @@ export const usersAppRouter = router({
             localUser: z.boolean(),
             bookmarkQuota: z.number().nullable(),
             storageQuota: z.number().nullable(),
-            emailVerified: z.number().nullable(),
+            emailVerified: z.date().nullable(),
           }),
         ),
       }),

--- a/packages/trpc/routers/users.ts
+++ b/packages/trpc/routers/users.ts
@@ -71,6 +71,7 @@ export const usersAppRouter = router({
             localUser: z.boolean(),
             bookmarkQuota: z.number().nullable(),
             storageQuota: z.number().nullable(),
+            emailVerified: z.number().nullable(),
           }),
         ),
       }),


### PR DESCRIPTION
Added the ability for admins to mark/unmark users as email verified:
- Updated updateUser tRPC endpoint to accept emailVerified boolean
- Modified endpoint to set emailVerified timestamp when true, null when false
- Added emailVerified field to users.list output schema
- Added Switch component to UpdateUserDialog for toggling email verification
- Updated UserList to pass emailVerified status to edit modal