### PR TITLE
feat(search): fallback search when Meilisearch unavailable

### DIFF
--- a/packages/trpc/routers/bookmarks.searchFallback.test.ts
+++ b/packages/trpc/routers/bookmarks.searchFallback.test.ts
@@ -49,14 +49,31 @@ describe("Bookmark Search Fallback", () => {
   }) => {
     const api = apiCallers[0]!;
 
-    await createBookmark(api, "First");
-    await createBookmark(api, "Second");
+    await createBookmark(api, "First", "https://first.example");
+    await createBookmark(api, "Second", "https://second.example");
 
     const res = await api.bookmarks.searchBookmarks({
       text: "",
       limit: 10,
     });
 
-    expect(res.bookmarks.length).toBeGreaterThan(0);
+    expect(res.bookmarks.length).toBe(2);
+  });
+
+  test<CustomTestContext>("searchBookmarks with matcher that yields zero IDs returns empty results", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0]!;
+
+    await createBookmark(api, "First", "https://first.example");
+    await createBookmark(api, "Second", "https://second.example");
+
+    const res = await api.bookmarks.searchBookmarks({
+      text: "tag:does-not-exist",
+      limit: 10,
+    });
+
+    expect(res.bookmarks).toEqual([]);
+    expect(res.nextCursor).toBeNull();
   });
 });

--- a/packages/trpc/routers/bookmarks.searchFallback.test.ts
+++ b/packages/trpc/routers/bookmarks.searchFallback.test.ts
@@ -76,4 +76,30 @@ describe("Bookmark Search Fallback", () => {
     expect(res.bookmarks).toEqual([]);
     expect(res.nextCursor).toBeNull();
   });
+
+  test<CustomTestContext>("fallback search treats LIKE wildcards literally", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0]!;
+
+    const plain = await createBookmark(
+      api,
+      "Hello World",
+      "https://plain.example",
+    );
+    const percent = await createBookmark(
+      api,
+      "100% Coverage",
+      "https://percent.example",
+    );
+
+    const res = await api.bookmarks.searchBookmarks({
+      text: "%",
+      limit: 10,
+    });
+
+    const ids = res.bookmarks.map((b) => b.id);
+    expect(ids).toContain(percent.id);
+    expect(ids).not.toContain(plain.id);
+  });
 });

