### PR TITLE
fix(web): show "+" in tag count badges when more pages exist

### DIFF
--- a/apps/web/components/dashboard/tags/AllTagsView.tsx
+++ b/apps/web/components/dashboard/tags/AllTagsView.tsx
@@ -332,7 +332,10 @@ export default function AllTagsView() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <span>{t("tags.your_tags")}</span>
-            <Badge variant="secondary">{allHumanTags.length}</Badge>
+            <Badge variant="secondary">
+              {allHumanTags.length}
+              {hasNextPageHumanTags ? "+" : ""}
+            </Badge>
           </CardTitle>
           <CardDescription>{t("tags.your_tags_info")}</CardDescription>
         </CardHeader>
@@ -362,7 +365,10 @@ export default function AllTagsView() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <span>{t("tags.ai_tags")}</span>
-            <Badge variant="secondary">{allAiTags.length}</Badge>
+            <Badge variant="secondary">
+              {allAiTags.length}
+              {hasNextPageAiTags ? "+" : ""}
+            </Badge>
           </CardTitle>
           <CardDescription>{t("tags.ai_tags_info")}</CardDescription>
         </CardHeader>
@@ -392,7 +398,10 @@ export default function AllTagsView() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <span>{t("tags.unused_tags")}</span>
-            <Badge variant="secondary">{allEmptyTags.length}</Badge>
+            <Badge variant="secondary">
+              {allEmptyTags.length}
+              {hasNextPageEmptyTags ? "+" : ""}
+            </Badge>
           </CardTitle>
           <CardDescription>{t("tags.unused_tags_info")}</CardDescription>
         </CardHeader>


### PR DESCRIPTION
## Problem

The Tags page shows a count badge next to each category header (*Your Tags*, *AI Tags*, *Unused Tags*).  The badge only reflects the number of tags loaded into the current page, so with more than 50 tags the badge shows a stale partial count (e.g. **50**) and jumps unexpectedly each time "Load More" is clicked.

Reported in #2395 (`pri/low`, `status/approved`).

## Root Cause

`AllTagsView` derives the count from `allHumanTags.length` / `allAiTags.length` / `allEmptyTags.length`, which are the accumulated in-memory arrays from `usePaginatedSearchTags`.  The paginated API response does not include a grand total, so computing the true count without fetching all pages would require an extra network round-trip.

## Fix

Append **"+"** to each count badge when `useInfiniteQuery` reports `hasNextPage === true`.

* `50+` → there are more tags not yet loaded
* `50` → all pages are loaded; the badge shows the exact count as before

This is already a well-established UX convention (GitHub issue counts, package registries, etc.) and avoids any extra API calls.

Once all pages are loaded the "+" disappears automatically and the badge shows the precise total, keeping the existing behaviour unchanged for users who load everything.

Fixes #2395