### PR TITLE
fix(mobile): status bar text invisible in dark mode

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout() {
   useInitialAndroidBarSync();
   const router = useRouter();
   const { hasShareIntent } = useShareIntent();
-  const { colorScheme, isDarkColorScheme } = useColorScheme();
+  const { colorScheme } = useColorScheme();
 
   useEffect(() => {
     if (hasShareIntent) {
@@ -129,10 +129,7 @@ export default function RootLayout() {
           </StyledStack>
         </NavThemeProvider>
       </KeyboardProvider>
-      <StatusBar
-        key={`root-status-bar-${isDarkColorScheme ? "light" : "dark"}`}
-        style={isDarkColorScheme ? "light" : "dark"}
-      />
+      <StatusBar style="auto" />
     </SafeAreaProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Use `StatusBar style="auto"` instead of manually computing the style from nativewind's color scheme
- Fixes the status bar text being black (invisible) in dark mode due to a race condition where nativewind's color scheme observable hasn't resolved yet on initial render

## Test plan
- [x] Open the iOS Simulator in Dark appearance and verify status bar text is white
- [x] Toggle to Light appearance and verify status bar text is black
- [x] Test in-app theme setting (Light / Dark / System) still works correctly