### PR TITLE
Update Chrome image reference in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # If you want to mount a custom directory, change the volume mapping above instead.
       DATA_DIR: /data # DON'T CHANGE THIS
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:124
+    image: docker.io/zenika/alpine-chrome:124
     restart: unless-stopped
     command:
       - --no-sandbox


### PR DESCRIPTION
gcr.io images are getting any updates because gcr was deprecated - switched chrome image from gcr to docker hub registry.