### PR TITLE
Show actual error message when AI summarization fails

### DIFF
--- a/apps/web/components/dashboard/bookmarks/SummarizeBookmarkArea.tsx
+++ b/apps/web/components/dashboard/bookmarks/SummarizeBookmarkArea.tsx
@@ -26,9 +26,9 @@ function AISummary({
   const [isExpanded, setIsExpanded] = React.useState(false);
   const { mutate: resummarize, isPending: isResummarizing } =
     useSummarizeBookmark({
-      onError: () => {
+      onError: (e) => {
         toast({
-          description: "Something went wrong",
+          description: e.message ?? "Something went wrong",
           variant: "destructive",
         });
       },


### PR DESCRIPTION
## Problem

When AI summarization fails, the user only sees a generic **"Something went wrong"** toast, even though the tRPC response already contains the actual error message from the inference provider.

The error is present in the network response but the `onError` callback in `SummarizeBookmarkArea` ignores it entirely. Two real-world examples:

**Wrong API key:**
```json
[
    {
        "error": {
            "json": {
                "message": "401 Incorrect API key provided: sk-svcac***. You can find your API key at https://platform.openai.com/account/api-keys.",
                "code": -32603,
                "data": {
                    "code": "INTERNAL_SERVER_ERROR",
                    "httpStatus": 500,
                    "path": "bookmarks.summarizeBookmark",
                    "zodError": null
                }
            }
        }
    }
]
```

**Missing API key scopes:**
```json
[
    {
        "error": {
            "json": {
                "message": "401 You have insufficient permissions for this operation. Missing scopes: model.request. Check that you have the correct role in your organization (Reader, Writer, Owner) and project (Member, Owner), and if you're using a restricted API key, that it has the necessary scopes.",
                "code": -32603,
                "data": {
                    "code": "INTERNAL_SERVER_ERROR",
                    "httpStatus": 500,
                    "path": "bookmarks.summarizeBookmark",
                    "zodError": null
                }
            }
        }
    }
]
```

This makes it needlessly hard to diagnose configuration problems.

## Fix

In `SummarizeBookmarkArea.tsx`, the `onError` callback now forwards `e.message` to the toast description instead of the hardcoded `"Something went wrong"` string. The original string is kept as fallback.

## Result

The user now sees the actual provider error in the toast instead of the generic message.
