### PR TITLE
feat: add INFERENCE_TTL support for LM Studio JIT model unloading

### DIFF
--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -77,6 +77,7 @@ const allEnv = z.object({
     .default("structured"),
   INFERENCE_ENABLE_AUTO_TAGGING: stringBool("true"),
   INFERENCE_ENABLE_AUTO_SUMMARIZATION: stringBool("false"),
+  INFERENCE_TTL: z.coerce.number().optional(),
   OCR_CACHE_DIR: z.string().optional(),
   OCR_LANGS: z
     .string()
@@ -307,6 +308,7 @@ const serverConfigSchema = allEnv.transform((val, ctx) => {
           : val.INFERENCE_OUTPUT_SCHEMA,
       enableAutoTagging: val.INFERENCE_ENABLE_AUTO_TAGGING,
       enableAutoSummarization: val.INFERENCE_ENABLE_AUTO_SUMMARIZATION,
+      ttl: val.INFERENCE_TTL,
     },
     embedding: {
       textModel: val.EMBEDDING_TEXT_MODEL,

--- a/packages/shared/inference.ts
+++ b/packages/shared/inference.ts
@@ -63,6 +63,7 @@ export interface OpenAIInferenceConfig {
   maxOutputTokens: number;
   useMaxCompletionTokens: boolean;
   outputSchema: "structured" | "json" | "plain";
+  ttl?: number;
 }
 
 export class InferenceClientFactory {
@@ -114,6 +115,7 @@ export class OpenAIInferenceClient implements InferenceClient {
       maxOutputTokens: serverConfig.inference.maxOutputTokens,
       useMaxCompletionTokens: serverConfig.inference.useMaxCompletionTokens,
       outputSchema: serverConfig.inference.outputSchema,
+      ttl: serverConfig.inference.ttl,
     });
   }
 
@@ -145,6 +147,8 @@ export class OpenAIInferenceClient implements InferenceClient {
           },
           this.config.outputSchema,
         ),
+        // @ts-ignore
+        ttl: this.config.ttl,
       },
       {
         signal: optsWithDefaults.abortSignal,
@@ -187,6 +191,8 @@ export class OpenAIInferenceClient implements InferenceClient {
           },
           this.config.outputSchema,
         ),
+        // @ts-ignore
+        ttl: this.config.ttl,
         messages: [
           {
             role: "user",


### PR DESCRIPTION
Adds INFERENCE_TTL environment variable to pass a TTL value to OpenAI-compatible endpoints that support it (e.g. LM Studio). When set, the TTL is passed as an extra field in chat completion requests, allowing LM Studio to automatically unload JIT-loaded models after the specified number of seconds. This follows the same pattern as the existing OLLAMA_KEEP_ALIVE setting for Ollama users.