### PR TITLE
fix(import): Remove queue size checks from import worker capacity calculation

### DIFF
--- a/apps/workers/workers/importWorker.ts
+++ b/apps/workers/workers/importWorker.ts
@@ -20,7 +20,6 @@ import {
   importSessions,
   importStagingBookmarks,
 } from "@karakeep/db/schema";
-import { LowPriorityCrawlerQueue, OpenAIQueue } from "@karakeep/shared-server";
 import logger, { throttledLogger } from "@karakeep/shared/logger";
 import {
   BookmarkTypes,
@@ -626,33 +625,23 @@ export class ImportWorker {
   }
 
   /**
-   * Backpressure: Calculate available capacity based on number of items in flight and the health of the import queues.
+   * Backpressure: Calculate available capacity based on number of items currently processing.
    */
   private async getAvailableCapacity(): Promise<number> {
-    const [processingCount, crawlerQueue, openaiQueue] = await Promise.all([
-      db
-        .select({ count: count() })
-        .from(importStagingBookmarks)
-        .where(
-          and(
-            eq(importStagingBookmarks.status, "processing"),
-            gt(
-              importStagingBookmarks.processingStartedAt,
-              new Date(Date.now() - this.staleThresholdMs),
-            ),
+    const processingCount = await db
+      .select({ count: count() })
+      .from(importStagingBookmarks)
+      .where(
+        and(
+          eq(importStagingBookmarks.status, "processing"),
+          gt(
+            importStagingBookmarks.processingStartedAt,
+            new Date(Date.now() - this.staleThresholdMs),
           ),
         ),
-      LowPriorityCrawlerQueue.stats(),
-      OpenAIQueue.stats(),
-    ]);
+      );
 
-    const crawlerTotal =
-      crawlerQueue.pending + crawlerQueue.running + crawlerQueue.pending_retry;
-    const openaiTotal =
-      openaiQueue.pending + openaiQueue.running + openaiQueue.pending_retry;
-    const processingTotal = processingCount[0]?.count ?? 0;
-
-    const inFlight = Math.max(crawlerTotal, openaiTotal, processingTotal);
+    const inFlight = processingCount[0]?.count ?? 0;
     importStagingInFlightGauge.set(inFlight);
 
     return this.maxInFlight - inFlight;


### PR DESCRIPTION
The available capacity now only considers the number of currently processing items, rather than also factoring in crawler and OpenAI queue sizes. This simplifies backpressure and avoids unnecessarily throttling imports when downstream queues are busy with non-import work.

https://claude.ai/code/session_01JKYA6h3Ycpes9iUKmwMAux