### PR TITLE
feat(mobile): add systemMaterial blur and improve tab icon readability on iOS <26

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/_layout.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from "react-native";
 import {
   Icon,
   Label,
@@ -11,7 +12,16 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 export default function TabLayout() {
   const { colors } = useColorScheme();
   return (
-    <NativeTabs backgroundColor={colors.grey6} minimizeBehavior="onScrollDown">
+    <NativeTabs
+      backgroundColor={Platform.OS === "ios" ? null : colors.grey6}
+      blurEffect={
+        Platform.OS === "ios" && parseInt(Platform.Version as string, 10) < 26
+          ? "systemMaterial"
+          : undefined
+      }
+      iconColor={{ default: colors.grey, selected: colors.primary }}
+      minimizeBehavior="onScrollDown"
+    >
       <NativeTabs.Trigger name="(home)">
         <Icon
           sf="house.fill"


### PR DESCRIPTION
## Summary
- Add `systemMaterial` blur effect to the tab bar on iOS < 26 for a translucent frosted-glass appearance
- Update unselected icon and text colors for the iOS < 26 tab bar for light/dark mode
- On iOS 26+, the blur effect is left to the system's fluid tab bar design

## Test plan
- [x] Build on iOS 18.x simulator — tab bar should show translucent systemMaterial blur and updated light and dark mode unselected icon colors
- [x] Build on iOS 26 simulator — tab bar should use native fluid appearance
- [x] Build on Android — tab bar should remain unchanged with solid background