### PR TITLE
feat: Add retry buttons for pending bookmarks in admin panel

### DIFF
--- a/apps/web/components/admin/BackgroundJobs.tsx
+++ b/apps/web/components/admin/BackgroundJobs.tsx
@@ -340,6 +340,13 @@ function useJobActions() {
   return {
     crawlActions: [
       {
+        label: t("admin.background_jobs.actions.recrawl_pending_links_only"),
+        onClick: () =>
+          recrawlLinks({ crawlStatus: "pending", runInference: true }),
+        variant: "secondary" as const,
+        loading: isRecrawlPending,
+      },
+      {
         label: t("admin.background_jobs.actions.recrawl_failed_links_only"),
         onClick: () =>
           recrawlLinks({ crawlStatus: "failure", runInference: true }),
@@ -361,6 +368,15 @@ function useJobActions() {
     inferenceActions: [
       {
         label: t(
+          "admin.background_jobs.actions.regenerate_ai_tags_for_pending_bookmarks_only",
+        ),
+        onClick: () =>
+          reRunInferenceOnAllBookmarks({ type: "tag", status: "pending" }),
+        variant: "secondary" as const,
+        loading: isInferencePending,
+      },
+      {
+        label: t(
           "admin.background_jobs.actions.regenerate_ai_tags_for_failed_bookmarks_only",
         ),
         onClick: () =>
@@ -374,6 +390,18 @@ function useJobActions() {
         ),
         onClick: () =>
           reRunInferenceOnAllBookmarks({ type: "tag", status: "all" }),
+        loading: isInferencePending,
+      },
+      {
+        label: t(
+          "admin.background_jobs.actions.regenerate_ai_summaries_for_pending_bookmarks_only",
+        ),
+        onClick: () =>
+          reRunInferenceOnAllBookmarks({
+            type: "summarize",
+            status: "pending",
+          }),
+        variant: "secondary" as const,
         loading: isInferencePending,
       },
       {

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -555,11 +555,14 @@
         }
       },
       "actions": {
+        "recrawl_pending_links_only": "Recrawl Pending Links Only",
         "recrawl_failed_links_only": "Recrawl Failed Links Only",
         "recrawl_all_links": "Recrawl All Links",
         "without_inference": "Without Inference",
+        "regenerate_ai_tags_for_pending_bookmarks_only": "Regenerate AI Tags for Pending Bookmarks Only",
         "regenerate_ai_tags_for_failed_bookmarks_only": "Regenerate AI Tags for Failed Bookmarks Only",
         "regenerate_ai_tags_for_all_bookmarks": "Regenerate AI Tags for All Bookmarks",
+        "regenerate_ai_summaries_for_pending_bookmarks_only": "Regenerate AI Summaries for Pending Bookmarks Only",
         "regenerate_ai_summaries_for_failed_bookmarks_only": "Regenerate AI Summaries for Failed Bookmarks Only",
         "regenerate_ai_summaries_for_all_bookmarks": "Regenerate AI Summaries for All Bookmarks",
         "reindex_all_bookmarks": "Reindex All Bookmarks",

--- a/packages/trpc/routers/admin.ts
+++ b/packages/trpc/routers/admin.ts
@@ -201,7 +201,7 @@ export const adminAppRouter = router({
   recrawlLinks: adminProcedure
     .input(
       z.object({
-        crawlStatus: z.enum(["success", "failure", "all"]),
+        crawlStatus: z.enum(["success", "failure", "pending", "all"]),
         runInference: z.boolean(),
       }),
     )
@@ -255,7 +255,7 @@ export const adminAppRouter = router({
     .input(
       z.object({
         type: z.enum(["tag", "summarize"]),
-        status: z.enum(["success", "failure", "all"]),
+        status: z.enum(["success", "failure", "pending", "all"]),
       }),
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
This commit adds the ability to retry pending bookmarks for both crawling
and inference operations in the admin panel.

Changes:
- Backend: Updated recrawlLinks mutation to accept "pending" status
- Backend: Updated reRunInferenceOnAllBookmarks mutation to accept "pending" status
- Frontend: Added buttons to retry pending crawls
- Frontend: Added buttons to retry pending tagging operations
- Frontend: Added buttons to retry pending summarization operations
- Translations: Added English translations for new button labels

The new buttons follow the same pattern as the existing "failed" and "all"
retry buttons, allowing admins to specifically target bookmarks that are
stuck in pending state.