### PR TITLE
Use the Ollama generate endpoint instead of chat

### DIFF
--- a/packages/shared/inference.ts
+++ b/packages/shared/inference.ts
@@ -292,7 +292,7 @@ class OllamaInferenceClient implements InferenceClient {
         num_ctx: this.config.contextLength,
         num_predict: this.config.maxOutputTokens,
       },
-      prompt: prompt, 
+      prompt: prompt,
       images: image ? [image] : undefined,
     });
 


### PR DESCRIPTION
Ollama has two API endpoints for text generation. There is a chat endpoint for interactive and interactive chat like generation of text and there is a generate endpoint that is used one one-shot prompts, such as summarization tasks and similar things.

Karakeep used the chat endpoint that resulted in odd summaries. This commit makes karakeep use the generate endpoint instead, which results in better and more compact summaries.