### PR TITLE
Polish dashboard, settings, and admin page headers

### DIFF
--- a/apps/web/app/admin/background_jobs/page.tsx
+++ b/apps/web/app/admin/background_jobs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import BackgroundJobs from "@/components/admin/BackgroundJobs";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Settings } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -10,6 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function BackgroundJobsPage() {
-  return <BackgroundJobs />;
+export default async function BackgroundJobsPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Settings className="size-5" />}
+        title={t("admin.background_jobs.background_jobs")}
+      />
+      <BackgroundJobs />
+    </div>
+  );
 }

--- a/apps/web/app/admin/overview/page.tsx
+++ b/apps/web/app/admin/overview/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import BasicStats from "@/components/admin/BasicStats";
 import ServiceConnections from "@/components/admin/ServiceConnections";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Activity } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -11,11 +13,19 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function AdminOverviewPage() {
+export default async function AdminOverviewPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
-    <div className="flex flex-col gap-6">
-      <BasicStats />
-      <ServiceConnections />
+    <div className="space-y-6">
+      <PageHeader
+        icon={<Activity className="size-5" />}
+        title={t("admin.server_stats.server_stats")}
+      />
+      <div className="flex flex-col gap-6">
+        <BasicStats />
+        <ServiceConnections />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/admin/users/page.tsx
+++ b/apps/web/app/admin/users/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import UserList from "@/components/admin/UserList";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Users } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -10,6 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function AdminUsersPage() {
-  return <UserList />;
+export default async function AdminUsersPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Users className="size-5" />}
+        title={t("admin.users_list.users_list")}
+      />
+      <UserList />
+    </div>
+  );
 }

--- a/apps/web/app/dashboard/archive/page.tsx
+++ b/apps/web/app/dashboard/archive/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
+import { PageHeader } from "@/components/layout/page-header";
 import InfoTooltip from "@/components/ui/info-tooltip";
 import { useTranslation } from "@/lib/i18n/server";
+import { Archive as ArchiveIcon } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -11,21 +13,22 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-function header() {
-  return (
-    <div className="flex gap-2">
-      <p className="text-2xl">🗄️ Archive</p>
-      <InfoTooltip size={17} className="my-auto" variant="explain">
-        <p>Archived bookmarks won&apos;t appear in the homepage</p>
-      </InfoTooltip>
-    </div>
-  );
-}
-
 export default async function ArchivedBookmarkPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
     <Bookmarks
-      header={header()}
+      header={
+        <PageHeader
+          icon={<ArchiveIcon className="size-5" />}
+          title={t("common.archive")}
+          actions={
+            <InfoTooltip size={17} className="my-auto" variant="explain">
+              <p>Archived bookmarks won&apos;t appear in the homepage</p>
+            </InfoTooltip>
+          }
+        />
+      }
       query={{ archived: true }}
       showDivider={true}
       showEditorCard={true}

--- a/apps/web/app/dashboard/bookmarks/page.tsx
+++ b/apps/web/app/dashboard/bookmarks/page.tsx
@@ -1,10 +1,24 @@
 import React from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
+import { useTranslation } from "@/lib/i18n/server";
+import { Home } from "lucide-react";
 
 export default async function BookmarksPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
     <div>
-      <Bookmarks query={{ archived: false }} showEditorCard={true} />
+      <Bookmarks
+        header={
+          <PageHeader
+            icon={<Home className="size-5" />}
+            title={t("common.home")}
+          />
+        }
+        query={{ archived: false }}
+        showEditorCard={true}
+      />
     </div>
   );
 }

--- a/apps/web/app/dashboard/cleanups/page.tsx
+++ b/apps/web/app/dashboard/cleanups/page.tsx
@@ -1,4 +1,5 @@
 import { TagDuplicationDetection } from "@/components/dashboard/cleanups/TagDuplicationDetention";
+import { PageHeader } from "@/components/layout/page-header";
 import { Separator } from "@/components/ui/separator";
 import { useTranslation } from "@/lib/i18n/server";
 import { Paintbrush, Tags } from "lucide-react";
