### PR TITLE
fix: stop theme flashes with cloudflare rocket loader

### DIFF
--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -5,7 +5,11 @@ import * as React from "react";
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider scriptProps={{ "data-cfasync": "false" }} {...props}>
+      {children}
+    </NextThemesProvider>
+  );
 }
 
 export function useToggleTheme() {


### PR DESCRIPTION
Fixes light mode flashes on page load when using Cloudflare Rocket Loader as per the next-theme docs: https://github.com/pacocoursey/next-themes#using-with-cloudflare-rocket-loader