### PR TITLE
fix:  Accept more permissive RSS feed content types and Fix User-Agent key

### DIFF
--- a/apps/workers/workers/feedWorker.ts
+++ b/apps/workers/workers/feedWorker.ts
@@ -158,7 +158,7 @@ async function run(req: DequeuedJob<ZFeedRequestSchema>) {
     headers: {
       "User-Agent":
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-      "Accept": "application/rss+xml, application/xml;q=0.9, text/xml;q=0.8"
+      Accept: "application/rss+xml, application/xml;q=0.9, text/xml;q=0.8",
     },
   });
   if (response.status !== 200) {


### PR DESCRIPTION
Some feeds are Content-Type application/xml only and will respond with a 406 error to responses with a header of content type application/rss+xml. This change allows for the more permissive content types application/xml and text/xml to be accepted.

Also fixes "UserAgent" header key with correct "User-Agent".