### PR TITLE
fix: allow JavaScript in archived pages to enable KaTeX/MathJax rendering

### DIFF
--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -1425,7 +1425,7 @@ async function archiveWebpage(
             : undefined,
           no_proxy: serverConfig.proxy.noProxy?.join(","),
         },
-      })("monolith", ["-", "-Ije", "-t", "5", "-b", url, "-o", assetPath]);
+      })("monolith", ["-", "-Ie", "-t", "5", "-b", url, "-o", assetPath]);
 
       if (res.isCanceled) {
         logger.error(


### PR DESCRIPTION
Fixes #1243

## Problem
Mathematical expressions weren't rendering in reader view because the monolith archiving tool was stripping JavaScript from archived pages.

## Root Cause
In crawlerWorker.ts, the monolith command was called with -Ije flags where -j means "No JavaScript". Since MathJax and KaTeX require JavaScript to render math expressions, the math was not being rendered.

## Solution
Changed the monolith arguments from ["-", "-Ije", ...] to ["-", "-Ie", ...] - removing the -j flag while keeping -I (isolate) and -e (no embeds) for security.

## Testing
This fix should be tested with: https://transformer-circuits.pub/2025/attribution-graphs/methods.html

/claim #1243