### PR TITLE
feat: Add ! negation alias and tag: qualifier alias for search queries

### DIFF
--- a/docs/docs/04-using-karakeep/search-query-language.md
+++ b/docs/docs/04-using-karakeep/search-query-language.md
@@ -11,7 +11,7 @@ Karakeep provides a search query language to filter and find bookmarks. Here are
 
 - Use spaces to separate multiple conditions (implicit AND)
 - Use `and`/`or` keywords for explicit boolean logic
-- Prefix qualifiers with `-` to negate them
+- Prefix qualifiers with `-` or `!` to negate them (e.g., `-is:archived` or `!is:archived`)
 - Use parentheses `()` for grouping conditions (note that groups can't be negated)
 
 ## Qualifiers
@@ -29,8 +29,8 @@ Here's a comprehensive table of all supported qualifiers:
 | `url:<value>`                    | Match bookmarks with URL substring                                                                                                                                                                        | `url:example.com`                            |
 | `title:<value>`                  | Match bookmarks with title substring                                                                                                               | `title:example`                              |
 |                                  | Supports quoted strings for titles with spaces                                                                                                   | `title:"my title"`                           |
-| `#<tag>`                         | Match bookmarks with specific tag                                                                                                                                                                         | `#important`                                 |
-|                                  | Supports quoted strings for tags with spaces                                                                                                                                                              | `#"work in progress"`                        |
+| `#<tag>` or `tag:<tag>`          | Match bookmarks with specific tag                                                                                                                                                                         | `#important` or `tag:important`              |
+|                                  | Supports quoted strings for tags with spaces                                                                                                                                                              | `#"work in progress"` or `tag:"work in progress"` |
 | `list:<name>`                    | Match bookmarks in specific list                                                                                                                                                                          | `list:reading`                               |
 |                                  | Supports quoted strings for list names with spaces                                                                                                                                                        | `list:"to review"`                           |
 | `after:<date>`                   | Bookmarks created on or after date (YYYY-MM-DD)                                                                                                                                                           | `after:2023-01-01`                           |
@@ -66,6 +66,12 @@ is:archived and (list:reading or #work)
 
 # Find bookmarks that are not favorited and not archived
 -is:fav -is:archived
+
+# Using ! as an alias for negation
+!is:fav !is:archived
+
+# Using tag: as an alias for #
+tag:important tag:"work in progress"
 ```
 
 ## Text Search

--- a/packages/shared/searchQueryParser.test.ts
+++ b/packages/shared/searchQueryParser.test.ts
@@ -333,6 +333,139 @@ describe("Search Query Parser", () => {
       },
     });
   });
+  test("! negation alias for -", () => {
+    // ! should work exactly like - for negation
+    expect(parseSearchQuery("!is:archived")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "archived",
+        archived: false,
+      },
+    });
+    expect(parseSearchQuery("!is:fav")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "favourited",
+        favourited: false,
+      },
+    });
+    expect(parseSearchQuery("!#my-tag")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "my-tag",
+        inverse: true,
+      },
+    });
+    expect(parseSearchQuery("!tag:my-tag")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "my-tag",
+        inverse: true,
+      },
+    });
+    expect(parseSearchQuery("!url:example.com")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "url",
+        url: "example.com",
+        inverse: true,
+      },
+    });
+    expect(parseSearchQuery("!list:my-list")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "listName",
+        listName: "my-list",
+        inverse: true,
+      },
+    });
+    expect(parseSearchQuery("!is:link")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "type",
+        typeName: BookmarkTypes.LINK,
+        inverse: true,
+      },
+    });
+    // Combined with complex queries
+    expect(parseSearchQuery("is:fav !is:archived")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "and",
+        matchers: [
+          {
+            type: "favourited",
+            favourited: true,
+          },
+          {
+            type: "archived",
+            archived: false,
+          },
+        ],
+      },
+    });
+  });
+
+  test("tag: qualifier alias for #", () => {
+    // tag: should work exactly like #
+    expect(parseSearchQuery("tag:my-tag")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "my-tag",
+        inverse: false,
+      },
+    });
+    expect(parseSearchQuery("-tag:my-tag")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "my-tag",
+        inverse: true,
+      },
+    });
+    expect(parseSearchQuery('tag:"my tag"')).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "my tag",
+        inverse: false,
+      },
+    });
+    expect(parseSearchQuery('-tag:"my tag"')).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "my tag",
+        inverse: true,
+      },
+    });
+    // Tags starting with qualifiers should be treated correctly
+    expect(parseSearchQuery("tag:android")).toEqual({
+      result: "full",
+      text: "",
+      matcher: {
+        type: "tagName",
+        tagName: "android",
+        inverse: false,
+      },
+    });
+  });
+
   test("date queries", () => {
     expect(parseSearchQuery("after:2023-10-12")).toEqual({
       result: "full",


### PR DESCRIPTION
Add `tag:` as an alternative syntax to `#` for tag search queries, and `!` as an alternative to `-` for negating qualifiers. This provides more intuitive syntax options for users who prefer text-based qualifiers over special characters.