--- a/packages/trpc/routers/bookmarks.searchFallback.test.ts
+++ b/packages/trpc/routers/bookmarks.searchFallback.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
+
+import type { APICallerType, CustomTestContext } from "../testUtils";
+import { defaultBeforeEach } from "../testUtils";
+
+beforeEach<CustomTestContext>(defaultBeforeEach(true));
+
+describe("Bookmark Search Fallback", () => {
+  async function createBookmark(
+    api: APICallerType,
+    title: string,
+    url = "https://example.com",
+  ) {
+    return await api.bookmarks.createBookmark({
+      type: BookmarkTypes.LINK,
+      url,
+      title,
+    });
+  }
+
+  test<CustomTestContext>("searchBookmarks falls back to title-only search when search engine is not configured", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0]!;
+
+    const a = await createBookmark(api, "Hello World", "https://a.example");
+    await createBookmark(api, "Something Else", "https://b.example");
+    await createBookmark(api, "HELLO there", "https://c.example");
+
+    const res = await api.bookmarks.searchBookmarks({
+      text: "Hello",
+      limit: 50,
+    });
+
+    expect(res.bookmarks.map((b) => b.id)).toContain(a.id);
+    expect(res.bookmarks.map((b) => b.title)).toEqual(
+      expect.arrayContaining(["Hello World", "HELLO there"]),
+    );
+    expect(res.bookmarks.map((b) => b.title)).not.toEqual(
+      expect.arrayContaining(["Something Else"]),
+    );
+    expect(res.nextCursor).toBeNull();
+  });
+
+  test<CustomTestContext>("searchBookmarks with empty query returns results without throwing", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0]!;
+
+    await createBookmark(api, "First");
+    await createBookmark(api, "Second");
+
+    const res = await api.bookmarks.searchBookmarks({
+      text: "",
+      limit: 10,
+    });
+
+    expect(res.bookmarks.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -1,5 +1,16 @@
 import { experimental_trpcMiddleware, TRPCError } from "@trpc/server";
-import { and, eq, gt, inArray, lt, or } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  like,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
 import { z } from "zod";
 
 import type { ZBookmarkContent } from "@karakeep/shared/types/bookmarks";
@@ -51,6 +62,83 @@ import { authedProcedure, createRateLimitMiddleware, router } from "../index";
 import { getBookmarkIdsFromMatcher } from "../lib/search";
 import { Asset } from "../models/assets";
 import { BareBookmark, Bookmark } from "../models/bookmarks";
+
+async function fallbackTitleOnlySearch(
+  ctx: AuthedContext,
+  opts: {
+    query: string;
+    filter?: FilterQuery[];
+    limit: number;
+    offset: number;
+    sortOrder: "asc" | "desc" | "relevance";
+  },
+) {
+  const whereConditions = [];
+  const trimmedQuery = opts.query.trim();
+
+  for (const filter of opts.filter ?? []) {
+    if (filter.type === "eq") {
+      if (filter.field === "userId") {
+        whereConditions.push(eq(bookmarks.userId, filter.value));
+      } else if (filter.field === "id") {
+        whereConditions.push(eq(bookmarks.id, filter.value));
+      }
+    } else if (filter.type === "in" && filter.field === "id") {
+      whereConditions.push(inArray(bookmarks.id, filter.values));
+    }
+  }
+
+  if (trimmedQuery.length > 0) {
+    whereConditions.push(like(bookmarks.title, `%${trimmedQuery}%`));
+  }
+
+  const where = whereConditions.length ? and(...whereConditions) : undefined;
+
+  const scoreExpr =
+    trimmedQuery.length === 0
+      ? sql<number>`0`
+      : sql<number>`
+        CASE
+          WHEN ${bookmarks.title} IS NULL THEN 0
+          WHEN lower(${bookmarks.title}) = lower(${trimmedQuery}) THEN 3
+          WHEN ${bookmarks.title} LIKE ${trimmedQuery + "%"} THEN 2
+          WHEN ${bookmarks.title} LIKE ${"%" + trimmedQuery + "%"} THEN 1
+          ELSE 0
+        END
+      `;
+
+  const orderBy =
+    opts.sortOrder === "asc"
+      ? [asc(bookmarks.createdAt)]
+      : opts.sortOrder === "desc"
+        ? [desc(bookmarks.createdAt)]
+        : trimmedQuery.length === 0
+          ? [desc(bookmarks.createdAt)]
+          : [desc(scoreExpr), desc(bookmarks.createdAt)];
+
+  const [{ count }] = await ctx.db
+    .select({ count: sql<number>`count(*)` })
+    .from(bookmarks)
+    .where(where);
+
+  const rows = await ctx.db
+    .select({
+      id: bookmarks.id,
+      score: scoreExpr.as("score"),
+      createdAt: bookmarks.createdAt,
+    })
+    .from(bookmarks)
+    .where(where)
+    .orderBy(...orderBy)
+    .limit(opts.limit)
+    .offset(opts.offset);
+
+  return {
+    hits: rows.map((r) => ({ id: r.id, score: r.score })),
+    totalHits: count ?? 0,
+    processingTimeMs: 0,
+  };
+}
 
 export const ensureBookmarkOwnership = experimental_trpcMiddleware<{
   ctx: AuthedContext;
@@ -599,12 +687,6 @@ export const bookmarksAppRouter = router({
       }
       const sortOrder = input.sortOrder || "relevance";
       const client = await getSearchClient();
-      if (!client) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Search functionality is not configured",
-        });
-      }
       const parsedQuery = parseSearchQuery(input.text);
 
       let filter: FilterQuery[];
@@ -626,17 +708,37 @@ export const bookmarksAppRouter = router({
        */
       const createdAtSortOrder = sortOrder === "relevance" ? "desc" : sortOrder;
 
-      const resp = await client.search({
-        query: parsedQuery.text,
-        filter,
-        sort: [{ field: "createdAt", order: createdAtSortOrder }],
-        limit: input.limit,
-        ...(input.cursor
-          ? {
-              offset: input.cursor.offset,
-            }
-          : {}),
-      });
+      const offset = input.cursor?.offset ?? 0;
+
+      const resp = await (async () => {
+        if (!client) {
+          return fallbackTitleOnlySearch(ctx, {
+            query: parsedQuery.text,
+            filter,
+            limit: input.limit!,
+            offset,
+            sortOrder,
+          });
+        }
+
+        try {
+          return await client.search({
+            query: parsedQuery.text,
+            filter,
+            sort: [{ field: "createdAt", order: createdAtSortOrder }],
+            limit: input.limit,
+            offset,
+          });
+        } catch {
+          return fallbackTitleOnlySearch(ctx, {
+            query: parsedQuery.text,
+            filter,
+            limit: input.limit!,
+            offset,
+            sortOrder,
+          });
+        }
+      })();
 
       if (resp.hits.length == 0) {
         return { bookmarks: [], nextCursor: null };


### PR DESCRIPTION
Fixes #1187.

Adds a lightweight fallback for bookmark search when Meilisearch isn’t configured or is temporarily unavailable.

Behavior:
- If a search engine client is available, keep using it.
- If it’s missing (minimal install) or errors at query time, fall back to a title-only LIKE query in the DB.

Notes:
- This is intentionally minimal: title-only search (no full-text / content search) to preserve usability without Meilisearch.
- Keeps existing qualifiers/matchers support since filtering still happens in the router.

Tests:
- `packages/trpc/routers/bookmarks.searchFallback.test.ts`
