### PR TITLE
feat: support bookmark source condition in rule engine (#2526)

### DIFF
--- a/apps/web/components/dashboard/rules/RuleEngineConditionBuilder.tsx
+++ b/apps/web/components/dashboard/rules/RuleEngineConditionBuilder.tsx
@@ -33,6 +33,7 @@ import type {
   RuleEngineCondition,
   RuleEngineEvent,
 } from "@karakeep/shared/types/rules";
+import { zBookmarkSourceSchema } from "@karakeep/shared/types/bookmarks";
 
 import { FeedSelector } from "../feeds/FeedSelector";
 import { TagAutocomplete } from "../tags/TagAutocomplete";
@@ -75,6 +76,9 @@ export function ConditionBuilder({
       case "bookmarkTypeIs":
         onChange({ type: "bookmarkTypeIs", bookmarkType: "link" });
         break;
+      case "bookmarkSourceIs":
+        onChange({ type: "bookmarkSourceIs", source: "rss" });
+        break;
       case "hasTag":
         onChange({ type: "hasTag", tagId: "" });
         break;
@@ -112,6 +116,8 @@ export function ConditionBuilder({
         return <Rss className="h-4 w-4" />;
       case "bookmarkTypeIs":
         return <FileType className="h-4 w-4" />;
+      case "bookmarkSourceIs":
+        return <Rss className="h-4 w-4" />;
       case "hasTag":
         return <Tag className="h-4 w-4" />;
       case "isFavourited":
@@ -209,6 +215,33 @@ export function ConditionBuilder({
                 <SelectItem value="asset">
                   {t("common.bookmark_types.media")}
                 </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        );
+
+      case "bookmarkSourceIs":
+        return (
+          <div className="mt-2">
+            <Select
+              value={value.source}
+              onValueChange={(source) =>
+                onChange({
+                  ...value,
+                  source:
+                    source as (typeof zBookmarkSourceSchema.options)[number],
+                })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select bookmark source" />
+              </SelectTrigger>
+              <SelectContent>
+                {zBookmarkSourceSchema.options.map((source) => (
+                  <SelectItem key={source} value={source}>
+                    {source}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
@@ -313,6 +346,9 @@ export function ConditionBuilder({
         </SelectItem>
         <SelectItem value="bookmarkTypeIs">
           {t("settings.rules.conditions_types.bookmark_type_is")}
+        </SelectItem>
+        <SelectItem value="bookmarkSourceIs">
+          {t("settings.rules.conditions_types.bookmark_source_is")}
         </SelectItem>
         <SelectItem value="hasTag">
           {t("settings.rules.conditions_types.has_tag")}

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -367,6 +367,7 @@
         "title_does_not_contain": "Title Does Not Contain",
         "imported_from_feed": "Imported From Feed",
         "bookmark_type_is": "Bookmark Type Is",
+        "bookmark_source_is": "Bookmark Source Is",
         "has_tag": "Has Tag",
         "is_favourited": "Is Favourited",
         "is_archived": "Is Archived",

--- a/packages/shared/types/rules.ts
+++ b/packages/shared/types/rules.ts
@@ -1,5 +1,7 @@
 import { RefinementCtx, z } from "zod";
 
+import { zBookmarkSourceSchema } from "./bookmarks";
+
 // Events
 const zBookmarkAddedEvent = z.object({
   type: z.literal("bookmarkAdded"),
@@ -79,6 +81,11 @@ const zBookmarkTypeIsCondition = z.object({
   bookmarkType: z.enum(["link", "text", "asset"]),
 });
 
+const zBookmarkSourceIsCondition = z.object({
+  type: z.literal("bookmarkSourceIs"),
+  source: zBookmarkSourceSchema,
+});
+
 const zHasTagCondition = z.object({
   type: z.literal("hasTag"),
   tagId: z.string(),
@@ -100,6 +107,7 @@ const nonRecursiveCondition = z.discriminatedUnion("type", [
   zTitleDoesNotContainCondition,
   zImportedFromFeedCondition,
   zBookmarkTypeIsCondition,
+  zBookmarkSourceIsCondition,
   zHasTagCondition,
   zIsFavouritedCondition,
   zIsArchivedCondition,
@@ -121,6 +129,7 @@ export const zRuleEngineConditionSchema: z.ZodType<RuleEngineCondition> =
       zTitleDoesNotContainCondition,
       zImportedFromFeedCondition,
       zBookmarkTypeIsCondition,
+      zBookmarkSourceIsCondition,
       zHasTagCondition,
       zIsFavouritedCondition,
       zIsArchivedCondition,
@@ -244,6 +253,7 @@ const ruleValidaitorFn = (
     switch (condition.type) {
       case "alwaysTrue":
       case "bookmarkTypeIs":
+      case "bookmarkSourceIs":
       case "isFavourited":
       case "isArchived":
         return true;

--- a/packages/trpc/lib/__tests__/ruleEngine.test.ts
+++ b/packages/trpc/lib/__tests__/ruleEngine.test.ts
@@ -129,6 +129,7 @@ describe("RuleEngine", () => {
           title: "Example Bookmark Title",
           favourited: false,
           archived: false,
+          source: "rss",
         })
         .returning({ id: bookmarks.id })
     ).map((b) => b.id);
@@ -295,6 +296,22 @@ describe("RuleEngine", () => {
       const condition: RuleEngineCondition = {
         type: "bookmarkTypeIs",
         bookmarkType: BookmarkTypes.TEXT,
+      };
+      expect(engine.doesBookmarkMatchConditions(condition)).toBe(false);
+    });
+
+    it("should return true for bookmarkSourceIs condition", () => {
+      const condition: RuleEngineCondition = {
+        type: "bookmarkSourceIs",
+        source: "rss",
+      };
+      expect(engine.doesBookmarkMatchConditions(condition)).toBe(true);
+    });
+
+    it("should return false for bookmarkSourceIs condition mismatch", () => {
+      const condition: RuleEngineCondition = {
+        type: "bookmarkSourceIs",
+        source: "web",
       };
       expect(engine.doesBookmarkMatchConditions(condition)).toBe(false);
     });

--- a/packages/trpc/lib/ruleEngine.ts
+++ b/packages/trpc/lib/ruleEngine.ts
@@ -118,6 +118,9 @@ export class RuleEngine {
       case "bookmarkTypeIs": {
         return this.bookmark.type === condition.bookmarkType;
       }
+      case "bookmarkSourceIs": {
+        return this.bookmark.source === condition.source;
+      }
       case "hasTag": {
         return this.bookmark.tagsOnBookmarks.some(
           (t) => t.tagId === condition.tagId,


### PR DESCRIPTION
## Summary`n- add bookmarkSourceIs rule condition`n- evaluate bookmark source in trpc rule engine`n- expose source condition in web rule builder`n- add tests`n`n## Verification`n- pnpm -C karakeep --filter @karakeep/trpc test -- --run lib/__tests__/ruleEngine.test.ts`n- pnpm -C karakeep --filter @karakeep/trpc typecheck`n- pnpm -C karakeep --filter @karakeep/web typecheck`n`nCloses #2526