### PR TITLE
fix(db): use millisecond precision for bookmark timestamps

### DIFF
--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -16,13 +16,13 @@ import {
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
 
 function createdAtField() {
-  return integer("createdAt", { mode: "timestamp" })
+  return integer("createdAt", { mode: "timestamp_ms" })
     .notNull()
     .$defaultFn(() => new Date());
 }
 
 function modifiedAtField() {
-  return integer("modifiedAt", { mode: "timestamp" })
+  return integer("modifiedAt", { mode: "timestamp_ms" })
     .$defaultFn(() => new Date())
     .$onUpdate(() => new Date());
 }


### PR DESCRIPTION
## Summary
Fixes bookmark `createdAt` being stored in Unix seconds instead of milliseconds, which causes incorrect sort order when sorting by "Newest first".

The `createdAtField()` and `modifiedAtField()` helper functions in the Drizzle schema used `mode: "timestamp"` (seconds precision). This meant new bookmarks got timestamps like `1773238339` instead of `1773238379976`, causing them to sort far below bookmarks with millisecond timestamps.

Changed both helpers to use `mode: "timestamp_ms"` for consistent millisecond-precision storage, matching other timestamp fields in the schema (e.g. `emailVerified`, `expires`).

Fixes #2583