### PR TITLE
fix: inject current date into summary prompt to prevent AI temporal confusion

### DIFF
--- a/packages/shared/prompts.ts
+++ b/packages/shared/prompts.ts
@@ -73,10 +73,12 @@ export function constructSummaryPrompt(
   customPrompts: string[],
   content: string,
 ): string {
+  const today = new Date().toISOString().split("T")[0];
   return `
 Summarize the following content responding ONLY with the summary. You MUST follow the following rules:
 - Summary must be in 3-4 sentences.
 - The summary must be in ${lang}.
+- Today's date is ${today}. Do NOT flag or question dates that are in the past relative to today.
 ${customPrompts && customPrompts.map((p) => `- ${p}`).join("\n")}
     ${content}`;
 }


### PR DESCRIPTION
## Problem

When the AI model generates summaries, it doesn't know the current date. This causes it to incorrectly flag recent dates in articles (e.g., \"2026 ClawHub trending list\") as potentially erroneous in the summary's \"questionable claims\" section, because the model reasons from its training cutoff year rather than the actual current date.

## Solution

Inject today's date (`new Date().toISOString().split('T')[0]`) into `constructSummaryPrompt` as an explicit rule. This is computed at runtime so it always reflects the server's actual current date.

```diff
+  const today = new Date().toISOString().split("T")[0];
   return `
 Summarize the following content responding ONLY with the summary. You MUST follow the following rules:
 - Summary must be in 3-4 sentences.
 - The summary must be in ${lang}.
+- Today's date is ${today}. Do NOT flag or question dates that are in the past relative to today.
```

## Changes

- `packages/shared/prompts.ts`: Added current date injection in `constructSummaryPrompt`

## Test plan

- [ ] Generate a summary for an article that mentions a recent year (e.g., 2025 or 2026)
- [ ] Verify the AI no longer flags those dates as \"potentially incorrect\" in the summary