### PR TITLE
fix(trpc): show collaborator bookmarks in public list view

### DIFF
--- a/packages/trpc/models/lists.ts
+++ b/packages/trpc/models/lists.ts
@@ -230,7 +230,7 @@ export abstract class List {
     const list = listObj.asZBookmarkList();
 
     const bookmarks = await Bookmark.loadMulti(authedCtx, {
-      ids: bookmarkIds,
+      listId: listdb.id,
       includeContent: false,
       limit: pagination.limit,
       sortOrder: pagination.order,

--- a/packages/trpc/routers/sharedLists.test.ts
+++ b/packages/trpc/routers/sharedLists.test.ts
@@ -866,6 +866,63 @@ describe("Shared Lists", () => {
       expect(ownerView.bookmarks).toHaveLength(2);
       expect(collabView.bookmarks).toHaveLength(2);
     });
+
+    test<CustomTestContext>("should return collaborator bookmarks when loading by listId instead of ids", async ({
+      apiCallers,
+    }) => {
+      const ownerApi = apiCallers[0];
+      const collaboratorApi = apiCallers[1];
+
+      const list = await ownerApi.lists.create({
+        name: "Shared List",
+        icon: "📚",
+        type: "manual",
+      });
+
+      // Owner adds a bookmark
+      const ownerBookmark = await ownerApi.bookmarks.createBookmark({
+        type: BookmarkTypes.TEXT,
+        text: "Owner's bookmark",
+      });
+
+      await ownerApi.lists.addToList({
+        listId: list.id,
+        bookmarkId: ownerBookmark.id,
+      });
+
+      // Share list with collaborator as editor
+      await addAndAcceptCollaborator(
+        ownerApi,
+        collaboratorApi,
+        list.id,
+        "editor",
+      );
+
+      // Collaborator adds their own bookmark
+      const collabBookmark = await collaboratorApi.bookmarks.createBookmark({
+        type: BookmarkTypes.TEXT,
+        text: "Collaborator's bookmark",
+      });
+
+      await collaboratorApi.lists.addToList({
+        listId: list.id,
+        bookmarkId: collabBookmark.id,
+      });
+
+      // Loading by listId returns all bookmarks (correct path used by public lists)
+      const byList = await ownerApi.bookmarks.getBookmarks({
+        listId: list.id,
+      });
+      expect(byList.bookmarks).toHaveLength(2);
+
+      // Loading by ids with owner context misses the collaborator's bookmark,
+      // because the ids-only path filters by userId. This is the code path
+      // that getPublicListContents previously used (before switching to listId).
+      const byIds = await ownerApi.bookmarks.getBookmarks({
+        ids: [ownerBookmark.id, collabBookmark.id],
+      });
+      expect(byIds.bookmarks).toHaveLength(1);
+    });
   });
 
   describe("Bookmark Editing Permissions", () => {


### PR DESCRIPTION
When a collaborative list is viewed via its public link, only the list owner's bookmarks are displayed — the bookmark count shows the correct total (including all collaborators), but the actual list is filtered to just the owner's items.

The root cause is in `getPublicListContents()` (`packages/trpc/models/lists.ts:232`). It fetches all bookmark IDs from `bookmarksInLists` (correctly), then passes them as `ids` to `Bookmark.loadMulti()`. The `ids`-only code path applies `eq(bookmarks.userId, ctx.user.id)`, which filters out bookmarks created by collaborators since they have different userIds.

The fix switches from `ids: bookmarkIds` to `listId: listdb.id`, which takes the `listId` code path. This path joins `bookmarksInLists` directly without a userId filter — the same path already used by the authenticated `getBookmarks` endpoint, where collaborative lists work correctly.

## Verification

- `npx vitest --run routers/sharedLists.test.ts` — 77 tests pass including the new regression test
- `npx vitest --run routers/bookmarks.test.ts` — 36 tests pass
- `npx vitest --run routers/lists.test.ts` — 22 tests pass
- `pnpm --filter @karakeep/trpc typecheck` — clean
- Full preflight (typecheck + lint + format across all 25 packages) — clean

Fixes #2594