### PR TITLE
Fix/sort by name case insensitive

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -4,7 +4,7 @@ export default {
     slug: "hoarder",
     scheme: "karakeep",
     version: "1.8.5",
-    orientation: "default",
+    orientation: "portrait",
     icon: {
       light: "./assets/icon.png",
       tinted: "./assets/icon-tinted.png",


### PR DESCRIPTION
Fix: Make tag name sorting case-insensitive
Description

fixes: #2477

This PR fixes an issue where sorting tags by name was case-sensitive, causing tags with capital letters to appear before lowercase ones (e.g. Contribution appearing before ansible).

The sorting logic has been updated to perform a case-insensitive comparison at the query level, ensuring a more natural and user-friendly alphabetical order.