### PR TITLE
fix: use user's preferred language for manual summarization

### DIFF
--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -14,6 +14,7 @@ import {
   bookmarkTexts,
   customPrompts,
   tagsOnBookmarks,
+  users,
 } from "@karakeep/db/schema";
 import {
   AssetPreprocessingQueue,
@@ -988,8 +989,15 @@ Author: ${bookmark.author ?? ""}
         },
       });
 
+      const userSettings = await ctx.db.query.users.findFirst({
+        where: eq(users.id, ctx.user.id),
+        columns: {
+          inferredTagLang: true,
+        },
+      });
+
       const summaryPrompt = await buildSummaryPrompt(
-        serverConfig.inference.inferredTagLang,
+        userSettings?.inferredTagLang ?? serverConfig.inference.inferredTagLang,
         prompts.map((p) => p.text),
         bookmarkDetails,
         serverConfig.inference.contextLength,


### PR DESCRIPTION
The manual summarizeBookmark endpoint was using only the global serverConfig.inference.inferredTagLang, ignoring the user's personal language preference. This fix fetches the user's inferredTagLang setting and uses it with a fallback to the server default, matching the behavior of the auto-summarization worker.

Fixes #2396 