### PR TITLE
Fix tablet rotation to default

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -4,7 +4,7 @@ export default {
     slug: "hoarder",
     scheme: "karakeep",
     version: "1.8.5",
-    orientation: "portrait",
+    orientation: "default",
     icon: {
       light: "./assets/icon.png",
       tinted: "./assets/icon-tinted.png",


### PR DESCRIPTION
### Fix tablet rotation when keyboard is attached

fixes: #2459

The app was locked to portrait mode via `orientation: "portrait"` in `app.config.js`.
On tablets with physical keyboards, this caused the UI to appear rotated by 90°.

This change switches orientation handling to `"default"`, allowing the OS to manage rotation.
- Phones remain unaffected
- Tablets can rotate correctly, especially in keyboard/laptop mode