@@ -8,18 +9,19 @@ export default async function Cleanups() {
   const { t } = await useTranslation();
 
   return (
-    <div className="flex flex-col gap-y-4 rounded-md border bg-background p-4">
-      <span className="flex items-center gap-1 text-2xl">
-        <Paintbrush />
-        {t("cleanups.cleanups")}
-      </span>
-      <Separator />
-      <span className="flex items-center gap-1 text-xl">
-        <Tags />
-        {t("cleanups.duplicate_tags.title")}
-      </span>
-      <Separator />
-      <TagDuplicationDetection />
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Paintbrush className="size-5" />}
+        title={t("cleanups.cleanups")}
+      />
+      <div className="space-y-4 rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
+        <div className="flex items-center gap-1 text-xl">
+          <Tags />
+          {t("cleanups.duplicate_tags.title")}
+        </div>
+        <Separator />
+        <TagDuplicationDetection />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/dashboard/favourites/page.tsx
+++ b/apps/web/app/dashboard/favourites/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Star } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -11,12 +13,15 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function FavouritesBookmarkPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
     <Bookmarks
       header={
-        <div className="flex items-center justify-between">
-          <p className="text-2xl">⭐️ Favourites</p>
-        </div>
+        <PageHeader
+          icon={<Star className="size-5" />}
+          title={t("lists.favourites")}
+        />
       }
       query={{ favourited: true }}
       showDivider={true}

--- a/apps/web/app/dashboard/highlights/page.tsx
+++ b/apps/web/app/dashboard/highlights/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import AllHighlights from "@/components/dashboard/highlights/AllHighlights";
-import { Separator } from "@/components/ui/separator";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
 import { api } from "@/server/api/client";
 import { Highlighter } from "lucide-react";
