### PR TITLE
fix(mobile): add border to cards for dark mode visibility

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkCard.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkCard.tsx
@@ -580,7 +580,7 @@ export default function BookmarkCard({
 
   return (
     <View
-      className="overflow-hidden rounded-xl bg-card"
+      className="overflow-hidden rounded-xl border border-border bg-card"
       style={{ borderCurve: "continuous" }}
     >
       {comp}

--- a/apps/mobile/components/highlights/HighlightCard.tsx
+++ b/apps/mobile/components/highlights/HighlightCard.tsx
@@ -81,7 +81,7 @@ export default function HighlightCard({
 
   return (
     <View
-      className="overflow-hidden rounded-xl bg-card p-4"
+      className="overflow-hidden rounded-xl border border-border bg-card p-4"
       style={{ borderCurve: "continuous" }}
     >
       <View className="flex gap-3">

--- a/apps/mobile/components/ui/GroupedList.tsx
+++ b/apps/mobile/components/ui/GroupedList.tsx
@@ -21,7 +21,7 @@ function GroupedSection({
         </Text>
       )}
       <View
-        className="overflow-hidden rounded-xl bg-card"
+        className="overflow-hidden rounded-xl border border-border bg-card"
         style={{ borderCurve: "continuous" }}
       >
         {children}


### PR DESCRIPTION
Fixes #2624

## Summary
Add border to mobile card components to improve visibility in iOS dark mode.

## Changes
- Added `border border-border` classes to BookmarkCard, HighlightCard, and GroupedList
- Matches web app card styling for consistency

## Testing
- Verified on iOS device in dark mode