### PR TITLE
feat(metrics): add prometheus metric for bookmark crawl latency

### DIFF
--- a/apps/workers/metrics.ts
+++ b/apps/workers/metrics.ts
@@ -1,5 +1,5 @@
 import { prometheus } from "@hono/prometheus";
-import { Counter, Registry } from "prom-client";
+import { Counter, Histogram, Registry } from "prom-client";
 
 export const registry = new Registry();
 
@@ -21,5 +21,15 @@ export const crawlerStatusCodeCounter = new Counter({
   labelNames: ["status_code"],
 });
 
+export const bookmarkCrawlLatencyHistogram = new Histogram({
+  name: "karakeep_bookmark_crawl_latency_seconds",
+  help: "Latency from bookmark creation to crawl completion (excludes recrawls and imports)",
+  buckets: [
+    0.1, 0.25, 0.5, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 45, 60, 90, 120, 180, 300,
+    600, 900, 1200,
+  ],
+});
+
 registry.registerMetric(workerStatsCounter);
 registry.registerMetric(crawlerStatusCodeCounter);
+registry.registerMetric(bookmarkCrawlLatencyHistogram);

--- a/apps/workers/workerUtils.ts
+++ b/apps/workers/workerUtils.ts
@@ -31,6 +31,8 @@ export async function getBookmarkDetails(bookmarkId: string) {
   return {
     url: bookmark.link.url,
     userId: bookmark.userId,
+    createdAt: bookmark.createdAt,
+    crawledAt: bookmark.link.crawledAt,
     screenshotAssetId: bookmark.assets.find(
       (a) => a.assetType == AssetTypes.LINK_SCREENSHOT,
     )?.id,


### PR DESCRIPTION
Track the time from bookmark creation to crawl completion as a histogram (karakeep_bookmark_crawl_latency_seconds). This measures the end-to-end latency users experience when adding bookmarks via extension, web, etc. Excludes recrawls (crawledAt already set) and imports (low priority jobs).

https://claude.ai/code/session_019jTGGXGWzK9C5aTznQhdgz