### PR TITLE
fix(crawler): normalize lazy-load img attributes to src before Readability

### DIFF
--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -74,6 +74,52 @@ const metascraperParser = metascraper([
   metascraperUrl(),
 ]);
 
+/**
+ * Many sites use custom data-* attributes for lazy loading images instead of the
+ * standard `src` attribute (e.g. WeChat's data-src, data-actualsrc, data-srv, or
+ * the common data-original / data-lazy patterns used by jQuery plugins).
+ *
+ * Readability and DOMPurify both operate on the DOM, so images with no `src` are
+ * either ignored or their placeholders are stripped.  We normalise these attributes
+ * to `src` *before* passing the document to Readability so that the extracted
+ * article retains the actual image URLs.
+ */
+const LAZY_SRC_ATTRS = [
+  "data-src",
+  "data-actualsrc",
+  "data-srv",
+  "data-original",
+  "data-lazy",
+  "data-lazyload",
+  "data-img-src",
+  "data-url",
+];
+
+function normalizeLazyLoadImages(document: Document): void {
+  const images = document.querySelectorAll("img");
+  for (const img of images) {
+    // Only fill in src if it is absent or a known placeholder (blank / data:)
+    const currentSrc = img.getAttribute("src") ?? "";
+    const needsSrc =
+      !currentSrc ||
+      currentSrc === "#" ||
+      currentSrc.startsWith("data:image/gif") ||
+      currentSrc.startsWith("data:image/png");
+
+    if (!needsSrc) {
+      continue;
+    }
+
+    for (const attr of LAZY_SRC_ATTRS) {
+      const value = img.getAttribute(attr);
+      if (value && value.trim() && !value.startsWith("data:")) {
+        img.setAttribute("src", value.trim());
+        break;
+      }
+    }
+  }
+}
+
 function extractReadableContent(
   htmlContent: string,
   url: string,
@@ -81,6 +127,7 @@ function extractReadableContent(
   const virtualConsole = new VirtualConsole();
   const dom = new JSDOM(htmlContent, { url, virtualConsole });
   try {
+    normalizeLazyLoadImages(dom.window.document);
     const readableContent = new Readability(dom.window.document).parse();
     if (!readableContent || typeof readableContent.content !== "string") {
       return null;


### PR DESCRIPTION
## Problem

Many sites — notably WeChat official accounts — defer image loading by placing the real URL in a custom data-* attribute instead of the standard `src` attribute. Common examples:

| Attribute | Used by |
|-----------|---------|
| `data-src` | Most lazy-load libs |
| `data-actualsrc` | WeChat |
| `data-srv` | WeChat |
| `data-original` | jQuery lazy plugins |
| `data-lazy` / `data-lazyload` | Various plugins |

When `<img>` has no `src`, Mozilla Readability ignores the element entirely; DOMPurify then strips the data-* attribute. The resulting article has broken image placeholders even though the URL was available in the original HTML.

Reported in #2493.

## Fix

Add `normalizeLazyLoadImages()`, called once on the JSDOM document **before** it is passed to Readability. The function iterates over every `<img>` element and promotes the first recognised lazy-loading attribute to `src` when `src` is absent or contains a known low-resolution placeholder (1 × 1 GIF/PNG data URI or a bare `#`).

The attribute priority list (in order):
```
data-src, data-actualsrc, data-srv, data-original,
data-lazy, data-lazyload, data-img-src, data-url
```

Images that already have a valid `src` are left untouched.

## Testing

1. Save a WeChat article (e.g. `https://mp.weixin.qq.com/s/kvhc3xjpBl8Uk4-Yv0-CAw`).
2. Open the bookmark in the reader view.
3. Images that previously showed as broken placeholders should now render correctly.

Fixes #2493