### PR TITLE
fix: use relative path for logout redirect to avoid port mismatch

### DIFF
--- a/apps/web/app/logout/page.tsx
+++ b/apps/web/app/logout/page.tsx
@@ -17,9 +17,9 @@ export default function Logout() {
     signOut({
       redirect: false,
       callbackUrl: "/",
-    }).then((d) => {
+    }).then(() => {
       clearHistory();
-      router.push(d.url);
+      router.push("/");
     });
   }, []);
   return <span />;


### PR DESCRIPTION
Fixes #2642

**Problem**
`signOut({ redirect: false })` returns an absolute URL built from `NEXTAUTH_URL` (e.g. `http://localhost:3000/`). When Docker remaps an external port to the container's internal port, the redirect sends users to the wrong port instead of the one they're actually on.

**Fix**
Replace `router.push(d.url)` with `router.push("/")` in `apps/web/app/logout/page.tsx`. The returned `d.url` is no longer needed — Next.js resolves relative paths against the user's current origin, so the port is always correct. The `signOut` call itself is unchanged; only the subsequent client redirect changes.

**What this doesn't change**
Session termination, the `callbackUrl: "/"` option, or any server-side auth behavior — this is purely a client-side redirect fix.