### PR TITLE
fix: Hide viewer-only shared lists in Manage Lists

### DIFF
--- a/apps/browser-extension/src/components/ListsSelector.tsx
+++ b/apps/browser-extension/src/components/ListsSelector.tsx
@@ -74,31 +74,33 @@ export function ListsSelector({ bookmarkId }: { bookmarkId: string }) {
           <CommandList>
             <CommandEmpty>You don&apos;t have any lists.</CommandEmpty>
             <CommandGroup>
-              {allLists?.allPaths.map((path) => {
-                const lastItem = path[path.length - 1];
+              {allLists?.allPaths
+                .filter((path) => path[path.length - 1].userRole !== "viewer")
+                .map((path) => {
+                  const lastItem = path[path.length - 1];
 
-                return (
-                  <CommandItem
-                    key={lastItem.id}
-                    value={lastItem.id}
-                    keywords={[lastItem.name, lastItem.icon]}
-                    onSelect={toggleList}
-                    disabled={currentlyUpdating.has(lastItem.id)}
-                  >
-                    <Check
-                      className={cn(
-                        "mr-2 size-4",
-                        existingListIds.has(lastItem.id)
-                          ? "opacity-100"
-                          : "opacity-0",
-                      )}
-                    />
-                    {path
-                      .map((item) => `${item.icon} ${item.name}`)
-                      .join(" / ")}
-                  </CommandItem>
-                );
-              })}
+                  return (
+                    <CommandItem
+                      key={lastItem.id}
+                      value={lastItem.id}
+                      keywords={[lastItem.name, lastItem.icon]}
+                      onSelect={toggleList}
+                      disabled={currentlyUpdating.has(lastItem.id)}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 size-4",
+                          existingListIds.has(lastItem.id)
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      {path
+                        .map((item) => `${item.icon} ${item.name}`)
+                        .join(" / ")}
+                    </CommandItem>
+                  );
+                })}
             </CommandGroup>
           </CommandList>
         </Command>

--- a/apps/mobile/app/dashboard/bookmarks/[slug]/manage_lists.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/manage_lists.tsx
@@ -68,6 +68,10 @@ const ListPickerPage = () => {
   };
 
   const { allPaths } = data ?? {};
+  // Filter out lists where user is a viewer (can't add/remove bookmarks)
+  const filteredPaths = allPaths?.filter(
+    (path) => path[path.length - 1].userRole !== "viewer",
+  );
   return (
     <CustomSafeAreaView>
       <FlatList
@@ -97,7 +101,7 @@ const ListPickerPage = () => {
             </Pressable>
           </View>
         )}
-        data={allPaths}
+        data={filteredPaths}
       />
     </CustomSafeAreaView>
   );

--- a/apps/web/components/dashboard/lists/BookmarkListSelector.tsx
+++ b/apps/web/components/dashboard/lists/BookmarkListSelector.tsx
@@ -46,10 +46,15 @@ export function BookmarkListSelector({
   }
 
   allPaths = allPaths?.filter((path) => {
-    if (hideBookmarkIds.includes(path[path.length - 1].id)) {
+    const lastItem = path[path.length - 1];
+    if (hideBookmarkIds.includes(lastItem.id)) {
       return false;
     }
-    if (!listTypes.includes(path[path.length - 1].type)) {
+    if (!listTypes.includes(lastItem.type)) {
+      return false;
+    }
+    // Hide lists where user is a viewer (can't add/remove bookmarks)
+    if (lastItem.userRole === "viewer") {
       return false;
     }
     if (!hideSubtreeOf) {


### PR DESCRIPTION
Users with viewer role cannot add/remove bookmarks from lists, so these lists should not appear in the Manage Lists dialog across all platforms (web, mobile, and extension).

Changes:
- Web: Updated BookmarkListSelector to filter out viewer lists
- Mobile: Updated manage_lists.tsx to filter out viewer lists
- Extension: Updated ListsSelector to filter out viewer lists