### PR TITLE
Fixes #1747 Add Unused Tags Management to Cleanups Dashboard

### DIFF
--- a/apps/web/app/dashboard/cleanups/page.tsx
+++ b/apps/web/app/dashboard/cleanups/page.tsx
@@ -1,5 +1,16 @@
-import { Cleanups } from "@/components/dashboard/cleanups/Cleanups";
+import { DuplicateTags } from "@/components/dashboard/cleanups/DuplicateTags";
+import { UnusedTags } from "@/components/dashboard/cleanups/UnusedTags";
 
-export default async function CleanupsPage() {
-  return <Cleanups />;
+export default function Cleanups() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-3">
+        <span className="text-2xl">Cleanups</span>
+      </div>
+
+      <DuplicateTags />
+
+      <UnusedTags showCount={true} />
+    </div>
+  );
 }

--- a/apps/web/app/dashboard/cleanups/page.tsx
+++ b/apps/web/app/dashboard/cleanups/page.tsx
@@ -1,25 +1,5 @@
-import { TagDuplicationDetection } from "@/components/dashboard/cleanups/TagDuplicationDetention";
-import { Separator } from "@/components/ui/separator";
-import { useTranslation } from "@/lib/i18n/server";
-import { Paintbrush, Tags } from "lucide-react";
+import { Cleanups } from "@/components/dashboard/cleanups/Cleanups";
 
-export default async function Cleanups() {
-  // oxlint-disable-next-line rules-of-hooks
-  const { t } = await useTranslation();
-
-  return (
-    <div className="flex flex-col gap-y-4 rounded-md border bg-background p-4">
-      <span className="flex items-center gap-1 text-2xl">
-        <Paintbrush />
-        {t("cleanups.cleanups")}
-      </span>
-      <Separator />
-      <span className="flex items-center gap-1 text-xl">
-        <Tags />
-        {t("cleanups.duplicate_tags.title")}
-      </span>
-      <Separator />
-      <TagDuplicationDetection />
-    </div>
-  );
+export default async function CleanupsPage() {
+  return <Cleanups />;
 }

--- a/apps/web/components/dashboard/cleanups/Cleanups.tsx
+++ b/apps/web/components/dashboard/cleanups/Cleanups.tsx
@@ -12,7 +12,7 @@ export function Cleanups() {
 
       <DuplicateTags />
 
-      <UnusedTags showAsCard={true} showCount={true} />
+      <UnusedTags showCount={true} />
     </div>
   );
 }

--- a/apps/web/components/dashboard/cleanups/Cleanups.tsx
+++ b/apps/web/components/dashboard/cleanups/Cleanups.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { DuplicateTags } from "./DuplicateTags";
+import { UnusedTags } from "./UnusedTags";
+
+export function Cleanups() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-3">
+        <span className="text-2xl">Cleanups</span>
+      </div>
+
+      <DuplicateTags />
+
+      <UnusedTags showAsCard={true} showCount={true} />
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/cleanups/DuplicateTags.tsx
+++ b/apps/web/components/dashboard/cleanups/DuplicateTags.tsx
@@ -4,8 +4,15 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ActionButton } from "@/components/ui/action-button";
 import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
