### PR TITLE
feat(mobile): add keep screen on toggle for bookmark viewing

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/(settings)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(settings)/index.tsx
@@ -202,6 +202,22 @@ export default function Settings() {
             }
           />
         </View>
+        <Divider orientation="horizontal" className="mx-6 my-1" />
+        <View className="flex flex-row items-center justify-between gap-8 px-4 py-1">
+          <Text className="flex-1" numberOfLines={1}>
+            Keep screen on while reading
+          </Text>
+          <Switch
+            className="shrink-0"
+            value={settings.keepScreenOnWhileReading}
+            onValueChange={(value) =>
+              setSettings({
+                ...settings,
+                keepScreenOnWhileReading: value,
+              })
+            }
+          />
+        </View>
       </View>
 
       <SectionHeader title="Media" />

--- a/apps/mobile/app/dashboard/(tabs)/(settings)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(settings)/index.tsx
@@ -209,13 +209,15 @@ export default function Settings() {
           </Text>
           <Switch
             className="shrink-0"
+            disabled={isSettingsLoading}
             value={settings.keepScreenOnWhileReading}
-            onValueChange={(value) =>
+            onValueChange={(value) => {
+              if (isSettingsLoading) return;
               setSettings({
                 ...settings,
                 keepScreenOnWhileReading: value,
-              })
-            }
+              });
+            }}
           />
         </View>
       </View>

--- a/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { KeyboardAvoidingView, Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useKeepAwake } from "expo-keep-awake";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import BookmarkAssetView from "@/components/bookmarks/BookmarkAssetView";
 import BookmarkLinkTypeSelector, {
@@ -19,6 +20,11 @@ import { useColorScheme } from "nativewind";
 
 import { useTRPC } from "@karakeep/shared-react/trpc";
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
+
+function KeepScreenOn() {
+  useKeepAwake();
+  return null;
+}
 
 export default function BookmarkView() {
   const insets = useSafeAreaInsets();
@@ -84,6 +90,7 @@ export default function BookmarkView() {
       style={{ flex: 1, paddingBottom: insets.bottom + 8 }}
       behavior="height"
     >
+      {settings.keepScreenOnWhileReading && <KeepScreenOn />}
       <Stack.Screen
         options={{
           headerTitle: title ?? "",

--- a/apps/mobile/lib/settings.ts
+++ b/apps/mobile/lib/settings.ts
@@ -18,6 +18,7 @@ const zSettingsSchema = z.object({
     .optional()
     .default("reader"),
   showNotes: z.boolean().optional().default(false),
+  keepScreenOnWhileReading: z.boolean().optional().default(false),
   customHeaders: z.record(z.string(), z.string()).optional().default({}),
   // Reader settings (local device overrides)
   readerFontSize: z.number().int().min(12).max(24).optional(),
@@ -42,6 +43,7 @@ const useSettings = create<AppSettingsState>((set, get) => ({
       theme: "system",
       defaultBookmarkView: "reader",
       showNotes: false,
+      keepScreenOnWhileReading: false,
       customHeaders: {},
     },
   },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -48,6 +48,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-image-picker": "~17.0.10",
+    "expo-keep-awake": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-navigation-bar": "~5.0.10",
     "expo-router": "~6.0.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       expo-image-picker:
         specifier: ~17.0.10
         version: 17.0.10(expo@54.0.31)
+      expo-keep-awake:
+        specifier: ~15.0.8
+        version: 15.0.8(expo@54.0.31)(react@19.2.3)
       expo-linking:
         specifier: ~8.0.11
         version: 8.0.11(expo@54.0.31)(react-native@0.81.5(@babel/core@7.26.0)(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -795,7 +798,7 @@ importers:
         version: 3.4.1
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.0.6(@types/node@24.10.3)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.3)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.3)(happy-dom@20.3.9)(jiti@2.4.2)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -1336,7 +1339,7 @@ importers:
         version: 6.4.17
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.3)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.1.1(typescript@5.9.3)(vite@7.0.6(@types/node@24.10.3)(jiti@2.4.2)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.3)(happy-dom@20.3.9)(jiti@2.4.2)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- Adds a "Keep screen on while reading" toggle in the mobile app's Settings → Reading section, defaulting off, persisted via the existing Zustand + `expo-secure-store` settings store.
- Activates `expo-keep-awake` only while a bookmark is open in the bookmark detail screen, covering every in-app view (LINK reader, browser/WebView, screenshot, archive, pdf, plus TEXT and ASSET image/PDF). Wake lock is automatically released as soon as the user navigates away or toggles the setting off.
- Mounted via a small `KeepScreenOn` helper component gated on the setting boolean, so React's "no conditional hooks" rule is respected and toggling the setting takes effect instantly without app restart.

Closes #2650.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format` (run as part of the pre-commit `preflight` — all 61 monorepo tasks pass)
- [ ] On a real device or simulator, with the toggle **off**, open a bookmark, leave idle past the OS screen-timeout, confirm screen dims as before
- [ ] With the toggle **on**, open a bookmark, leave idle past the OS screen-timeout, confirm screen stays on
- [ ] Navigate back to the bookmark list, leave idle, confirm screen now dims normally (wake lock released)
- [ ] Toggle off while a bookmark is still open, confirm screen now dims after the OS timeout
- [ ] Verify across all bookmark view types: LINK reader, LINK browser, LINK screenshot, LINK archive, LINK pdf, TEXT, ASSET image, ASSET pdf
- [ ] Kill and relaunch the app, confirm the toggle setting persists via SecureStore

## Notes
- `pnpm-lock.yaml` includes some incidental churn from pnpm renormalizing two unrelated `vite-tsconfig-paths` peer pins (vite 7.0.6 ↔ 7.3.1 swap between two workspaces). Both versions were already in the lockfile; this is a pnpm side-effect of running `install` and is not behavioral.