### PR TITLE
fix: Add JSON instruction to default text tagging prompt before content insertion

### DIFF
--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -58,6 +58,7 @@ Analyze the attached image and suggest relevant tags that describe its key theme
 - If the tag is not generic enough, don't include it.
 - Aim for 10-15 tags.
 - If there are no good tags, don't emit any.
+- You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.
 ${tagStyleInstruction}
 ${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
 You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.`;


### PR DESCRIPTION
Added the prompt instruction
```
- You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.
```
to the default text tagging instructions before the content insertion. This change significantly improves the success rate of a response containing structured JSON when a prompt is truncated by the LLM due to the prompt exceeding a maximum token limit.

I kept the original JSON instruction at the end of the prompt because it "reminds" the LLM to use JSON structure after the content insertion, and it causes no issues.