### PR TITLE
feat(mobile): open links and images in in-app browser

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkHtmlHighlighterDom.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkHtmlHighlighterDom.tsx
@@ -48,6 +48,29 @@ export default function BookmarkHtmlHighlighterDom({
   }) => void;
   dom?: import("expo/dom").DOMProps;
 }) {
+  // Strip href from links so the browser treats them as regular selectable text
+  // instead of activating native link gestures (iOS preview, Android drag).
+  // The URL is preserved in data-href for our click handler.
+  useEffect(() => {
+    const stripHrefs = () => {
+      document.querySelectorAll("a[href]").forEach((a) => {
+        const anchor = a as HTMLAnchorElement;
+        if (!anchor.dataset.href) {
+          anchor.dataset.href = anchor.getAttribute("href")!;
+          anchor.removeAttribute("href");
+        }
+      });
+    };
+
+    stripHrefs();
+
+    // Re-strip if the DOM changes (e.g. highlight effects re-render content)
+    const observer = new MutationObserver(stripHrefs);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+
   // Intercept link and image clicks to open them externally
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -59,12 +82,16 @@ export default function BookmarkHtmlHighlighterDom({
         return;
       }
 
-      // Check for link clicks
+      // Check for link clicks (href is stored in data-href)
       const anchor = target.closest("a");
-      if (anchor?.href) {
-        const href = anchor.href;
+      const href = anchor?.dataset.href;
+      if (href) {
         // Allow in-page anchor links
-        if (anchor.getAttribute("href")?.startsWith("#")) {
+        if (href.startsWith("#")) {
+          const targetEl = document.querySelector(href);
+          if (targetEl) {
+            targetEl.scrollIntoView();
+          }
           return;
         }
         // Ignore javascript: URLs
@@ -86,8 +113,8 @@ export default function BookmarkHtmlHighlighterDom({
       }
     };
 
-    document.addEventListener("click", handleClick, true);
-    return () => document.removeEventListener("click", handleClick, true);
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
   }, [onLinkPress, onImagePress]);
   return (
     <div style={{ maxWidth: "100vw", overflowX: "hidden" }}>

--- a/apps/mobile/components/bookmarks/BookmarkHtmlHighlighterDom.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkHtmlHighlighterDom.tsx
@@ -64,10 +64,7 @@ export default function BookmarkHtmlHighlighterDom({
       if (anchor?.href) {
         const href = anchor.href;
         // Allow in-page anchor links
-        if (
-          href.startsWith("#") ||
-          anchor.getAttribute("href")?.startsWith("#")
-        ) {
+        if (anchor.getAttribute("href")?.startsWith("#")) {
           return;
         }
         // Ignore javascript: URLs

--- a/apps/mobile/components/bookmarks/BookmarkHtmlHighlighterDom.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkHtmlHighlighterDom.tsx
@@ -2,6 +2,8 @@
 
 import "@/globals.css";
 
+import { useEffect } from "react";
+
 import type { Highlight } from "@karakeep/shared-react/components/BookmarkHtmlHighlighter";
 import BookmarkHTMLHighlighter from "@karakeep/shared-react/components/BookmarkHtmlHighlighter";
 import ScrollProgressTracker from "@karakeep/shared-react/components/ScrollProgressTracker";
@@ -14,6 +16,8 @@ export default function BookmarkHtmlHighlighterDom({
   onHighlight,
   onUpdateHighlight,
   onDeleteHighlight,
+  onLinkPress,
+  onImagePress,
   readingProgressOffset,
   readingProgressAnchor,
   restoreReadingPosition,
@@ -27,6 +31,8 @@ export default function BookmarkHtmlHighlighterDom({
   onHighlight?: (highlight: Highlight) => void;
   onUpdateHighlight?: (highlight: Highlight) => void;
   onDeleteHighlight?: (highlight: Highlight) => void;
+  onLinkPress?: (url: string) => void;
+  onImagePress?: (src: string) => void;
   readingProgressOffset?: number | null;
   readingProgressAnchor?: string | null;
   restoreReadingPosition?: boolean;
@@ -42,6 +48,50 @@ export default function BookmarkHtmlHighlighterDom({
   }) => void;
   dom?: import("expo/dom").DOMProps;
 }) {
+  // Intercept link and image clicks to open them externally
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+
+      // Don't intercept if the user is selecting text (for highlighting)
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) {
+        return;
+      }
+
+      // Check for link clicks
+      const anchor = target.closest("a");
+      if (anchor?.href) {
+        const href = anchor.href;
+        // Allow in-page anchor links
+        if (
+          href.startsWith("#") ||
+          anchor.getAttribute("href")?.startsWith("#")
+        ) {
+          return;
+        }
+        // Ignore javascript: URLs
+        if (href.startsWith("javascript:")) {
+          e.preventDefault();
+          return;
+        }
+        e.preventDefault();
+        onLinkPress?.(href);
+        return;
+      }
+
+      // Check for image clicks
+      const img = target.closest("img");
+      if (img?.src) {
+        e.preventDefault();
+        onImagePress?.(img.src);
+        return;
+      }
+    };
+
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  }, [onLinkPress, onImagePress]);
   return (
     <div style={{ maxWidth: "100vw", overflowX: "hidden" }}>
       <ScrollProgressTracker

--- a/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { Linking, Pressable, TouchableOpacity, View } from "react-native";
 import ImageView from "react-native-image-viewing";
 import WebView from "react-native-webview";
-import { ShouldStartLoadRequest } from "react-native-webview/lib/WebViewTypes";
-import { WebViewSourceUri } from "react-native-webview/lib/WebViewTypes";
+import { ShouldStartLoadRequest, WebViewSourceUri } from "react-native-webview/lib/WebViewTypes";
 import * as WebBrowser from "expo-web-browser";
 import { Text } from "@/components/ui/Text";
 import { useAssetUrl } from "@/lib/hooks";
@@ -49,19 +48,16 @@ export function BookmarkLinkBrowserPreview({
     throw new Error("Wrong content type rendered");
   }
 
-  const hasLoaded = useRef(false);
-
   const onShouldStartLoadWithRequest = useCallback(
     (request: ShouldStartLoadRequest) => {
-      // Allow the initial page load
-      if (!hasLoaded.current) {
-        hasLoaded.current = true;
+      const bookmarkOrigin = new URL(bookmark.content.url).origin;
+      if (request.url.startsWith(bookmarkOrigin)) {
         return true;
       }
       openUrlExternally(request.url);
       return false;
     },
-    [],
+    [bookmark.content.url],
   );
 
   return (

--- a/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
@@ -2,7 +2,10 @@ import { useCallback, useState } from "react";
 import { Linking, Pressable, TouchableOpacity, View } from "react-native";
 import ImageView from "react-native-image-viewing";
 import WebView from "react-native-webview";
-import { ShouldStartLoadRequest, WebViewSourceUri } from "react-native-webview/lib/WebViewTypes";
+import {
+  ShouldStartLoadRequest,
+  WebViewSourceUri,
+} from "react-native-webview/lib/WebViewTypes";
 import * as WebBrowser from "expo-web-browser";
 import { Text } from "@/components/ui/Text";
 import { useAssetUrl } from "@/lib/hooks";

--- a/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
-import { Pressable, TouchableOpacity, View } from "react-native";
+import { useCallback, useRef, useState } from "react";
+import { Linking, Pressable, TouchableOpacity, View } from "react-native";
 import ImageView from "react-native-image-viewing";
 import WebView from "react-native-webview";
+import { ShouldStartLoadRequest } from "react-native-webview/lib/WebViewTypes";
 import { WebViewSourceUri } from "react-native-webview/lib/WebViewTypes";
+import * as WebBrowser from "expo-web-browser";
 import { Text } from "@/components/ui/Text";
 import { useAssetUrl } from "@/lib/hooks";
 import { useReaderSettings, WEBVIEW_FONT_FAMILIES } from "@/lib/readerSettings";
@@ -25,6 +27,19 @@ import BookmarkAssetImage from "./BookmarkAssetImage";
 import BookmarkHtmlHighlighterDom from "./BookmarkHtmlHighlighterDom";
 import { PDFViewer } from "./PDFViewer";
 
+function openUrlExternally(url: string) {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    void WebBrowser.openBrowserAsync(url);
+  } else if (
+    url.startsWith("mailto:") ||
+    url.startsWith("tel:") ||
+    url.startsWith("sms:")
+  ) {
+    void Linking.openURL(url);
+  }
+  // Ignore javascript: and other schemes
+}
+
 export function BookmarkLinkBrowserPreview({
   bookmark,
 }: {
@@ -34,11 +49,28 @@ export function BookmarkLinkBrowserPreview({
     throw new Error("Wrong content type rendered");
   }
 
+  const hasLoaded = useRef(false);
+
+  const onShouldStartLoadWithRequest = useCallback(
+    (request: ShouldStartLoadRequest) => {
+      // Allow the initial page load
+      if (!hasLoaded.current) {
+        hasLoaded.current = true;
+        return true;
+      }
+      openUrlExternally(request.url);
+      return false;
+    },
+    [],
+  );
+
   return (
     <WebView
       startInLoadingState={true}
       mediaPlaybackRequiresUserAction={true}
       source={{ uri: bookmark.content.url }}
+      setSupportMultipleWindows={false}
+      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
     />
   );
 }
@@ -112,6 +144,16 @@ export function BookmarkLinkReaderPreview({
     bookmarkId: bookmark.id,
   });
 
+  const [viewingImage, setViewingImage] = useState<string | null>(null);
+
+  const handleLinkPress = useCallback((url: string) => {
+    openUrlExternally(url);
+  }, []);
+
+  const handleImagePress = useCallback((src: string) => {
+    setViewingImage(src);
+  }, []);
+
   if (isLoading) {
     return <FullPageSpinner />;
   }
@@ -135,6 +177,13 @@ export function BookmarkLinkReaderPreview({
 
   return (
     <View className="flex-1 bg-background">
+      <ImageView
+        visible={!!viewingImage}
+        imageIndex={0}
+        onRequestClose={() => setViewingImage(null)}
+        doubleTapToZoomEnabled={true}
+        images={viewingImage ? [{ uri: viewingImage }] : []}
+      />
       {showBanner && (
         <View className="flex-row items-center gap-2 border-b border-border bg-background px-4 py-2">
           <BookOpen size={16} className="text-muted-foreground" />
@@ -165,6 +214,8 @@ export function BookmarkLinkReaderPreview({
         restoreReadingPosition={restorePosition}
         onSavePosition={onSavePosition}
         onScrollPositionChange={onScrollPositionChange}
+        onLinkPress={handleLinkPress}
+        onImagePress={handleImagePress}
         onHighlight={(h) =>
           createHighlight({
             startOffset: h.startOffset,
@@ -204,6 +255,22 @@ export function BookmarkLinkArchivePreview({
 
   const assetSource = useAssetUrl(asset?.id ?? "");
 
+  const originUri = assetSource.uri;
+  const onShouldStartLoadWithRequest = useCallback(
+    (request: ShouldStartLoadRequest) => {
+      // Allow loading the archive asset itself
+      if (
+        originUri &&
+        (request.url === originUri || request.url.startsWith(originUri))
+      ) {
+        return true;
+      }
+      openUrlExternally(request.url);
+      return false;
+    },
+    [originUri],
+  );
+
   if (!asset) {
     return (
       <View className="flex-1 bg-background">
@@ -216,12 +283,15 @@ export function BookmarkLinkArchivePreview({
     uri: assetSource.uri!,
     headers: assetSource.headers,
   };
+
   return (
     <WebView
       startInLoadingState={true}
       mediaPlaybackRequiresUserAction={true}
       source={webViewUri}
       decelerationRate={0.998}
+      setSupportMultipleWindows={false}
+      onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
     />
   );
 }

--- a/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkLinkPreview.tsx
@@ -51,23 +51,25 @@ export function BookmarkLinkBrowserPreview({
     throw new Error("Wrong content type rendered");
   }
 
+  const bookmarkUrl = bookmark.content.url;
+
   const onShouldStartLoadWithRequest = useCallback(
     (request: ShouldStartLoadRequest) => {
-      const bookmarkOrigin = new URL(bookmark.content.url).origin;
+      const bookmarkOrigin = new URL(bookmarkUrl).origin;
       if (request.url.startsWith(bookmarkOrigin)) {
         return true;
       }
       openUrlExternally(request.url);
       return false;
     },
-    [bookmark.content.url],
+    [bookmarkUrl],
   );
 
   return (
     <WebView
       startInLoadingState={true}
       mediaPlaybackRequiresUserAction={true}
-      source={{ uri: bookmark.content.url }}
+      source={{ uri: bookmarkUrl }}
       setSupportMultipleWindows={false}
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
     />


### PR DESCRIPTION
## Summary

When viewing a bookmark in the mobile app, clicking a link or media item within the reader, browser, or archive view navigates the current embedded WebView away from the bookmark content. Since there are no back/forward navigation controls in these embedded WebViews, the user gets stuck on the navigated page with no way to return to the bookmark they were reading — the only option is to exit the bookmark preview entirely and reopen it.

This PR fixes the behavior by intercepting link and media clicks:

- Links in all bookmark views (reader, browser, archive) now open in an in-app browser overlay (via expo-web-browser) instead of navigating the embedded WebView
- Images in reader view open in a fullscreen image viewer
- Edge cases are handled: anchor links still work for in-page navigation, mailto/tel links use native handlers, javascript: URLs are ignored, and text highlighting is not disrupted

### Link long-press fix

On mobile, long-pressing a link triggers native browser gestures (iOS shows a link preview sheet, Android initiates drag-and-drop) instead of allowing text selection for highlighting. Simply preventing these events via CSS/JS isn't enough — the browser still recognizes the element as a link and uses link-specific gesture handling rather than falling through to text selection.

To fix this, we strip the `href` attribute from all `<a>` tags in the reader content and store the URL in a `data-href` attribute instead. This makes the browser treat links as regular styled text, so long-press triggers normal text selection for highlighting. A `MutationObserver` re-strips any links that reappear after DOM changes (e.g. from highlight effects). The click handler reads `data-href` to open links on tap, and in-page anchor links use `scrollIntoView()` directly.

## Test plan
- [ ] Open a link bookmark in reader view, click a hyperlink → should open in-app browser overlay
- [ ] Click an image in reader view → should open fullscreen image viewer
- [ ] Open a bookmark in browser view, click a link on the page → should open in-app browser
- [ ] Open a bookmark in archive view, click a link → should open in-app browser
- [ ] Long-press a link in reader view → should select text for highlighting, not show link preview
- [ ] Test text highlighting still works across links and regular text in reader view
- [ ] Test anchor links (table of contents) still work within reader view