### PR TITLE
fix(api): ensure sourceUrl is saved when creating asset bookmarks

### DIFF
--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -254,7 +254,7 @@ export const bookmarksAppRouter = router({
                   content: null,
                   metadata: null,
                   fileName: input.fileName ?? null,
-                  sourceUrl: null,
+                  sourceUrl: input.sourceUrl ?? null,
                 })
                 .returning();
               const uploadedAsset = await Asset.fromId(ctx, input.assetId);
@@ -286,6 +286,8 @@ export const bookmarksAppRouter = router({
                 type: BookmarkTypes.ASSET,
                 assetType: asset.assetType,
                 assetId: asset.assetId,
+                fileName: asset.fileName,
+                sourceUrl: asset.sourceUrl,
               };
               break;
             }


### PR DESCRIPTION
Previously, when creating a new bookmark of type `asset` from API `/v1/bookmarks`, the `sourceUrl` was hardcoded to `null` during database insertion, ignoring the `sourceUrl` passed in the request body. This fix ensures that the provided `sourceUrl` is properly saved to the `bookmarkAssets` table and correctly returned in the API response.