### PR TITLE
fix(crawler): skip getContentType network call when precrawled archive is provided

### DIFF
--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -2090,7 +2090,9 @@ async function runCrawler(
     `[Crawler][${jobId}] Will crawl "${url}" for link with id "${bookmarkId}"`,
   );
 
-  const contentType = await getContentType(url, jobId, job.abortSignal);
+  const contentType = precrawledArchiveAssetId
+    ? null
+    : await getContentType(url, jobId, job.abortSignal);
   job.abortSignal.throwIfAborted();
 
   // Link bookmarks get transformed into asset bookmarks if they point to a supported asset instead of a webpage


### PR DESCRIPTION
## Problem

When uploading a SingleFile HTML archive, the crawler still made an outbound HTTP GET to the original URL to determine content type — even though `precrawledArchiveAssetId` was already set, meaning the archive was already available locally.

This caused metadata loss for auth-gated or crawler-blocking sites: the pre-check HTTP request would fail, causing the bookmark to lose its title and other metadata, even though the uploaded archive was perfectly valid.

Root cause identified by reporter in #2579: `getContentType(url, ...)` is called unconditionally at line 2093 of `crawlerWorker.ts`, before checking whether `precrawledArchiveAssetId` is set.

## Fix

Guard the `getContentType` call so it is skipped when `precrawledArchiveAssetId` is set:

```typescript
// Before
const contentType = await getContentType(url, jobId, job.abortSignal);

// After
const contentType = precrawledArchiveAssetId
  ? null
  : await getContentType(url, jobId, job.abortSignal);
```

`precrawledArchiveAssetId` is already in scope (destructured at line 2084). A `null` content type safely falls through to the `else` branch that calls `crawlAndParseUrl`, which already has first-class handling for precrawled archives — it reads the uploaded HTML directly and skips all network requests.

## Scope

1 file, 3-line diff. No existing test infrastructure for `crawlerWorker.ts`.

Fixes #2579