### PR TITLE
fix: Add JSON instruction to default text tagging prompt before content insertion

### DIFF
--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -85,6 +85,7 @@ Analyze the TEXT_CONTENT below and suggest relevant tags that describe its key t
     - Boilerplate content (cookie consent, login walls, GDPR notices)
 - Aim for 3-5 tags.
 - If there are no good tags, leave the array empty.
+- You must respond in JSON with the key "tags" and the value is an array of string tags.
 ${tagStyleInstruction}
 ${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
 


### PR DESCRIPTION
Added the following prompt instruction
```
- You must respond in JSON with the key "tags" and the value is an array of string tags.
```
to the default text tagging instructions before the content insertion. This change significantly improves the success rate of a response containing structured JSON when a prompt is truncated by the LLM due to the prompt exceeding a maximum token limit.

I kept the original JSON instruction at the end of the prompt because it reminds the LLM to use JSON structure after the content insertion, and it causes no issues.