### PR TITLE
fix(crawler): strip Twitter/X reply articles before Readability extraction

### DIFF
--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -120,6 +120,22 @@ function normalizeLazyLoadImages(document: Document): void {
   }
 }
 
+function stripTwitterReplies(document: Document, url: string): void {
+  try {
+    const hostname = new URL(url).hostname;
+    if (!hostname.includes("twitter.com") && !hostname.includes("x.com")) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  // Keep only the first tweet article element; remove all replies that follow
+  const articles = document.querySelectorAll('article[data-testid="tweet"]');
+  for (let i = 1; i < articles.length; i++) {
+    articles[i].remove();
+  }
+}
+
 function extractReadableContent(
   htmlContent: string,
   url: string,
@@ -128,6 +144,7 @@ function extractReadableContent(
   const dom = new JSDOM(htmlContent, { url, virtualConsole });
   try {
     normalizeLazyLoadImages(dom.window.document);
+    stripTwitterReplies(dom.window.document, url);
     const readableContent = new Readability(dom.window.document).parse();
     if (!readableContent || typeof readableContent.content !== "string") {
       return null;


### PR DESCRIPTION
## Problem

When bookmarking a tweet with browser cookies configured, Mozilla Readability treats reply threads as part of the article body. This pollutes reader view, the full-text search index, and AI tagging with content from other users' replies — not just the original tweet.

## Root Cause

Twitter/X renders replies as additional `article[data-testid="tweet"]` elements in the DOM after the main tweet. Readability has no way to distinguish the original tweet from replies, so it extracts everything.

## Fix

Add a `stripTwitterReplies` preprocessing step in `extractReadableContent` that:
1. Detects Twitter/X URLs by hostname
2. Queries all `article[data-testid="tweet"]` elements in the JSDOM document
3. Removes all but the first (the original tweet) before Readability runs

```typescript
function stripTwitterReplies(document: Document, url: string): void {
  const hostname = new URL(url).hostname;
  if (!hostname.includes("twitter.com") && !hostname.includes("x.com")) return;
  const articles = document.querySelectorAll('article[data-testid="tweet"]');
  for (let i = 1; i < articles.length; i++) articles[i].remove();
}
```

This runs before `new Readability(dom.window.document).parse()`, ensuring only the original tweet's text and media is extracted.

## Scope

1 file, 17-line addition. No behavior change for non-Twitter URLs.

Fixes #2651