### PR TITLE
feat: add GET /api/version endpoint

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -20,6 +20,7 @@ import rss from "./routes/rss";
 import tags from "./routes/tags";
 import trpc from "./routes/trpc";
 import users from "./routes/users";
+import version from "./routes/version";
 import webhooks from "./routes/webhooks";
 
 await loadAllPlugins();
@@ -67,6 +68,7 @@ const app = new Hono<{
   })
   .use(trpcAdapter)
   .route("/health", health)
+  .route("/version", version)
   .route("/trpc", trpc)
   .route("/v1", v1)
   .route("/assets", assets)

--- a/packages/api/routes/version.ts
+++ b/packages/api/routes/version.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+
+import serverConfig from "@karakeep/shared/config";
+import { Context } from "@karakeep/trpc";
+
+const version = new Hono<{
+  Variables: {
+    ctx: Context;
+  };
+}>().get("/", (c) => {
+  return c.json({
+    version: serverConfig.serverVersion ?? "unknown",
+  });
+});
+
+export default version;


### PR DESCRIPTION
Implements a new API endpoint that returns the server version from serverConfig. This will be used for Home Assistant integration to check for updates.

Fixes #2148