### PR TITLE
feat: Add Readwise Reader import

### DIFF
--- a/apps/web/components/settings/ImportExport.tsx
+++ b/apps/web/components/settings/ImportExport.tsx
@@ -309,6 +309,25 @@ export function ImportExportRow() {
             <p>Import</p>
           </FilePickerButton>
         </ImportCard>
+        <ImportCard
+          text="Readwise Reader"
+          description={t(
+            "settings.import.import_bookmarks_from_readwise_reader_export",
+          )}
+        >
+          <FilePickerButton
+            size={"sm"}
+            loading={false}
+            accept=".csv"
+            multiple={false}
+            className="flex items-center gap-2"
+            onFileSelect={(file) =>
+              runUploadBookmarkFile({ file, source: "readwise-reader" })
+            }
+          >
+            <p>Import</p>
+          </FilePickerButton>
+        </ImportCard>
         <ExportButton />
       </div>
       {importProgress && (

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -311,6 +311,7 @@
       "import_bookmarks_from_tab_session_manager_export": "Import Bookmarks from Tab Session Manager",
       "import_bookmarks_from_mymind_export": "Import Bookmarks from mymind export",
       "import_bookmarks_from_instapaper_export": "Import Bookmarks from Instapaper export",
+      "import_bookmarks_from_readwise_reader_export": "Import Bookmarks from Readwise Reader export",
       "export_links_and_notes": "Export Links and Notes",
       "imported_bookmarks": "Imported Bookmarks"
     },

--- a/apps/web/lib/i18n/locales/en_US/translation.json
+++ b/apps/web/lib/i18n/locales/en_US/translation.json
@@ -343,7 +343,8 @@
       "export_links_and_notes": "Export Links and Notes",
       "imported_bookmarks": "Imported Bookmarks",
       "import_bookmarks_from_mymind_export": "Import Bookmarks from mymind export",
-      "import_bookmarks_from_instapaper_export": "Import Bookmarks from Instapaper export"
+      "import_bookmarks_from_instapaper_export": "Import Bookmarks from Instapaper export",
+      "import_bookmarks_from_readwise_reader_export": "Import Bookmarks from Readwise Reader export"
     },
     "api_keys": {
       "api_keys": "API Keys",

--- a/packages/shared/import-export/parsers.test.ts
+++ b/packages/shared/import-export/parsers.test.ts
@@ -665,4 +665,21 @@ describe("parseReadwiseReaderBookmarkFile", () => {
       "CSV file contains an invalid Readwise Reader bookmark file",
     );
   });
+
+  it("handles complex tag formatting in Readwise Reader CSV", () => {
+    const csv = `Title,URL,ID,Document tags,Saved date,Reading progress,Location,Seen
+"Single Tag","https://single.com","id1",['test'],"2026-03-14 23:55:23.291000+00:00","0","new","True"
+"Complex Tags","https://complex.com","id2","['test', 'test2', ""it's crazy""]","2026-03-14 23:55:23.291000+00:00","0","new","True"
+"Escaped Quotes","https://escaped.com","id3","['tag\\'s', 'another']","2026-03-14 23:55:23.291000+00:00","0","new","True"
+"Empty Tags","https://empty.com","id4",,"2026-03-14 23:55:23.291000+00:00","0","new","True"`;
+
+    const parsed = parseImportFile("readwise-reader", csv);
+    const result = parsed.bookmarks;
+
+    expect(result).toHaveLength(4);
+    expect(result[0].tags).toEqual(["test"]);
+    expect(result[1].tags).toEqual(["test", "test2", "it's crazy"]);
+    expect(result[2].tags).toEqual(["tag's", "another"]);
+    expect(result[3].tags).toEqual([]);
+  });
 });

