### PR TITLE
fix(mobile): fix Save button not working in Server Address screen

### DIFF
--- a/apps/mobile/app/server-address.tsx
+++ b/apps/mobile/app/server-address.tsx
@@ -94,6 +94,7 @@ export default function ServerAddress() {
       <Stack.Screen
         options={{
           title: "Server Address",
+          headerTransparent: false,
           headerRight: () => (
             <Pressable onPress={handleSave}>
               <Text className="text-base font-semibold text-blue-500">


### PR DESCRIPTION
## Summary
- Fix Save button in Edit Server Address screen not responding to taps on Android
- The issue was caused by `headerTransparent: true` being inherited from the default screen options, which breaks touch handling for header buttons
- Setting `headerTransparent: false` explicitly fixes the issue

## Test plan
- [x] Open the mobile app and navigate to Settings > Server Address
- [x] Verify the Save button in the header now responds to taps
- [x] Verify changes are saved correctly when pressing Save

🤖 Generated with [Claude Code](https://claude.com/claude-code)