### PR TITLE
fix(mobile): prevent crash with certain bookmark attributes

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkCard.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkCard.tsx
@@ -352,7 +352,12 @@ function LinkCard({
   const url = bookmark.content.url;
   const parsedUrl = new URL(url);
 
-  const imageUrl = getBookmarkLinkImageUrl(bookmark.content);
+  const rawImageUrl = getBookmarkLinkImageUrl(bookmark.content);
+  // expo-image doesn't support SVG images and will crash on Android - skip external SVG URLs
+  const imageUrl =
+    rawImageUrl && !rawImageUrl.localAsset && /\.svg(\?|$)/i.test(rawImageUrl.url)
+      ? null
+      : rawImageUrl;
 
   let imageComp;
   if (imageUrl) {

--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -65,6 +65,7 @@ import {
   saveAsset,
   saveAssetFromFile,
   silentDeleteAsset,
+  SUPPORTED_ASSET_TYPES,
   SUPPORTED_UPLOAD_ASSET_TYPES,
 } from "@karakeep/shared/assetdb";
 import serverConfig from "@karakeep/shared/config";
@@ -1299,6 +1300,13 @@ async function downloadAndStoreFile(
         );
         if (!contentType) {
           throw new Error("No content type in the response");
+        }
+
+        if (!SUPPORTED_ASSET_TYPES.has(contentType)) {
+          logger.warn(
+            `[Crawler][${jobId}] Skipping download of unsupported content type "${contentType}" for ${fileType} at "${url.length > 100 ? url.slice(0, 100) + "..." : url}"`,
+          );
+          return null;
         }
 
         const assetId = newAssetId();


### PR DESCRIPTION
Fixes #2596

## Changes

- In `crawlerWorker`, check content-type from response headers before downloading the full file body. Return null early (with a warning log) for unsupported content types like `image/svg+xml`, avoiding wasted bandwidth and changing the log from error to warn level.
- In mobile `BookmarkCard`, filter out external SVG URLs before passing to `expo-image`, which does not support SVG and crashes on Android.

Generated with [Claude Code](https://claude.ai/code)