### PR TITLE
fix(web): add dedicated health route to prevent memory leak (#2344)

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -2,6 +2,7 @@
 // Without this, every healthcheck call triggers next-auth init() which allocates
 // ~14 closure objects per request and causes a gradual memory leak (GitHub issue #2344).
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export function GET() {
   return Response.json({ status: "ok", message: "Web app is working" });

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,8 @@
+// Dedicated health endpoint that bypasses the auth middleware in [[...route]]/route.ts.
+// Without this, every healthcheck call triggers next-auth init() which allocates
+// ~14 closure objects per request and causes a gradual memory leak (GitHub issue #2344).
+export const runtime = "nodejs";
+
+export function GET() {
+  return Response.json({ status: "ok", message: "Web app is working" });
+}


### PR DESCRIPTION
fixes #2344

## Problem

The `/api/health` endpoint was handled by the Hono catch-all route in
`apps/web/app/api/[[...route]]/route.ts`, which runs the `nextAuth`
middleware on **every request**. This middleware calls
`createContextFromRequest()` → `next-auth init()`, which allocates ~14
new closure objects wrapping all DrizzleAdapter methods per request.

With healthchecks running every 30–60 seconds (Docker built-in, Uptime
Kuma, Pangolin, Blackbox Exporter, etc.), these objects accumulate in the
V8 old generation heap faster than GC can collect them, causing gradual
memory growth of **~3–17 MB/hour** depending on healthcheck interval.

This is the root cause of the memory leak reported in #2344. Several
users confirmed that **disabling healthchecks stopped the memory growth**.

## Fix

Add a dedicated Next.js route at `apps/web/app/api/health/route.ts`.
Next.js static routes take priority over `[[...route]]` catch-all routes,
so healthcheck requests no longer trigger auth context initialization.

The response format is preserved: `{"status":"ok","message":"..."}`

## Testing

Verified locally: `GET /api/health` returns `200 OK` without any
auth/session calls appearing in logs.