### PR TITLE
fix(mobile): replace deprecated ImagePicker.MediaTypeOptions with media type literal

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
@@ -65,14 +65,13 @@ function HeaderRight({
               });
             }
           } catch {
-            if (uploadToastIdRef.current !== null) {
-              sonnerToast.error("Failed to open photo library", {
-                id: uploadToastIdRef.current,
-              });
-              uploadToastIdRef.current = null;
-            } else {
-              sonnerToast.error("Failed to open photo library");
-            }
+            sonnerToast.error("Failed to open photo library", {
+              id:
+                uploadToastIdRef.current !== null
+                  ? uploadToastIdRef.current
+                  : undefined,
+            });
+            uploadToastIdRef.current = null;
           }
         }
       }}


### PR DESCRIPTION
## Summary
- Replace deprecated `ImagePicker.MediaTypeOptions.Images` enum with the v17 `["images"]` media type literal array
- Wrap `launchImageLibraryAsync` in try/catch to handle permission denials and system errors
- Guard `result.assets[0]` before accessing properties
- Show a failure toast via `sonnerToast.error` on catch, clearing `uploadToastIdRef` if set

## Test plan
- [ ] Open app → tap Plus → Photo Library → pick an image → verify upload succeeds
- [ ] Deny photo library permission → tap Photo Library → verify error toast appears
- [ ] Verify no deprecation warning in console for `MediaTypeOptions`