### PR TITLE
feat(mobile): Add server version display to settings page

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/settings.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/settings.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { ActivityIndicator, Pressable, Switch, View } from "react-native";
 import { Slider } from "react-native-awesome-slider";
 import { useSharedValue } from "react-native-reanimated";
+import Constants from "expo-constants";
 import { Link } from "expo-router";
 import { Button } from "@/components/ui/Button";
 import ChevronRight from "@/components/ui/ChevronRight";
@@ -9,6 +10,7 @@ import CustomSafeAreaView from "@/components/ui/CustomSafeAreaView";
 import { Divider } from "@/components/ui/Divider";
 import PageTitle from "@/components/ui/PageTitle";
 import { Text } from "@/components/ui/Text";
+import { useServerVersion } from "@/lib/hooks";
 import { useSession } from "@/lib/session";
 import useAppSettings from "@/lib/settings";
 import { api } from "@/lib/trpc";
@@ -30,6 +32,11 @@ export default function Dashboard() {
   }, [settings]);
 
   const { data, error, isLoading } = api.users.whoami.useQuery();
+  const {
+    data: serverVersion,
+    isLoading: isServerVersionLoading,
+    error: serverVersionError,
+  } = useServerVersion();
 
   if (error?.data?.code === "UNAUTHORIZED") {
     logout();
@@ -141,6 +148,19 @@ export default function Dashboard() {
         >
           <Text>Log Out</Text>
         </Button>
+        <View className="mt-4 w-full gap-1">
+          <Text className="text-center text-sm text-muted-foreground">
+            App Version: {Constants.expoConfig?.version ?? "unknown"}
+          </Text>
+          <Text className="text-center text-sm text-muted-foreground">
+            Server Version:{" "}
+            {isServerVersionLoading
+              ? "Loading..."
+              : serverVersionError
+                ? "unavailable"
+                : (serverVersion ?? "unknown")}
+          </Text>
+        </View>
       </View>
     </CustomSafeAreaView>
   );

--- a/apps/mobile/lib/hooks.ts
+++ b/apps/mobile/lib/hooks.ts
@@ -1,4 +1,5 @@
 import { ImageURISource } from "react-native";
+import { useQuery } from "@tanstack/react-query";
 
 import useAppSettings from "./settings";
 import { buildApiHeaders } from "./utils";
@@ -9,4 +10,26 @@ export function useAssetUrl(assetId: string): ImageURISource {
     uri: `${settings.address}/api/assets/${assetId}`,
     headers: buildApiHeaders(settings.apiKey, settings.customHeaders),
   };
+}
+
+export function useServerVersion() {
+  const { settings } = useAppSettings();
+
+  return useQuery({
+    queryKey: ["serverVersion", settings.address],
+    queryFn: async () => {
+      const response = await fetch(`${settings.address}/api/version`, {
+        headers: buildApiHeaders(settings.apiKey, settings.customHeaders),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch server version: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.version as string;
+    },
+    enabled: !!settings.address,
+    staleTime: 1000 * 60 * 5, // Cache for 5 minutes
+  });
 }


### PR DESCRIPTION
- Created useServerVersion hook to fetch server version from /api/version
- Display both app version (from expo-constants) and server version
- Added version info at the bottom of settings page
- Server version shows loading state and handles errors gracefully