### PR TITLE
Fix memory leak in in-memory rate limiter

### DIFF
--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -23,6 +23,7 @@
     "@restatedev/restate-sdk": "^1.9.0",
     "@restatedev/restate-sdk-clients": "^1.9.0",
     "liteque": "^0.7.0",
+    "lru-cache": "^11.2.2",
     "meilisearch": "^0.45.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The rate limiter used a probabilistic cleanup (1% chance per request) which allowed the internal Map to grow unbounded over time, causing continuous memory growth until container restart.

- Replace manual Map with lru-cache (as we're also using that in another package) for automatic LRU eviction and bounded size (50k entries)
- Eliminates O(n) cleanup iterations that could block the event loop