@@ -18,13 +18,14 @@ export default async function HighlightsPage() {
   const { t } = await useTranslation();
   const highlights = await api.highlights.getAll({});
   return (
-    <div className="flex flex-col gap-8 rounded-md border bg-background p-4">
-      <span className="flex items-center gap-1 text-2xl">
-        <Highlighter className="size-6" />
-        {t("common.highlights")}
-      </span>
-      <Separator />
-      <AllHighlights highlights={highlights} />
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Highlighter className="size-5" />}
+        title={t("common.highlights")}
+      />
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
+        <AllHighlights highlights={highlights} />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/dashboard/lists/page.tsx
+++ b/apps/web/app/dashboard/lists/page.tsx
@@ -1,7 +1,8 @@
 import AllListsView from "@/components/dashboard/lists/AllListsView";
-import { Separator } from "@/components/ui/separator";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
 import { api } from "@/server/api/client";
+import { ClipboardList } from "lucide-react";
 
 export default async function ListsPage() {
   // oxlint-disable-next-line rules-of-hooks
@@ -9,10 +10,14 @@ export default async function ListsPage() {
   const lists = await api.lists.list();
 
   return (
-    <div className="flex flex-col gap-3 rounded-md border bg-background p-4">
-      <p className="text-2xl">📋 {t("lists.all_lists")}</p>
-      <Separator />
-      <AllListsView initialData={lists.lists} />
+    <div className="space-y-4">
+      <PageHeader
+        icon={<ClipboardList className="size-5" />}
+        title={t("lists.all_lists")}
+      />
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
+        <AllListsView initialData={lists.lists} />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/dashboard/search/page.tsx
+++ b/apps/web/app/dashboard/search/page.tsx
@@ -3,9 +3,12 @@
 import { Suspense, useEffect } from "react";
 import BookmarksGrid from "@/components/dashboard/bookmarks/BookmarksGrid";
 import BookmarksGridSkeleton from "@/components/dashboard/bookmarks/BookmarksGridSkeleton";
+import { PageHeader } from "@/components/layout/page-header";
 import { useBookmarkSearch } from "@/lib/hooks/bookmark-search";
+import { useTranslation } from "@/lib/i18n/client";
 import { useInSearchPageStore } from "@/lib/store/useInSearchPageStore";
 import { useSortOrderStore } from "@/lib/store/useSortOrderStore";
+import { Search as SearchIcon } from "lucide-react";
 
 function SearchComp() {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
@@ -14,6 +17,7 @@ function SearchComp() {
   const { setInSearchPage } = useInSearchPageStore();
 
   const { setSortOrder } = useSortOrderStore();
+  const { t } = useTranslation();
 
   useEffect(() => {
     // also see related cleanup code in SortOrderToggle.tsx
@@ -26,7 +30,11 @@ function SearchComp() {
   }, [setInSearchPage]);
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        icon={<SearchIcon className="size-5" />}
+        title={t("common.search")}
+      />
       {data ? (
         <BookmarksGrid
           hasNextPage={hasNextPage}

--- a/apps/web/app/settings/ai/page.tsx
+++ b/apps/web/app/settings/ai/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import AISettings from "@/components/settings/AISettings";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Sparkles } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -10,6 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function AISettingsPage() {
-  return <AISettings />;
+export default async function AISettingsPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Sparkles className="size-5" />}
+        title={t("settings.ai.ai_settings")}
+      />
+      <AISettings />
+    </div>
+  );
 }

--- a/apps/web/app/settings/api-keys/page.tsx
+++ b/apps/web/app/settings/api-keys/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import ApiKeySettings from "@/components/settings/ApiKeySettings";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { KeyRound } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -11,9 +13,17 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function ApiKeysPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
-    <div className="rounded-md border bg-background p-4">
-      <ApiKeySettings />
+    <div className="space-y-4">
+      <PageHeader
+        icon={<KeyRound className="size-5" />}
+        title={t("settings.api_keys.api_keys")}
+      />
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
+        <ApiKeySettings />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/settings/assets/page.tsx
+++ b/apps/web/app/settings/assets/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { PageHeader } from "@/components/layout/page-header";
 import { ActionButton } from "@/components/ui/action-button";
 import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,7 @@ import { ASSET_TYPE_TO_ICON } from "@/lib/attachments";
 import { useTranslation } from "@/lib/i18n/client";
 import { api } from "@/lib/trpc";
 import { formatBytes } from "@/lib/utils";
-import { ExternalLink, Trash2 } from "lucide-react";
+import { ExternalLink, Image as ImageIcon, Trash2 } from "lucide-react";
 
 import { useDetachBookmarkAsset } from "@karakeep/shared-react/hooks/assets";
 import { getAssetUrl } from "@karakeep/shared/utils/assetUtils";
@@ -65,11 +66,12 @@ export default function AssetsSettingsPage() {
   }
 
   return (
-    <div className="rounded-md border bg-background p-4">
-      <div className="flex flex-col gap-2">
-        <div className="mb-2 text-lg font-medium">
-          {t("settings.manage_assets.manage_assets")}
-        </div>
+    <div className="space-y-4">
+      <PageHeader
+        icon={<ImageIcon className="size-5" />}
+        title={t("settings.manage_assets.manage_assets")}
+      />
+      <div className="flex flex-col gap-2 rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
         {assets.length === 0 && (
           <p className="rounded-md bg-muted p-2 text-sm text-muted-foreground">
             {t("settings.manage_assets.no_assets")}

--- a/apps/web/app/settings/broken-links/page.tsx
+++ b/apps/web/app/settings/broken-links/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PageHeader } from "@/components/layout/page-header";
 import { ActionButton } from "@/components/ui/action-button";
 import { FullPageSpinner } from "@/components/ui/full-page-spinner";
 import {
@@ -11,7 +12,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { toast } from "@/components/ui/use-toast";
-import { RefreshCw, Trash2 } from "lucide-react";
+import { Link as LinkIcon, RefreshCw, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -58,13 +59,12 @@ export default function BrokenLinksPage() {
     });
 
   return (
-    <div className="rounded-md border bg-background p-4">
-      <div className="flex items-center justify-between">
-        <div className="mb-2 text-lg font-medium">
-          {t("settings.broken_links.broken_links")}
-        </div>
-      </div>
-      <div className="mt-2">
+    <div className="space-y-4">
+      <PageHeader
+        icon={<LinkIcon className="size-5" />}
+        title={t("settings.broken_links.broken_links")}
+      />
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
         {isPending && <FullPageSpinner />}
         {!isPending && data && data.bookmarks.length == 0 && (
           <p className="rounded-md bg-muted p-2 text-sm text-muted-foreground">

--- a/apps/web/app/settings/feeds/page.tsx
+++ b/apps/web/app/settings/feeds/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
-import FeedSettings from "@/components/settings/FeedSettings";
+import FeedSettings, { FeedsEditorDialog } from "@/components/settings/FeedSettings";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Rss } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -10,6 +12,17 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function FeedSettingsPage() {
-  return <FeedSettings />;
+export default async function FeedSettingsPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Rss className="size-5" />}
+        title={t("settings.feeds.rss_subscriptions")}
+        actions={<FeedsEditorDialog />}
+      />
+      <FeedSettings />
+    </div>
+  );
 }

--- a/apps/web/app/settings/import/page.tsx
+++ b/apps/web/app/settings/import/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import ImportExport from "@/components/settings/ImportExport";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Download } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -10,6 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function ImportSettingsPage() {
-  return <ImportExport />;
+export default async function ImportSettingsPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Download className="size-5" />}
+        title={t("settings.import.import_export")}
+      />
+      <ImportExport />
+    </div>
+  );
 }

--- a/apps/web/app/settings/info/page.tsx
+++ b/apps/web/app/settings/info/page.tsx
@@ -3,7 +3,9 @@ import { ChangePassword } from "@/components/settings/ChangePassword";
 import { DeleteAccount } from "@/components/settings/DeleteAccount";
 import UserDetails from "@/components/settings/UserDetails";
 import UserOptions from "@/components/settings/UserOptions";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { User } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -14,12 +16,17 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function InfoPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
-    <div className="flex flex-col gap-4">
-      <UserDetails />
-      <ChangePassword />
-      <UserOptions />
-      <DeleteAccount />
+    <div className="space-y-4">
+      <PageHeader icon={<User className="size-5" />} title={t("settings.info.user_info")} />
+      <div className="flex flex-col gap-4">
+        <UserDetails />
+        <ChangePassword />
+        <UserOptions />
+        <DeleteAccount />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/settings/rules/page.tsx
+++ b/apps/web/app/settings/rules/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import { RuleEditor } from "@/components/dashboard/rules/RuleEngineRuleEditor";
 import RuleList from "@/components/dashboard/rules/RuleEngineRuleList";
 import { Button } from "@/components/ui/button";
@@ -8,7 +9,7 @@ import { FullPageSpinner } from "@/components/ui/full-page-spinner";
 import { useTranslation } from "@/lib/i18n/client";
 import { api } from "@/lib/trpc";
 import { Tooltip, TooltipContent, TooltipTrigger } from "components/ui/tooltip";
-import { FlaskConical, PlusCircle } from "lucide-react";
+import { FlaskConical, GitBranch, PlusCircle } from "lucide-react";
 
 import { RuleEngineRule } from "@karakeep/shared/types/rules";
 
@@ -44,10 +45,11 @@ export default function RulesSettingsPage() {
   };
 
   return (
-    <div className="rounded-md border bg-background p-4">
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center justify-between">
-          <span className="flex items-center gap-2 text-lg font-medium">
+    <div className="space-y-4">
+      <PageHeader
+        icon={<GitBranch className="size-5" />}
+        title={
+          <span className="flex items-center gap-2">
             {t("settings.rules.rules")}
             <Tooltip>
               <TooltipTrigger className="text-muted-foreground">
@@ -58,30 +60,34 @@ export default function RulesSettingsPage() {
               </TooltipContent>
             </Tooltip>
           </span>
+        }
+        description={t("settings.rules.description")}
+        actions={
           <Button onClick={handleCreateRule} variant="default">
             <PlusCircle className="mr-2 h-4 w-4" />
             {t("settings.rules.ceate_rule")}
           </Button>
-        </div>
-        <p className="text-sm italic text-muted-foreground">
-          {t("settings.rules.description")}
-        </p>
-        {!rules || isLoading ? (
-          <FullPageSpinner />
-        ) : (
-          <RuleList
-            rules={rules.rules}
-            onEditRule={(r) => setEditingRule(r)}
-            onDeleteRule={handleDeleteRule}
-          />
-        )}
-        <div className="lg:col-span-7">
-          {editingRule && (
-            <RuleEditor
-              rule={editingRule}
-              onCancel={() => setEditingRule(null)}
+        }
+      />
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
+        <div className="flex flex-col gap-2">
+          {!rules || isLoading ? (
+            <FullPageSpinner />
+          ) : (
+            <RuleList
+              rules={rules.rules}
+              onEditRule={(r) => setEditingRule(r)}
+              onDeleteRule={handleDeleteRule}
             />
           )}
+          <div className="lg:col-span-7">
+            {editingRule && (
+              <RuleEditor
+                rule={editingRule}
+                onCancel={() => setEditingRule(null)}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/app/settings/stats/page.tsx
+++ b/apps/web/app/settings/stats/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
@@ -184,14 +185,11 @@ export default function StatsPage() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold">
-            {t("settings.stats.usage_statistics")}
-          </h1>
-          <p className="text-muted-foreground">
-            {t("settings.stats.insights_description")}
-          </p>
-        </div>
+        <PageHeader
+          icon={<BarChart3 className="size-5" />}
+          title={t("settings.stats.usage_statistics")}
+          description={t("settings.stats.insights_description")}
+        />
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           {Array.from({ length: 8 }).map((_, i) => (
@@ -222,19 +220,20 @@ export default function StatsPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold">
-          {t("settings.stats.usage_statistics")}
-        </h1>
-        <p className="text-muted-foreground">
-          Insights into your bookmarking habits and collection
-          {userSettings?.timezone && userSettings.timezone !== "UTC" && (
-            <span className="block text-sm">
-              Times shown in {userSettings.timezone} timezone
-            </span>
-          )}
-        </p>
-      </div>
+      <PageHeader
+        icon={<BarChart3 className="size-5" />}
+        title={t("settings.stats.usage_statistics")}
+        description={
+          <>
+            {t("settings.stats.insights_description")}
+            {userSettings?.timezone && userSettings.timezone !== "UTC" && (
+              <span className="block text-xs text-muted-foreground">
+                Times shown in {userSettings.timezone} timezone
+              </span>
+            )}
+          </>
+        }
+      />
 
       {/* Overview Stats */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">

--- a/apps/web/app/settings/subscription/page.tsx
+++ b/apps/web/app/settings/subscription/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import SubscriptionSettings from "@/components/settings/SubscriptionSettings";
 import { QuotaProgress } from "@/components/subscription/QuotaProgress";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { CreditCard } from "lucide-react";
 
 import serverConfig from "@karakeep/shared/config";
 
@@ -19,10 +21,18 @@ export default async function SubscriptionPage() {
     redirect("/settings");
   }
 
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
   return (
-    <div className="flex flex-col gap-4">
-      <SubscriptionSettings />
-      <QuotaProgress />
+    <div className="space-y-4">
+      <PageHeader
+        icon={<CreditCard className="size-5" />}
+        title={t("settings.subscription.subscription")}
+      />
+      <div className="flex flex-col gap-4">
+        <SubscriptionSettings />
+        <QuotaProgress />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/settings/webhooks/page.tsx
+++ b/apps/web/app/settings/webhooks/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import WebhookSettings from "@/components/settings/WebhookSettings";
+import { PageHeader } from "@/components/layout/page-header";
 import { useTranslation } from "@/lib/i18n/server";
+import { Webhook } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
   // oxlint-disable-next-line rules-of-hooks
@@ -10,6 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function WebhookSettingsPage() {
-  return <WebhookSettings />;
+export default async function WebhookSettingsPage() {
+  // oxlint-disable-next-line rules-of-hooks
+  const { t } = await useTranslation();
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        icon={<Webhook className="size-5" />}
+        title={t("settings.webhooks.webhooks")}
+      />
+      <WebhookSettings />
+    </div>
+  );
 }

--- a/apps/web/components/admin/AdminCard.tsx
+++ b/apps/web/components/admin/AdminCard.tsx
@@ -8,7 +8,12 @@ export function AdminCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className={cn("rounded-md border bg-background p-4", className)}>
+    <div
+      className={cn(
+        "rounded-xl border bg-card p-4 text-card-foreground shadow-sm",
+        className,
+      )}
+    >
       {children}
     </div>
   );

--- a/apps/web/components/admin/BasicStats.tsx
+++ b/apps/web/components/admin/BasicStats.tsx
@@ -60,7 +60,10 @@ function StatsSkeleton() {
       <div className="mb-4 h-7 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
       <div className="flex flex-col gap-4 sm:flex-row">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="rounded-md border bg-background p-4 sm:w-1/4">
+          <div
+            key={i}
+            className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm sm:w-1/4"
+          >
             <div className="mb-2 h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
             <div className="h-9 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
           </div>
@@ -86,13 +89,13 @@ export default function BasicStats() {
         {t("admin.server_stats.server_stats")}
       </div>
       <div className="flex flex-col gap-4 sm:flex-row">
-        <div className="rounded-md border bg-background p-4 sm:w-1/4">
+        <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm sm:w-1/4">
           <div className="text-sm font-medium text-gray-400">
             {t("admin.server_stats.total_users")}
           </div>
           <div className="text-3xl font-semibold">{serverStats.numUsers}</div>
         </div>
-        <div className="rounded-md border bg-background p-4 sm:w-1/4">
+        <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm sm:w-1/4">
           <div className="text-sm font-medium text-gray-400">
             {t("admin.server_stats.total_bookmarks")}
           </div>
@@ -100,7 +103,7 @@ export default function BasicStats() {
             {serverStats.numBookmarks}
           </div>
         </div>
-        <div className="rounded-md border bg-background p-4 sm:w-1/4">
+        <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm sm:w-1/4">
           <div className="text-sm font-medium text-gray-400">
             {t("admin.server_stats.server_version")}
           </div>

--- a/apps/web/components/dashboard/tags/AllTagsView.tsx
+++ b/apps/web/components/dashboard/tags/AllTagsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect } from "react";
+import { PageHeader } from "@/components/layout/page-header";
 import { ActionButton } from "@/components/ui/action-button";
 import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
 import { Badge } from "@/components/ui/badge";
@@ -256,27 +257,30 @@ export default function AllTagsView() {
         />
       )}
       <div className="flex flex-col gap-4">
-        <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-3">
-          <span className="text-2xl">{t("tags.all_tags")}</span>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <CreateTagModal />
-            <BulkTagAction />
-            <Toggle
-              variant="outline"
-              className="bg-background"
-              aria-label={t("tags.drag_and_drop_merging")}
-              pressed={draggingEnabled}
-              onPressedChange={toggleDraggingEnabled}
-              disabled={isBulkEditEnabled}
-            >
-              <Combine className="mr-2 size-4" />
-              {t("tags.drag_and_drop_merging")}
-              <InfoTooltip size={15} className="my-auto ml-2" variant="explain">
-                <p>{t("tags.drag_and_drop_merging_info")}</p>
-              </InfoTooltip>
-            </Toggle>
-          </div>
-        </div>
+        <PageHeader
+          icon={<Tag className="size-5" />}
+          title={t("tags.all_tags")}
+          actions={
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <CreateTagModal />
+              <BulkTagAction />
+              <Toggle
+                variant="outline"
+                className="bg-background"
+                aria-label={t("tags.drag_and_drop_merging")}
+                pressed={draggingEnabled}
+                onPressedChange={toggleDraggingEnabled}
+                disabled={isBulkEditEnabled}
+              >
+                <Combine className="mr-2 size-4" />
+                {t("tags.drag_and_drop_merging")}
+                <InfoTooltip size={15} className="my-auto ml-2" variant="explain">
+                  <p>{t("tags.drag_and_drop_merging_info")}</p>
+                </InfoTooltip>
+              </Toggle>
+            </div>
+          }
+        />
         <div className="flex flex-col gap-3">
           <div className="flex w-full items-center gap-2">
             <div className="flex-1">

--- a/apps/web/components/layout/page-header.tsx
+++ b/apps/web/components/layout/page-header.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  icon,
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        {icon ? (
+          <div className="flex size-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+            {icon}
+          </div>
+        ) : null}
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold leading-none tracking-tight text-foreground">
+            {title}
+          </h1>
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </div>
+      </div>
+      {actions ? (
+        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/settings/AISettings.tsx
+++ b/apps/web/components/settings/AISettings.tsx
@@ -349,7 +349,7 @@ export default function AISettings() {
   const { t } = useTranslation();
   return (
     <>
-      <div className="rounded-md border bg-background p-4">
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
         <div className="mb-2 flex flex-col gap-3">
           <div className="w-full text-2xl font-medium sm:w-1/3">
             {t("settings.ai.ai_settings")}
@@ -357,7 +357,7 @@ export default function AISettings() {
           <TaggingRules />
         </div>
       </div>
-      <div className="mt-4 rounded-md border bg-background p-4">
+      <div className="mt-4 rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
         <PromptDemo />
       </div>
     </>

--- a/apps/web/components/settings/FeedSettings.tsx
+++ b/apps/web/components/settings/FeedSettings.tsx
@@ -459,41 +459,33 @@ export default function FeedSettings() {
   const { t } = useTranslation();
   const { data: feeds, isLoading } = api.feeds.list.useQuery();
   return (
-    <>
-      <div className="rounded-md border bg-background p-4">
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between">
-            <span className="flex items-center gap-2 text-lg font-medium">
-              {t("settings.feeds.rss_subscriptions")}
-            </span>
-            <FeedsEditorDialog />
-          </div>
-          {isLoading && <FullPageSpinner />}
-          {feeds && feeds.feeds.length == 0 && (
-            <p className="rounded-md bg-muted p-2 text-sm text-muted-foreground">
-              You don&apos;t have any RSS subscriptions yet.
-            </p>
-          )}
-          {feeds && feeds.feeds.length > 0 && (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("common.name")}</TableHead>
-                  <TableHead>{t("common.url")}</TableHead>
-                  <TableHead>Last Fetch</TableHead>
-                  <TableHead>Last Status</TableHead>
-                  <TableHead>{t("common.actions")}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {feeds.feeds.map((feed) => (
-                  <FeedRow key={feed.id} feed={feed} />
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </div>
+    <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
+      <div className="flex flex-col gap-2">
+        {isLoading && <FullPageSpinner />}
+        {feeds && feeds.feeds.length == 0 && (
+          <p className="rounded-md bg-muted p-2 text-sm text-muted-foreground">
+            You don&apos;t have any RSS subscriptions yet.
+          </p>
+        )}
+        {feeds && feeds.feeds.length > 0 && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("common.name")}</TableHead>
+                <TableHead>{t("common.url")}</TableHead>
+                <TableHead>Last Fetch</TableHead>
+                <TableHead>Last Status</TableHead>
+                <TableHead>{t("common.actions")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {feeds.feeds.map((feed) => (
+                <FeedRow key={feed.id} feed={feed} />
+              ))}
+            </TableBody>
+          </Table>
+        )}
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/components/settings/ImportExport.tsx
+++ b/apps/web/components/settings/ImportExport.tsx
@@ -285,7 +285,7 @@ export default function ImportExport() {
   const { t } = useTranslation();
   return (
     <div className="space-y-3">
-      <div className="rounded-md border bg-background p-4">
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
         <div className="flex w-full flex-col gap-6">
           <div>
             <p className="mb-4 text-lg font-medium">
@@ -296,7 +296,7 @@ export default function ImportExport() {
         </div>
       </div>
 
-      <div className="rounded-md border bg-background p-4">
+      <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
         <ImportSessionsSection />
       </div>
     </div>

--- a/apps/web/components/settings/WebhookSettings.tsx
+++ b/apps/web/components/settings/WebhookSettings.tsx
@@ -482,7 +482,7 @@ export default function WebhookSettings() {
   const { t } = useTranslation();
   const { data: webhooks, isLoading } = api.webhooks.list.useQuery();
   return (
-    <div className="rounded-md border bg-background p-4">
+    <div className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm">
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <span className="flex items-center gap-2 text-lg font-medium">


### PR DESCRIPTION
## Summary
- add a shared `PageHeader` component and wire it into the dashboard, settings, and admin shells
- refresh the cards/containers used by dashboard utilities, settings modules, and admin widgets so they share the same design language
- update tag management and feed management flows to adopt the new header/actions pattern for consistency

## Testing
- pnpm lint --filter @karakeep/web

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9dacccb4832cab25ecec10ae3288)