### PR TITLE
fix: Reader settings preview on mobile matches reader view formatting

### DIFF
--- a/apps/mobile/app/dashboard/settings/reader-settings.tsx
+++ b/apps/mobile/app/dashboard/settings/reader-settings.tsx
@@ -63,6 +63,12 @@ export default function ReaderSettingsPage() {
   const [displayLineHeight, setDisplayLineHeight] =
     useState(effectiveLineHeight);
 
+  // Refs to track latest display values (avoids stale closures in callbacks)
+  const displayFontSizeRef = useRef(displayFontSize);
+  displayFontSizeRef.current = displayFontSize;
+  const displayLineHeightRef = useRef(displayLineHeight);
+  displayLineHeightRef.current = displayLineHeight;
+
   // Ref for the WebView preview component
   const previewRef = useRef<ReaderPreviewRef>(null);
 
@@ -73,10 +79,10 @@ export default function ReaderSettingsPage() {
       previewRef.current?.updateStyles(
         effectiveFontFamily,
         fontSize,
-        displayLineHeight,
+        displayLineHeightRef.current,
       );
     },
-    [effectiveFontFamily, displayLineHeight],
+    [effectiveFontFamily],
   );
 
   const updatePreviewLineHeight = useCallback(
@@ -84,11 +90,11 @@ export default function ReaderSettingsPage() {
       setDisplayLineHeight(lineHeight);
       previewRef.current?.updateStyles(
         effectiveFontFamily,
-        displayFontSize,
+        displayFontSizeRef.current,
         lineHeight,
       );
     },
-    [effectiveFontFamily, displayFontSize],
+    [effectiveFontFamily],
   );
 
   // Sync slider progress and display values with effective settings

--- a/apps/mobile/components/reader/ReaderPreview.tsx
+++ b/apps/mobile/components/reader/ReaderPreview.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { View } from "react-native";
 import WebView from "react-native-webview";
 import { WEBVIEW_FONT_FAMILIES } from "@/lib/readerSettings";
@@ -45,6 +45,15 @@ export const ReaderPreview = forwardRef<ReaderPreviewRef, ReaderPreviewProps>(
         `);
       },
     }));
+
+    // Update colors when theme changes
+    useEffect(() => {
+      webViewRef.current?.injectJavaScript(`
+        document.body.style.color = "${textColor}";
+        document.body.style.background = "${bgColor}";
+        true;
+      `);
+    }, [isDark, textColor, bgColor]);
 
     const html = `
       <!DOCTYPE html>


### PR DESCRIPTION
The reader settings preview on mobile was using a native text element, which has slightly different interpretations of font family/size and line height compared to the Webview used by the reader view. The reader settings preview now uses a pared down Webview with live settings syncing so the previews will actually match the formatting of the reader view.