### PR TITLE
fix(browser-extension): handle unreachable background script on Firef…

### DIFF
--- a/apps/browser-extension/src/BookmarkSavedPage.tsx
+++ b/apps/browser-extension/src/BookmarkSavedPage.tsx
@@ -22,14 +22,19 @@ export default function BookmarkSavedPage() {
 
   const { mutate: deleteBookmark, isPending } = useDeleteBookmark({
     onSuccess: async () => {
-      const [currentTab] = await chrome.tabs.query({
-        active: true,
-        lastFocusedWindow: true,
-      });
-      await chrome.runtime.sendMessage({
-        type: MessageType.BOOKMARK_REFRESH_BADGE,
-        currentTab: currentTab,
-      });
+      try {
+        const [currentTab] = await chrome.tabs.query({
+          active: true,
+          lastFocusedWindow: true,
+        });
+        await chrome.runtime.sendMessage({
+          type: MessageType.BOOKMARK_REFRESH_BADGE,
+          currentTab: currentTab,
+        });
+      } catch {
+        // Badge refresh is best-effort — on Firefox Android the background
+        // script may not be reachable from the popup context.
+      }
       navigate("/bookmarkdeleted");
     },
     onError: (e) => {

--- a/apps/browser-extension/src/SavePage.tsx
+++ b/apps/browser-extension/src/SavePage.tsx
@@ -29,14 +29,19 @@ export default function SavePage() {
       },
       onSuccess: async () => {
         // After successful creation, update badge cache and notify background
-        const [currentTab] = await chrome.tabs.query({
-          active: true,
-          lastFocusedWindow: true,
-        });
-        await chrome.runtime.sendMessage({
-          type: MessageType.BOOKMARK_REFRESH_BADGE,
-          currentTab: currentTab,
-        });
+        try {
+          const [currentTab] = await chrome.tabs.query({
+            active: true,
+            lastFocusedWindow: true,
+          });
+          await chrome.runtime.sendMessage({
+            type: MessageType.BOOKMARK_REFRESH_BADGE,
+            currentTab: currentTab,
+          });
+        } catch {
+          // Badge refresh is best-effort — on Firefox Android the background
+          // script may not be reachable from the popup context.
+        }
       },
     }),
   );


### PR DESCRIPTION
…ox Android
Fixes https://github.com/karakeep-app/karakeep/issues/2122

When saving a bookmark via the Firefox Android extension, the popup tries to send a badge refresh message to the background script. On Firefox Android the background script isn't always reachable from the popup context, causing chrome.runtime.sendMessage to throw. This error bubbled up through the mutation's onSuccess callback and showed an error to the user even though the bookmark was saved.

Tested on firefox nightly on android