-import { badgeVariants } from "@/components/ui/badge";
+import { Badge, badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
@@ -25,7 +32,7 @@ import { useTranslation } from "@/lib/i18n/client";
 import { api } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { distance } from "fastest-levenshtein";
-import { Check, Combine, X } from "lucide-react";
+import { Check, Combine, Tags, X } from "lucide-react";
 
 import { useMergeTag } from "@karakeep/shared-react/hooks/tags";
 
@@ -198,7 +205,7 @@ function SuggestionRow({
   );
 }
 
-export function TagDuplicationDetection() {
+export function DuplicateTags() {
   const [expanded, setExpanded] = useState(false);
   let { data: allTags } = api.tags.list.useQuery(
     {},
@@ -239,48 +246,64 @@ export function TagDuplicationDetection() {
     setSuggestions(initialSuggestions);
   }, [allTags]);
 
-  if (!allTags) {
-    return <LoadingSpinner />;
-  }
-
   return (
-    <Collapsible open={expanded} onOpenChange={setExpanded}>
-      You have {suggestions.length} suggestions for tag merging.
-      {suggestions.length > 0 && (
-        <CollapsibleTrigger asChild>
-          <Button variant="link" size="sm">
-            {expanded ? "Hide All" : "Show All"}
-          </Button>
-        </CollapsibleTrigger>
-      )}
-      <CollapsibleContent>
-        <p className="text-sm italic text-muted-foreground">
-          For every suggestion, select the tag that you want to keep and other
-          tags will be merged into it.
-        </p>
-        {suggestions.length > 0 && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Tags</TableHead>
-                <TableHead className="text-center">
-                  <ApplyAllButton suggestions={suggestions} />
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {suggestions.map((suggestion) => (
-                <SuggestionRow
-                  key={suggestion.mergeIntoId}
-                  suggestion={suggestion}
-                  updateMergeInto={updateMergeInto}
-                  deleteSuggestion={deleteSuggestion}
-                />
-              ))}
-            </TableBody>
-          </Table>
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Tags className="size-5" />
+          <span>Duplicate Tags</span>
+          {allTags && <Badge variant="secondary">{suggestions.length}</Badge>}
+        </CardTitle>
+        <CardDescription>
+          Merge similar tags to keep your collection organized
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {!allTags ? (
+          <div className="flex justify-center py-8">
+            <LoadingSpinner />
+          </div>
+        ) : (
+          <Collapsible open={expanded} onOpenChange={setExpanded}>
+            You have {suggestions.length} suggestions for tag merging.
+            {suggestions.length > 0 && (
+              <CollapsibleTrigger asChild>
+                <Button variant="link" size="sm">
+                  {expanded ? "Hide All" : "Show All"}
+                </Button>
+              </CollapsibleTrigger>
+            )}
+            <CollapsibleContent>
+              <p className="text-sm italic text-muted-foreground">
+                For every suggestion, select the tag that you want to keep and
+                other tags will be merged into it.
+              </p>
+              {suggestions.length > 0 && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Tags</TableHead>
+                      <TableHead className="text-center">
+                        <ApplyAllButton suggestions={suggestions} />
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {suggestions.map((suggestion) => (
+                      <SuggestionRow
+                        key={suggestion.mergeIntoId}
+                        suggestion={suggestion}
+                        updateMergeInto={updateMergeInto}
+                        deleteSuggestion={deleteSuggestion}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CollapsibleContent>
+          </Collapsible>
         )}
-      </CollapsibleContent>
-    </Collapsible>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/components/dashboard/cleanups/UnusedTags.tsx
+++ b/apps/web/components/dashboard/cleanups/UnusedTags.tsx
@@ -65,12 +65,12 @@ function DeleteAllUnusedTags({ numUnusedTags }: { numUnusedTags: number }) {
 }
 
 interface UnusedTagsProps {
-  showAsCard?: boolean;
   showCount?: boolean;
+  searchQuery?: string;
 }
 
 export function UnusedTags({
-  showAsCard = true,
+  searchQuery = "",
   showCount = true,
 }: UnusedTagsProps) {
   const { t } = useTranslation();
@@ -84,7 +84,7 @@ export function UnusedTags({
     fetchNextPage: fetchNextPageUnusedTags,
     isFetchingNextPage: isFetchingNextPageUnusedTags,
   } = usePaginatedSearchTags({
-    nameContains: "",
+    nameContains: searchQuery,
     sortBy: "usage",
     attachedBy: "none",
     limit: 50,
@@ -97,70 +97,6 @@ export function UnusedTags({
     setSelectedTag(tag);
   };
 
-  const content = (
-    <>
-      {selectedTag && (
-        <DeleteTagConfirmationDialog
-          tag={selectedTag}
-          open={isDialogOpen}
-          setOpen={(o) => {
-            if (!o) {
-              setSelectedTag(null);
-            }
-          }}
-        />
-      )}
-      {isUnusedTagsLoading && unusedTags.length === 0 ? (
-        <div className="flex justify-center py-8">
-          <LoadingSpinner />
-        </div>
-      ) : (
-        <>
-          {unusedTags.length > 0 && (
-            <div className="flex flex-wrap gap-3">
-              {unusedTags.map((tag) => (
-                <TagPill
-                  key={tag.id}
-                  id={tag.id}
-                  name={tag.name}
-                  count={showCount ? tag.numBookmarks : 0}
-                  isDraggable={false}
-                  onOpenDialog={handleOpenDialog}
-                  showCount={false}
-                />
-              ))}
-            </div>
-          )}
-          {unusedTags.length === 0 && (
-            <p className="py-4 text-center text-sm text-muted-foreground">
-              {t("tags.no_unused_tags")}
-            </p>
-          )}
-          {hasNextPageUnusedTags && (
-            <div className="mt-4">
-              <ActionButton
-                variant="secondary"
-                onClick={() => fetchNextPageUnusedTags()}
-                loading={isFetchingNextPageUnusedTags}
-                ignoreDemoMode
-              >
-                {t("actions.load_more")}
-              </ActionButton>
-            </div>
-          )}
-          {numUnusedTags > 0 && (
-            <div className="mt-4">
-              <DeleteAllUnusedTags numUnusedTags={numUnusedTags} />
-            </div>
-          )}
-        </>
-      )}
-    </>
-  );
-  if (!showAsCard) {
-    return content;
-  }
-
   return (
     <Card>
       <CardHeader>
@@ -170,7 +106,64 @@ export function UnusedTags({
         </CardTitle>
         <CardDescription>{t("tags.unused_tags_info")}</CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col gap-4">{content}</CardContent>
+      <CardContent className="flex flex-col gap-4">
+        {selectedTag && (
+          <DeleteTagConfirmationDialog
+            tag={selectedTag}
+            open={isDialogOpen}
+            setOpen={(o) => {
+              if (!o) {
+                setSelectedTag(null);
+              }
+            }}
+          />
+        )}
+        {isUnusedTagsLoading && unusedTags.length === 0 ? (
+          <div className="flex justify-center py-8">
+            <LoadingSpinner />
+          </div>
+        ) : (
+          <>
+            {unusedTags.length > 0 && (
+              <div className="flex flex-wrap gap-3">
+                {unusedTags.map((tag) => (
+                  <TagPill
+                    key={tag.id}
+                    id={tag.id}
+                    name={tag.name}
+                    count={showCount ? tag.numBookmarks : 0}
+                    isDraggable={false}
+                    onOpenDialog={handleOpenDialog}
+                    showCount={false}
+                  />
+                ))}
+              </div>
+            )}
+            {unusedTags.length === 0 && (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                {t("tags.no_unused_tags")}
+              </p>
+            )}
+            {hasNextPageUnusedTags && (
+              <div className="mt-4">
+                <ActionButton
+                  variant="secondary"
+                  onClick={() => fetchNextPageUnusedTags()}
+                  loading={isFetchingNextPageUnusedTags}
+                  ignoreDemoMode
+                >
+                  {t("actions.load_more")}
+                </ActionButton>
+              </div>
+            )}
+            {numUnusedTags > 0 && (
+              <div className="mt-4">
+                <DeleteAllUnusedTags numUnusedTags={numUnusedTags} />
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
     </Card>
   );
 }

--- a/apps/web/components/dashboard/cleanups/UnusedTags.tsx
+++ b/apps/web/components/dashboard/cleanups/UnusedTags.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import React, { useState } from "react";
+import { ActionButton } from "@/components/ui/action-button";
+import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import LoadingSpinner from "@/components/ui/spinner";
+import { toast } from "@/components/ui/use-toast";
+import { useTranslation } from "@/lib/i18n/client";
+import { Trash2 } from "lucide-react";
+
+import type { ZTagBasic } from "@karakeep/shared/types/tags";
+import {
+  useDeleteUnusedTags,
+  usePaginatedSearchTags,
+} from "@karakeep/shared-react/hooks/tags";
+
+import DeleteTagConfirmationDialog from "../tags/DeleteTagConfirmationDialog";
+import { TagPill } from "../tags/TagPill";
+
+function DeleteAllUnusedTags({ numUnusedTags }: { numUnusedTags: number }) {
+  const { t } = useTranslation();
+  const { mutate, isPending } = useDeleteUnusedTags({
+    onSuccess: () => {
+      toast({
+        description: `Deleted all ${numUnusedTags} unused tags`,
+      });
+    },
+    onError: () => {
+      toast({
+        description: "Something went wrong",
+        variant: "destructive",
+      });
+    },
+  });
+  return (
+    <ActionConfirmingDialog
+      title={t("tags.delete_all_unused_tags")}
+      description={`Are you sure you want to delete the ${numUnusedTags} unused tags?`}
+      actionButton={() => (
+        <ActionButton
+          variant="destructive"
+          loading={isPending}
+          onClick={() => mutate()}
+        >
+          <Trash2 className="mr-2 size-4" />
+          {t("tags.delete_all_unused_tags_button")}
+        </ActionButton>
+      )}
+    >
+      <Button variant="destructive" disabled={numUnusedTags == 0}>
+        <Trash2 className="mr-2 size-4" />
+        {t("tags.delete_all_unused_tags")}
+      </Button>
+    </ActionConfirmingDialog>
+  );
+}
+
+interface UnusedTagsProps {
+  showAsCard?: boolean;
+  showCount?: boolean;
+}
+
+export function UnusedTags({
+  showAsCard = true,
+  showCount = true,
+}: UnusedTagsProps) {
+  const { t } = useTranslation();
+  const [selectedTag, setSelectedTag] = useState<ZTagBasic | null>(null);
+  const isDialogOpen = !!selectedTag;
+
+  const {
+    data: unusedTagsData,
+    isLoading: isUnusedTagsLoading,
+    hasNextPage: hasNextPageUnusedTags,
+    fetchNextPage: fetchNextPageUnusedTags,
+    isFetchingNextPage: isFetchingNextPageUnusedTags,
+  } = usePaginatedSearchTags({
+    nameContains: "",
+    sortBy: "usage",
+    attachedBy: "none",
+    limit: 50,
+  });
+
+  const unusedTags = unusedTagsData?.tags ?? [];
+  const numUnusedTags = unusedTags.length;
+
+  const handleOpenDialog = (tag: ZTagBasic) => {
+    setSelectedTag(tag);
+  };
+
+  const content = (
+    <>
+      {selectedTag && (
+        <DeleteTagConfirmationDialog
+          tag={selectedTag}
+          open={isDialogOpen}
+          setOpen={(o) => {
+            if (!o) {
+              setSelectedTag(null);
+            }
+          }}
+        />
+      )}
+      {isUnusedTagsLoading && unusedTags.length === 0 ? (
+        <div className="flex justify-center py-8">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        <>
+          {unusedTags.length > 0 && (
+            <div className="flex flex-wrap gap-3">
+              {unusedTags.map((tag) => (
+                <TagPill
+                  key={tag.id}
+                  id={tag.id}
+                  name={tag.name}
+                  count={showCount ? tag.numBookmarks : 0}
+                  isDraggable={false}
+                  onOpenDialog={handleOpenDialog}
+                  showCount={false}
+                />
+              ))}
+            </div>
+          )}
+          {unusedTags.length === 0 && (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              {t("tags.no_unused_tags")}
+            </p>
+          )}
+          {hasNextPageUnusedTags && (
+            <div className="mt-4">
+              <ActionButton
+                variant="secondary"
+                onClick={() => fetchNextPageUnusedTags()}
+                loading={isFetchingNextPageUnusedTags}
+                ignoreDemoMode
+              >
+                {t("actions.load_more")}
+              </ActionButton>
+            </div>
+          )}
+          {numUnusedTags > 0 && (
+            <div className="mt-4">
+              <DeleteAllUnusedTags numUnusedTags={numUnusedTags} />
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+  if (!showAsCard) {
+    return content;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <span>{t("tags.unused_tags")}</span>
+          <Badge variant="secondary">{numUnusedTags}</Badge>
+        </CardTitle>
+        <CardDescription>{t("tags.unused_tags_info")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">{content}</CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/tags/AllTagsView.tsx
+++ b/apps/web/components/dashboard/tags/AllTagsView.tsx
@@ -332,7 +332,7 @@ export default function AllTagsView() {
           )}
         </CardContent>
       </Card>
-      <UnusedTags showAsCard={true} showCount={true} />
+      <UnusedTags searchQuery={searchQuery} showCount={false} />
     </div>
   );
 }

--- a/apps/web/components/dashboard/tags/AllTagsView.tsx
+++ b/apps/web/components/dashboard/tags/AllTagsView.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect } from "react";
 import { ActionButton } from "@/components/ui/action-button";
-import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,60 +23,21 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import Spinner from "@/components/ui/spinner";
 import { Toggle } from "@/components/ui/toggle";
-import { toast } from "@/components/ui/use-toast";
 import useBulkTagActionsStore from "@/lib/bulkTagActions";
 import { useTranslation } from "@/lib/i18n/client";
 import { ArrowDownAZ, ChevronDown, Combine, Search, Tag } from "lucide-react";
 import { parseAsStringEnum, useQueryState } from "nuqs";
 
 import type { ZGetTagResponse, ZTagBasic } from "@karakeep/shared/types/tags";
-import {
-  useDeleteUnusedTags,
-  usePaginatedSearchTags,
-} from "@karakeep/shared-react/hooks/tags";
+import { usePaginatedSearchTags } from "@karakeep/shared-react/hooks/tags";
 import { useDebounce } from "@karakeep/shared-react/hooks/use-debounce";
 
+import { UnusedTags } from "../cleanups/UnusedTags";
 import BulkTagAction from "./BulkTagAction";
 import { CreateTagModal } from "./CreateTagModal";
 import DeleteTagConfirmationDialog from "./DeleteTagConfirmationDialog";
 import { MultiTagSelector } from "./MultiTagSelector";
 import { TagPill } from "./TagPill";
-
-function DeleteAllUnusedTags({ numUnusedTags }: { numUnusedTags: number }) {
-  const { t } = useTranslation();
-  const { mutate, isPending } = useDeleteUnusedTags({
-    onSuccess: () => {
-      toast({
-        description: `Deleted all ${numUnusedTags} unused tags`,
-      });
-    },
-    onError: () => {
-      toast({
-        description: "Something went wrong",
-        variant: "destructive",
-      });
-    },
-  });
-  return (
-    <ActionConfirmingDialog
-      title={t("tags.delete_all_unused_tags")}
-      description={`Are you sure you want to delete the ${numUnusedTags} unused tags?`}
-      actionButton={() => (
-        <ActionButton
-          variant="destructive"
-          loading={isPending}
-          onClick={() => mutate()}
-        >
-          DELETE THEM ALL
-        </ActionButton>
-      )}
-    >
-      <Button variant="destructive" disabled={numUnusedTags == 0}>
-        {t("tags.delete_all_unused_tags")}
-      </Button>
-    </ActionConfirmingDialog>
-  );
-}
 
 export default function AllTagsView() {
   const { t } = useTranslation();
@@ -138,38 +98,22 @@ export default function AllTagsView() {
     limit: 50,
   });
 
-  const {
-    data: allEmptyTagsRaw,
-    isFetching: isEmptyTagsFetching,
-    isLoading: isEmptyTagsLoading,
-    hasNextPage: hasNextPageEmptyTags,
-    fetchNextPage: fetchNextPageEmptyTags,
-    isFetchingNextPage: isFetchingNextPageEmptyTags,
-  } = usePaginatedSearchTags({
-    nameContains: searchQuery,
-    sortBy,
-    attachedBy: "none",
-    limit: 50,
-  });
+  const isFetching = isHumanTagsFetching || isAiTagsFetching;
 
-  const isFetching =
-    isHumanTagsFetching || isAiTagsFetching || isEmptyTagsFetching;
-
-  const { allHumanTags, allAiTags, allEmptyTags } = React.useMemo(() => {
+  const { allHumanTags, allAiTags } = React.useMemo(() => {
     return {
       allHumanTags: allHumanTagsRaw?.tags ?? [],
       allAiTags: allAiTagsRaw?.tags ?? [],
-      allEmptyTags: allEmptyTagsRaw?.tags ?? [],
     };
-  }, [allHumanTagsRaw, allAiTagsRaw, allEmptyTagsRaw]);
+  }, [allHumanTagsRaw, allAiTagsRaw]);
 
   useEffect(() => {
-    const allTags = [...allHumanTags, ...allAiTags, ...allEmptyTags];
+    const allTags = [...allHumanTags, ...allAiTags];
     setVisibleTagIds(allTags.map((tag) => tag.id) ?? []);
     return () => {
       setVisibleTagIds([]);
     };
-  }, [allHumanTags, allAiTags, allEmptyTags, setVisibleTagIds]);
+  }, [allHumanTags, allAiTags, setVisibleTagIds]);
 
   const sortLabels: Record<typeof sortBy, string> = {
     name: t("tags.sort_by_name"),
@@ -388,39 +332,7 @@ export default function AllTagsView() {
           )}
         </CardContent>
       </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <span>{t("tags.unused_tags")}</span>
-            <Badge variant="secondary">{allEmptyTags.length}</Badge>
-          </CardTitle>
-          <CardDescription>{t("tags.unused_tags_info")}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {tagsToPill(
-            allEmptyTags,
-            isBulkEditEnabled,
-            {
-              emptyMessage: t("tags.no_unused_tags"),
-              searchEmptyMessage: t("tags.no_unused_tags_match_your_search"),
-            },
-            isEmptyTagsLoading,
-          )}
-          {hasNextPageEmptyTags && (
-            <ActionButton
-              variant="secondary"
-              onClick={() => fetchNextPageEmptyTags()}
-              loading={isFetchingNextPageEmptyTags}
-              ignoreDemoMode
-            >
-              {t("actions.load_more")}
-            </ActionButton>
-          )}
-          {allEmptyTags.length > 0 && (
-            <DeleteAllUnusedTags numUnusedTags={allEmptyTags.length} />
-          )}
-        </CardContent>
-      </Card>
+      <UnusedTags showAsCard={true} showCount={true} />
     </div>
   );
 }

--- a/apps/web/components/dashboard/tags/TagPill.tsx
+++ b/apps/web/components/dashboard/tags/TagPill.tsx
@@ -15,12 +15,14 @@ export const TagPill = React.memo(function TagPill({
   count,
   isDraggable,
   onOpenDialog,
+  showCount = true,
 }: {
   id: string;
   name: string;
   count: number;
   isDraggable: boolean;
   onOpenDialog: (tag: { id: string; name: string }) => void;
+  showCount?: boolean;
 }) {
   const [isHovered, setIsHovered] = useState(false);
   const draggableRef = useRef<HTMLDivElement>(null);
@@ -86,7 +88,12 @@ export const TagPill = React.memo(function TagPill({
         draggable={false}
         prefetch={false}
       >
-        {name} <Separator orientation="vertical" /> {count}
+        {name}
+        {showCount && (
+          <>
+            <Separator orientation="vertical" /> {count}
+          </>
+        )}
       </Link>
 
       {isHovered && !isDraggable && (

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -611,6 +611,7 @@
     "unused_tags": "Unused Tags",
     "unused_tags_info": "Tags that are not attached to any bookmarks",
     "delete_all_unused_tags": "Delete All Unused Tags",
+    "delete_all_unused_tags_button": "DELETE THEM ALL",
     "drag_and_drop_merging": "Drag & Drop Merging",
     "drag_and_drop_merging_info": "Drag and drop tags on each other to merge them",
     "sort_by_name": "Sort by Name",

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -611,7 +611,7 @@
     "unused_tags": "Unused Tags",
     "unused_tags_info": "Tags that are not attached to any bookmarks",
     "delete_all_unused_tags": "Delete All Unused Tags",
-    "delete_all_unused_tags_button": "DELETE THEM ALL",
+    "delete_all_unused_tags_button": "Delete All",
     "drag_and_drop_merging": "Drag & Drop Merging",
     "drag_and_drop_merging_info": "Drag and drop tags on each other to merge them",
     "sort_by_name": "Sort by Name",


### PR DESCRIPTION
Fixes #1747

- Removed the vertical separator and the number of tags the unused tag belongs to. Previously all Unused tags showed  `(Tag | 0)`
- Matched the style of the Cleanups dashboard with the Tags Dashboard. Duplicate tags are in a card, Unused Tags are in a separate card below it.
- Moved hardcoded "DELETE ALL TAGS" confirmation into a locale so it can be translated.
- Added a badge for the number of unused tags next to the Header Title. Did the same for the duplicate tags header.

<img width="1478" height="1058" alt="Screenshot 2025-12-05 at 19-51-14 All Tags Karakeep" src="https://github.com/user-attachments/assets/70f7ce34-24ee-40fa-9fd9-2186da0118de" />


<img width="1478" height="1058" alt="Screenshot 2025-12-05 at 19-50-54 Karakeep" src="https://github.com/user-attachments/assets/30147030-bacf-4e66-adc7-ff388125d65f" />