--- a/packages/shared/import-export/parsers.test.ts
+++ b/packages/shared/import-export/parsers.test.ts
@@ -581,7 +581,7 @@ describe("parsePocketBookmarkFile", () => {
 
 describe("parseReadwiseReaderBookmarkFile", () => {
   it("parses a Readwise Reader CSV file with multiple items", () => {
-    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+    const csv = `Title,URL,ID,Document tags,Saved date,Reading progress,Location,Seen
 "Example Site","https://example.com","id1","['tag1','tag2']","2026-03-14 23:55:23.291000+00:00","0","new","True"
 "Example Tag less Site","https://notags.com","id2",,"2026-03-14 23:55:23.291000+00:00","100","new","True"
 "Archived Site","https://archived.com","id3",['tag1'],"2026-03-14 23:55:23.291000+00:00","100","archive","True"`;
@@ -625,7 +625,7 @@ describe("parseReadwiseReaderBookmarkFile", () => {
     });
   });
   it("filters out feed items", () => {
-    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+    const csv = `Title,URL,ID,Document tags,Saved date,Reading progress,Location,Seen
 "Feed Item","https://feed.com","id1",,"2026-03-14 23:55:23.291000+00:00","0","feed","True"
 "Normal Item","https://normal.com","id2",,"2026-03-14 23:55:23.291000+00:00","0","new","True"`;
 
@@ -637,7 +637,7 @@ describe("parseReadwiseReaderBookmarkFile", () => {
   });
 
   it("handles invalid JSON in DocumentTags", () => {
-    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+    const csv = `Title,URL,ID,Document tags,Saved date,Reading progress,Location,Seen
 "Invalid Tags","https://invalid.com","id1","not-json","2026-03-14 23:55:23.291000+00:00","0","new","True"`;
 
     const parsed = parseImportFile("readwise-reader", csv);
@@ -648,7 +648,7 @@ describe("parseReadwiseReaderBookmarkFile", () => {
   });
 
   it("handles empty URL", () => {
-    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+    const csv = `Title,URL,ID,Document tags,Saved date,Reading progress,Location,Seen
 "No URL","","id1",,"2026-03-14 23:55:23.291000+00:00","0","new","True"`;
 
     const parsed = parseImportFile("readwise-reader", csv);

--- a/packages/shared/import-export/parsers.test.ts
+++ b/packages/shared/import-export/parsers.test.ts
@@ -647,15 +647,14 @@ describe("parseReadwiseReaderBookmarkFile", () => {
     expect(result[0].tags).toEqual([]);
   });
 
-  it("handles missing URL", () => {
+  it("handles empty URL", () => {
     const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
 "No URL","","id1",,"2026-03-14 23:55:23.291000+00:00","0","new","True"`;
 
     const parsed = parseImportFile("readwise-reader", csv);
     const result = parsed.bookmarks;
 
-    expect(result).toHaveLength(1);
-    expect(result[0].content).toBeUndefined();
+    expect(result).toHaveLength(0);
   });
 
   it("throws error for invalid Readwise Reader CSV", () => {

--- a/packages/shared/import-export/parsers.test.ts
+++ b/packages/shared/import-export/parsers.test.ts
@@ -578,3 +578,92 @@ describe("parsePocketBookmarkFile", () => {
     expect(result.bookmarks[0].archived).toBeFalsy();
   });
 });
+
+describe("parseReadwiseReaderBookmarkFile", () => {
+  it("parses a Readwise Reader CSV file with multiple items", () => {
+    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+"Example Site","https://example.com","id1","['tag1','tag2']","2026-03-14 23:55:23.291000+00:00","0","new","True"
+"Example Tag less Site","https://notags.com","id2",,"2026-03-14 23:55:23.291000+00:00","100","new","True"
+"Archived Site","https://archived.com","id3",['tag1'],"2026-03-14 23:55:23.291000+00:00","100","archive","True"`;
+
+    const parsed = parseImportFile("readwise-reader", csv);
+    const result = parsed.bookmarks;
+
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toMatchObject({
+      title: "Example Site",
+      content: {
+        type: "link",
+        url: "https://example.com",
+      },
+      tags: ["tag1", "tag2"],
+      addDate: 1773532523.291,
+      archived: false,
+    });
+
+    expect(result[1]).toMatchObject({
+      title: "Example Tag less Site",
+      content: {
+        type: "link",
+        url: "https://notags.com",
+      },
+      tags: [],
+      addDate: 1773532523.291,
+      archived: false,
+    });
+
+    expect(result[2]).toMatchObject({
+      title: "Archived Site",
+      content: {
+        type: "link",
+        url: "https://archived.com",
+      },
+      tags: ["tag1"],
+      addDate: 1773532523.291,
+      archived: true,
+    });
+  });
+  it("filters out feed items", () => {
+    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+"Feed Item","https://feed.com","id1",,"2026-03-14 23:55:23.291000+00:00","0","feed","True"
+"Normal Item","https://normal.com","id2",,"2026-03-14 23:55:23.291000+00:00","0","new","True"`;
+
+    const parsed = parseImportFile("readwise-reader", csv);
+    const result = parsed.bookmarks;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Normal Item");
+  });
+
+  it("handles invalid JSON in DocumentTags", () => {
+    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+"Invalid Tags","https://invalid.com","id1","not-json","2026-03-14 23:55:23.291000+00:00","0","new","True"`;
+
+    const parsed = parseImportFile("readwise-reader", csv);
+    const result = parsed.bookmarks;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tags).toEqual([]);
+  });
+
+  it("handles missing URL", () => {
+    const csv = `Title,Url,Id,Document Tags,Saved Date,Reading Progress,Location,Seen
+"No URL","","id1",,"2026-03-14 23:55:23.291000+00:00","0","new","True"`;
+
+    const parsed = parseImportFile("readwise-reader", csv);
+    const result = parsed.bookmarks;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBeUndefined();
+  });
+
+  it("throws error for invalid Readwise Reader CSV", () => {
+    const csv = `Title,Url,Id
+"Missing Columns","https://missing.com","id1"`;
+
+    expect(() => parseImportFile("readwise-reader", csv)).toThrow(
+      "CSV file contains an invalid Readwise Reader bookmark file",
+    );
+  });
+});

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -513,6 +513,13 @@ function parseReadwiseReaderBookmarkFile(
   const record = parse(textContent, {
     columns: true,
     skip_empty_lines: true,
+    cast: function (value, context) {
+      //Replace for json parsing.
+      if (context.index === 3) {
+        return value.replace(/'/g, '"');
+      }
+      return value;
+    },
   });
 
   const parsed = zReadwiseReaderExportScheme.safeParse(record);

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -17,6 +17,7 @@ export type ImportSource =
   | "linkwarden"
   | "tab-session-manager"
   | "mymind"
+  | "readwise-reader"
   | "instapaper";
 
 export interface ParsedBookmark {
@@ -493,6 +494,69 @@ function parseInstapaperBookmarkFile(textContent: string): ParsedBookmark[] {
   });
 }
 
+function parseReadwiseReaderBookmarkFile(
+  textContent: string,
+): ParsedBookmark[] {
+  const zReadwiseReaderRecordScheme = z.object({
+    Title: z.string(),
+    Url: z.string(),
+    Id: z.string(),
+    DocumentTags: z.string(),
+    SavedDate: z.string(),
+    ReadingProgress: z.string(),
+    Location: z.string(),
+    Seen: z.string(),
+  });
+
+  const zReadwiseReaderExportScheme = z.array(zReadwiseReaderRecordScheme);
+
+  const record = parse(textContent, {
+    columns: true,
+    skip_empty_lines: true,
+  });
+
+  const parsed = zReadwiseReaderExportScheme.safeParse(record);
+
+  if (!parsed.success) {
+    throw new Error(
+      `CSV file contains an invalid Readwise Reader bookmark file: ${parsed.error.toString()}`,
+    );
+  }
+
+  //Feed (RSS) articles are included automatically, so filter them.
+  const feedFilteredArticles = parsed.data.filter(
+    (record) => record.Location !== "feed",
+  );
+
+  return feedFilteredArticles.map((record) => {
+    let content: ParsedBookmark["content"];
+    if (record.Url && record.Url.trim().length > 0) {
+      content = { type: BookmarkTypes.LINK as const, url: record.Url.trim() };
+    }
+
+    const addDate = parseInt(record.SavedDate);
+
+    let tags: string[] = [];
+    try {
+      const parsedTags = JSON.parse(record.DocumentTags);
+      if (Array.isArray(parsedTags)) {
+        tags = parsedTags.map((tag) => tag.toString().trim());
+      }
+    } catch {
+      tags = [];
+    }
+
+    return {
+      title: record.Title || "",
+      content,
+      addDate,
+      tags,
+      paths: [], // TODO
+      archived: record.Location === "archive",
+    };
+  });
+}
+
 function deduplicateBookmarks(bookmarks: ParsedBookmark[]): ParsedBookmark[] {
   const deduplicatedBookmarksMap = new Map<string, ParsedBookmark>();
   const textBookmarks: ParsedBookmark[] = [];
@@ -579,6 +643,9 @@ export function parseImportFile(
       break;
     case "instapaper":
       result = parseInstapaperBookmarkFile(textContent);
+      break;
+    case "readwise-reader":
+      result = parseReadwiseReaderBookmarkFile(textContent);
       break;
   }
   return { bookmarks: deduplicateBookmarks(result), lists: [] };

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -505,7 +505,7 @@ function parseReadwiseReaderBookmarkFile(
     "Saved date": z.string(),
     "Reading progress": z.string(),
     Location: z.string(),
-    Seen: z.string(),
+    Seen: z.enum(["True", "False"]),
   });
 
   const zReadwiseReaderExportScheme = z.array(zReadwiseReaderRecordScheme);

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -501,9 +501,9 @@ function parseReadwiseReaderBookmarkFile(
     Title: z.string(),
     Url: z.string(),
     Id: z.string(),
-    DocumentTags: z.string(),
-    SavedDate: z.string(),
-    ReadingProgress: z.string(),
+    "Document Tags": z.string(),
+    "Saved Date": z.string(),
+    "Reading Progress": z.string(),
     Location: z.string(),
     Seen: z.string(),
   });
@@ -534,13 +534,16 @@ function parseReadwiseReaderBookmarkFile(
       content = { type: BookmarkTypes.LINK as const, url: record.Url.trim() };
     }
 
-    const addDate = parseInt(record.SavedDate);
+    const addDate = new Date(record["Saved Date"]).getTime() / 1000;
 
     let tags: string[] = [];
     try {
-      const parsedTags = JSON.parse(record.DocumentTags);
-      if (Array.isArray(parsedTags)) {
-        tags = parsedTags.map((tag) => tag.toString().trim());
+      const documentTags = record["Document Tags"];
+      if (documentTags) {
+        const parsedTags = JSON.parse(documentTags);
+        if (Array.isArray(parsedTags)) {
+          tags = parsedTags.map((tag) => tag.toString().trim());
+        }
       }
     } catch {
       tags = [];

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -514,7 +514,7 @@ function parseReadwiseReaderBookmarkFile(
     columns: true,
     skip_empty_lines: true,
     cast: function (value, context) {
-      //Replace for json parsing.
+      //Replace for json parsing; original comes with \' instead of \" so it's not json parsable.
       if (context.index === 3) {
         return value.replace(/'/g, '"');
       }
@@ -530,16 +530,19 @@ function parseReadwiseReaderBookmarkFile(
     );
   }
 
-  //Feed (RSS) articles are included automatically, so filter them.
+  //Feed (RSS) articles are included automatically, so filter them. Only include actively added links.
   const feedFilteredArticles = parsed.data.filter(
     (record) => record.Location !== "feed",
   );
+  const emptyFilteredArticles = feedFilteredArticles.filter(
+    (record) => record.Url && record.Url.trim().length > 0,
+  );
 
-  return feedFilteredArticles.map((record) => {
-    let content: ParsedBookmark["content"];
-    if (record.Url && record.Url.trim().length > 0) {
-      content = { type: BookmarkTypes.LINK as const, url: record.Url.trim() };
-    }
+  return emptyFilteredArticles.map((record) => {
+    let content: ParsedBookmark["content"] = {
+      type: BookmarkTypes.LINK as const,
+      url: record.Url.trim(),
+    };
 
     const addDate = new Date(record["Saved Date"]).getTime() / 1000;
 

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -515,8 +515,12 @@ function parseReadwiseReaderBookmarkFile(
     skip_empty_lines: true,
     cast: function (value, context) {
       //Replace for json parsing; original comes with \' instead of \" so it's not json parsable.
-      if (context.index === 3) {
-        return value.replace(/'/g, '"');
+      if (context.column === "Document tags") {
+        return value
+          .replace(/\\'/g, "'")
+          .replace(/(^|\[|,)\s*'/g, '$1"')
+          .replace(/'\s*(]|,|$)/g, '"$1')
+          .replace(/""/g, '"');
       }
       return value;
     },

--- a/packages/shared/import-export/parsers.ts
+++ b/packages/shared/import-export/parsers.ts
@@ -499,11 +499,11 @@ function parseReadwiseReaderBookmarkFile(
 ): ParsedBookmark[] {
   const zReadwiseReaderRecordScheme = z.object({
     Title: z.string(),
-    Url: z.string(),
-    Id: z.string(),
-    "Document Tags": z.string(),
-    "Saved Date": z.string(),
-    "Reading Progress": z.string(),
+    URL: z.string(),
+    ID: z.string(),
+    "Document tags": z.string(),
+    "Saved date": z.string(),
+    "Reading progress": z.string(),
     Location: z.string(),
     Seen: z.string(),
   });
@@ -535,20 +535,20 @@ function parseReadwiseReaderBookmarkFile(
     (record) => record.Location !== "feed",
   );
   const emptyFilteredArticles = feedFilteredArticles.filter(
-    (record) => record.Url && record.Url.trim().length > 0,
+    (record) => record.URL && record.URL.trim().length > 0,
   );
 
   return emptyFilteredArticles.map((record) => {
     let content: ParsedBookmark["content"] = {
       type: BookmarkTypes.LINK as const,
-      url: record.Url.trim(),
+      url: record.URL.trim(),
     };
 
-    const addDate = new Date(record["Saved Date"]).getTime() / 1000;
+    const addDate = new Date(record["Saved date"]).getTime() / 1000;
 
     let tags: string[] = [];
     try {
-      const documentTags = record["Document Tags"];
+      const documentTags = record["Document tags"];
       if (documentTags) {
         const parsedTags = JSON.parse(documentTags);
         if (Array.isArray(parsedTags)) {


### PR DESCRIPTION
As the title suggests: This PR adds the functionality of importing from Readwise Reader's CSV export file. 

<img width="1437" height="793" alt="image" src="https://github.com/user-attachments/assets/e0d2fff0-6ce5-449f-866d-76033efeaffa" />

See issue #2588 for more information.
