### PR TITLE
fix: update tag mapping to return normalized tags instead of original tags in connectTags function

### DIFF
--- a/apps/workers/workers/inference/tagging.ts
+++ b/apps/workers/workers/inference/tagging.ts
@@ -346,7 +346,7 @@ async function connectTags(
               (mt) => normalizeTag(mt.name) === t.normalizedTag,
             ),
         )
-        .map((t) => t.normalizedTag);
+        .map((t) => t.originalTag.toLowerCase());
 
       return { matchedTagIds, notFoundTagNames };
     })();


### PR DESCRIPTION
See #1578 

UPDATE:

Tested on my machine, probably it's just better to do `t.originalTag.toLowerCase()` than getting the normalized one otherwise spaces will be removed etc. etc.