### PR TITLE
fix(mobile): fix Android text clipping in search and tags

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/index.tsx
@@ -99,7 +99,10 @@ export default function Home() {
                   <Search size={16} color={styles?.color?.toString()} />
                 )}
               />
-              <Text className="text-muted">Search</Text>
+              {/* Trailing space fixes Android text clipping: https://github.com/facebook/react-native/issues/53286 */}
+              <Text className="text-muted">
+                Search{Platform.OS === "android" ? " " : ""}
+              </Text>
             </Pressable>
           </View>
         }

--- a/apps/mobile/components/bookmarks/TagPill.tsx
+++ b/apps/mobile/components/bookmarks/TagPill.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from "react-native";
+import { Platform, Text, View } from "react-native";
 import { Link } from "expo-router";
 
 import { ZBookmarkTags } from "@karakeep/shared/types/tags";
@@ -10,6 +10,7 @@ export default function TagPill({
   tag: ZBookmarkTags;
   clickable?: boolean;
 }) {
+  // Trailing space fixes Android text clipping: https://github.com/facebook/react-native/issues/53286
   return (
     <View
       key={tag.id}
@@ -18,9 +19,13 @@ export default function TagPill({
       {clickable ? (
         <Link className="text-foreground" href={`dashboard/tags/${tag.id}`}>
           {tag.name}
+          {Platform.OS === "android" ? " " : ""}
         </Link>
       ) : (
-        <Text className="text-foreground">{tag.name}</Text>
+        <Text className="text-foreground">
+          {tag.name}
+          {Platform.OS === "android" ? " " : ""}
+        </Text>
       )}
     </View>
   );


### PR DESCRIPTION
Add trailing space workaround for React Native Android text clipping bug where last characters are cut off in rounded containers.

<img width="1096" height="2560" alt="image" src="https://github.com/user-attachments/assets/0221da27-aa38-48b2-964a-f079c6d229b1" />

The fix only applies on Android (Platform.OS === "android"), leaving iOS unchanged.

See: https://github.com/facebook/react-native/issues/53286

🤖 Generated with [Claude Code](https://claude.com/claude-code)