### PR TITLE
fix(import-export): preserve list hierarchy on karakeep round-trip

### DIFF
--- a/apps/web/lib/hooks/useBookmarkImport.ts
+++ b/apps/web/lib/hooks/useBookmarkImport.ts
@@ -93,6 +93,9 @@ export function useBookmarkImport() {
           onProgress: (done, total) => setImportProgress({ done, total }),
         },
         {
+          // Karakeep imports restore the original list hierarchy at the top
+          // level so that the imported state matches the exported state.
+          restoreTopLevelLists: source === "karakeep",
           // Use a custom parser to avoid re-parsing the file
           parsers: {
             [source]: () => parsedImport,

--- a/packages/shared/import-export/importer.test.ts
+++ b/packages/shared/import-export/importer.test.ts
@@ -578,6 +578,112 @@ describe("importBookmarksFromFile", () => {
     });
   });
 
+  it("restores top-level lists without a parent when restoreTopLevelLists is true", async () => {
+    const parsers = {
+      karakeep: vi.fn().mockReturnValue({
+        bookmarks: [
+          {
+            title: "Bookmark 1",
+            content: { type: "link", url: "https://example.com/1" },
+            tags: [],
+            addDate: 100,
+            paths: [],
+            listExternalIds: ["child-id"],
+          },
+          {
+            title: "Unassigned Bookmark",
+            content: { type: "link", url: "https://example.com/unassigned" },
+            tags: [],
+            addDate: 200,
+            paths: [],
+          },
+        ],
+        lists: [
+          {
+            externalId: "root-list-id",
+            name: "Work",
+            icon: "💼",
+            parentExternalId: null,
+            type: "manual",
+          },
+          {
+            externalId: "child-id",
+            name: "Projects",
+            icon: "📁",
+            parentExternalId: "root-list-id",
+            type: "manual",
+          },
+        ],
+      }),
+    };
+
+    let idCounter = 0;
+    const createdLists: {
+      id: string;
+      name: string;
+      parentId?: string;
+      icon: string;
+    }[] = [];
+    const createList = vi.fn(
+      async (input: { name: string; icon: string; parentId?: string }) => {
+        const id = `list-${idCounter++}`;
+        createdLists.push({ id, name: input.name, parentId: input.parentId, icon: input.icon });
+        return { id };
+      },
+    );
+
+    const stagedBookmarks: StagedBookmark[] = [];
+    const stageImportedBookmarks = vi.fn(
+      async (input: {
+        importSessionId: string;
+        bookmarks: StagedBookmark[];
+      }) => {
+        stagedBookmarks.push(...input.bookmarks);
+      },
+    );
+
+    await importBookmarksFromFile(
+      {
+        file: fakeFile,
+        source: "karakeep",
+        rootListName: "Import Root",
+        deps: {
+          createList,
+          stageImportedBookmarks,
+          finalizeImportStaging: vi.fn(),
+          createImportSession: vi.fn(async () => ({ id: "session-1" })),
+        },
+      },
+      { parsers, restoreTopLevelLists: true },
+    );
+
+    // Import root list is still created for tracking / unassigned bookmarks
+    const importRoot = createdLists.find((l) => l.name === "Import Root");
+    expect(importRoot).toBeDefined();
+
+    // "Work" is a top-level exported list → must be created WITHOUT a parent
+    const workList = createdLists.find((l) => l.name === "Work");
+    expect(workList).toBeDefined();
+    expect(workList!.parentId).toBeUndefined();
+
+    // "Projects" is a child of "Work" → must be created under the new "Work" id
+    const projectsList = createdLists.find((l) => l.name === "Projects");
+    expect(projectsList).toBeDefined();
+    expect(projectsList!.parentId).toBe(workList!.id);
+
+    // Bookmark with listExternalIds is placed in "Projects" (not under import root)
+    const assigned = stagedBookmarks.find(
+      (b) => b.url === "https://example.com/1",
+    );
+    expect(assigned!.listIds).toEqual([projectsList!.id]);
+
+    // Bookmark with no list assignment falls back to the import root
+    const unassigned = stagedBookmarks.find(
+      (b) => b.url === "https://example.com/unassigned",
+    );
+    expect(unassigned!.listIds).toEqual([importRoot!.id]);
+  });
+
   it("handles HTML bookmarks with empty folder names", async () => {
     const htmlContent = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">

--- a/packages/shared/import-export/importer.ts
+++ b/packages/shared/import-export/importer.ts
@@ -44,6 +44,14 @@ export interface ImportOptions {
   parsers?: Partial<
     Record<ImportSource, (textContent: string) => ParsedImportFile>
   >;
+  /**
+   * When true, lists whose parent is the root of the export (i.e. they had no
+   * parent in the source) are recreated at the top level of the user's list
+   * space rather than being nested under the import-session root list.  This
+   * produces a faithful state-restoration when round-tripping a karakeep
+   * export back into a (possibly different) karakeep instance.
+   */
+  restoreTopLevelLists?: boolean;
 }
 
 export interface ImportResult {
@@ -68,7 +76,7 @@ export async function importBookmarksFromFile(
   },
   options: ImportOptions = {},
 ): Promise<ImportResult> {
-  const { parsers } = options;
+  const { parsers, restoreTopLevelLists } = options;
 
   const textContent = await file.text();
   const parsedImport = parsers?.[source]
@@ -111,7 +119,9 @@ export async function importBookmarksFromFile(
 
         const parentId = list.parentExternalId
           ? externalListIdToCreatedListId[list.parentExternalId]
-          : rootList.id;
+          : restoreTopLevelLists
+            ? undefined
+            : rootList.id;
 
         const createdList = await deps.createList({
           name: list.name.substring(0, MAX_LIST_NAME_LENGTH),
@@ -128,12 +138,12 @@ export async function importBookmarksFromFile(
       }
 
       // Break cycles or unresolved parent references by attaching remaining
-      // lists to the import root.
+      // lists to the import root (or top level when restoring).
       if (!createdAny) {
         for (const [externalId, list] of unresolvedLists) {
           const createdList = await deps.createList({
             name: list.name.substring(0, MAX_LIST_NAME_LENGTH),
-            parentId: rootList.id,
+            ...(restoreTopLevelLists ? {} : { parentId: rootList.id }),
             icon: list.icon ?? "📁",
             description: list.description,
             ...(list.type === "smart" && list.query


### PR DESCRIPTION
When importing a karakeep JSON export, top-level lists (those with no parent in the source file) were placed under the import-session root list instead of being created at the top level of the user's list space. This meant that a round-trip export → import produced a different hierarchy than the original, making it impossible to restore state on another instance.

Add a `restoreTopLevelLists` option to `importBookmarksFromFile` that, when enabled, creates exported top-level lists without a parent so the full original hierarchy is faithfully reproduced.  The import-session root list is still created and serves as the fallback container for any bookmarks that carry no list assignment.

Enable the option automatically for the "karakeep" source in the web hook so that every karakeep-format import is a true state restoration.