### PR TITLE
#2372 avoid masonry overflow in bookmark grids

### DIFF
--- a/apps/web/components/dashboard/bookmarks/BookmarksGrid.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarksGrid.tsx
@@ -117,12 +117,20 @@ export default function BookmarksGrid({
     <>
       {bookmarkLayoutSwitch(layout, {
         masonry: (
-          <Masonry className="flex gap-4" breakpointCols={breakpointConfig}>
+          <Masonry
+            className="-ml-4 flex w-auto"
+            columnClassName="pl-4"
+            breakpointCols={breakpointConfig}
+          >
             {children}
           </Masonry>
         ),
         grid: (
-          <Masonry className="flex gap-4" breakpointCols={breakpointConfig}>
+          <Masonry
+            className="-ml-4 flex w-auto"
+            columnClassName="pl-4"
+            breakpointCols={breakpointConfig}
+          >
             {children}
           </Masonry>
         ),

--- a/apps/web/components/dashboard/bookmarks/BookmarksGridSkeleton.tsx
+++ b/apps/web/components/dashboard/bookmarks/BookmarksGridSkeleton.tsx
@@ -69,12 +69,20 @@ export default function BookmarksGridSkeleton({
 
   return bookmarkLayoutSwitch(layout, {
     masonry: (
-      <Masonry className="flex gap-4" breakpointCols={breakpointConfig}>
+      <Masonry
+        className="-ml-4 flex w-auto"
+        columnClassName="pl-4"
+        breakpointCols={breakpointConfig}
+      >
         {children}
       </Masonry>
     ),
     grid: (
-      <Masonry className="flex gap-4" breakpointCols={breakpointConfig}>
+      <Masonry
+        className="-ml-4 flex w-auto"
+        columnClassName="pl-4"
+        breakpointCols={breakpointConfig}
+      >
         {children}
       </Masonry>
     ),

--- a/apps/web/components/public/lists/PublicBookmarkGrid.tsx
+++ b/apps/web/components/public/lists/PublicBookmarkGrid.tsx
@@ -227,7 +227,11 @@ export default function PublicBookmarkGrid({
   }, [data]);
   return (
     <>
-      <Masonry className="flex gap-4" breakpointCols={breakpointConfig}>
+      <Masonry
+        className="-ml-4 flex w-auto"
+        columnClassName="pl-4"
+        breakpointCols={breakpointConfig}
+      >
         {bookmarks.map((bookmark) => (
           <BookmarkCard key={bookmark.id} bookmark={bookmark} />
         ))}


### PR DESCRIPTION
Solves #2372

Simple change. Tested all the masonry column options on my machine.

Swapped the masonry gutter implementation to use column padding instead of flex gaps so the react-masonry-css column widths (100/n) no longer add extra horizontal space, which removes the scrollbar at 4 columns. The overflow came from className="flex gap-4" on Masonry while the library already sets column widths by percentage; the gap adds (cols - 1) * gap to the total width.

(I had to recreate this PR because I changed the source branch)