### PR TITLE
fix: disable password change when password auth is disabled

### DIFF
--- a/apps/web/components/settings/ChangePassword.tsx
+++ b/apps/web/components/settings/ChangePassword.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/sonner";
+import { useClientConfig } from "@/lib/clientConfig";
 import { useTranslation } from "@/lib/i18n/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
@@ -28,9 +29,12 @@ import { SettingsSection } from "./SettingsPage";
 export function ChangePassword() {
   const api = useTRPC();
   const { t } = useTranslation();
+  const clientConfig = useClientConfig();
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const isPasswordAuthDisabled = clientConfig.auth.disablePasswordAuth;
+
   const form = useForm<z.infer<typeof zChangePasswordSchema>>({
     resolver: zodResolver(zChangePasswordSchema),
     defaultValues: {
@@ -67,6 +71,10 @@ export function ChangePassword() {
       currentPassword: value.currentPassword,
       newPassword: value.newPassword,
     });
+  }
+
+  if (isPasswordAuthDisabled) {
+    return null;
   }
 
   return (

--- a/packages/trpc/routers/users.test.ts
+++ b/packages/trpc/routers/users.test.ts
@@ -14,6 +14,11 @@ import type { CustomTestContext } from "../testUtils";
 import * as emailModule from "../email";
 import { defaultBeforeEach, getApiCaller } from "../testUtils";
 
+const authConfigOverrides = {
+  emailVerificationRequired: true,
+  disablePasswordAuth: false,
+};
+
 // Mock server config with email settings
 vi.mock("@karakeep/shared/config", async (original) => {
   const mod = (await original()) as typeof import("@karakeep/shared/config");
@@ -23,7 +28,12 @@ vi.mock("@karakeep/shared/config", async (original) => {
       ...mod.default,
       auth: {
         ...mod.default.auth,
-        emailVerificationRequired: true,
+        get emailVerificationRequired() {
+          return authConfigOverrides.emailVerificationRequired;
+        },
+        get disablePasswordAuth() {
+          return authConfigOverrides.disablePasswordAuth;
+        },
       },
       email: {
         smtp: {
@@ -848,6 +858,35 @@ describe("User Routes", () => {
           newPassword: "newpass456",
         }),
       ).rejects.toThrow();
+    });
+
+    test<CustomTestContext>("changePassword - disabled when password auth is disabled", async ({
+      db,
+      unauthedAPICaller,
+    }) => {
+      const user = await unauthedAPICaller.users.create({
+        name: "Test User",
+        email: "disabledpass@test.com",
+        password: "oldpass123",
+        confirmPassword: "oldpass123",
+      });
+
+      const caller = getApiCaller(db, user.id, user.email, user.role || "user");
+
+      authConfigOverrides.disablePasswordAuth = true;
+
+      try {
+        await expect(() =>
+          caller.users.changePassword({
+            currentPassword: "oldpass123",
+            newPassword: "newpass456",
+          }),
+        ).rejects.toThrow(
+          /Password authentication is disabled in server config/,
+        );
+      } finally {
+        authConfigOverrides.disablePasswordAuth = false;
+      }
     });
 
     test<CustomTestContext>("changePassword - OAuth user (no password)", async ({

--- a/packages/trpc/routers/users.ts
+++ b/packages/trpc/routers/users.ts
@@ -108,6 +108,14 @@ export const usersAppRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      if (serverConfig.auth.disablePasswordAuth) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Password authentication is disabled in server config. Use OAuth instead.",
+        });
+      }
+
       const user = await User.fromCtx(ctx);
       await user.changePassword(input.currentPassword, input.newPassword);
     }),


### PR DESCRIPTION
## Summary
Fixes #784 by making password-change behavior consistent with auth config when password login is disabled.

## Root Cause
`users.changePassword` could still be called even when `auth.disablePasswordAuth=true`, and the settings UI still rendered the Change Password section.

## Changes
- Web: hide `ChangePassword` settings section when `disablePasswordAuth` is enabled.
- tRPC: add guard in `users.changePassword` to reject with `FORBIDDEN` when password auth is disabled.
- Tests: add regression test ensuring `changePassword` throws when password auth is disabled.

## Verification
- Passed pre-commit preflight (`typecheck`, `lint`, `format`).
- OpenAPI check passed.
- Added/updated unit tests in `packages/trpc/routers/users.test.ts`.

## Risk
Low. Small, issue-scoped change with explicit backend guard + test coverage.

## Rollback
Revert commit `ca378d5e15e5658d449595fcef0c8db19d892c49`.