### PR TITLE
fix(mobile): share PDF file for link bookmarks pointing to PDFs

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkCard.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkCard.tsx
@@ -104,12 +104,45 @@ function ActionBar({ bookmark }: { bookmark: ZBookmark }) {
   const handleShare = async () => {
     try {
       switch (bookmark.content.type) {
-        case BookmarkTypes.LINK:
-          await Share.share({
-            url: bookmark.content.url,
-            message: bookmark.content.url,
-          });
+        case BookmarkTypes.LINK: {
+          const pdfAsset = bookmark.assets.find((a) => a.assetType === "pdf");
+          if (pdfAsset && (await Sharing.isAvailableAsync())) {
+            const assetUrl = `${settings.address}/api/assets/${pdfAsset.id}`;
+            const fileName =
+              pdfAsset.fileName ||
+              `${bookmark.title || bookmark.content.title || "document"}.pdf`;
+            const fileUri = `${FileSystem.documentDirectory}${fileName}`;
+
+            const downloadResult = await FileSystem.downloadAsync(
+              assetUrl,
+              fileUri,
+              {
+                headers: buildApiHeaders(
+                  settings.apiKey,
+                  settings.customHeaders,
+                ),
+              },
+            );
+
+            if (downloadResult.status === 200) {
+              await Sharing.shareAsync(downloadResult.uri, {
+                mimeType: "application/pdf",
+                UTI: "com.adobe.pdf",
+              });
+              await FileSystem.deleteAsync(downloadResult.uri, {
+                idempotent: true,
+              });
+            } else {
+              throw new Error("Failed to download PDF");
+            }
+          } else {
+            await Share.share({
+              url: bookmark.content.url,
+              message: bookmark.content.url,
+            });
+          }
           break;
+        }
 
         case BookmarkTypes.TEXT:
           await Clipboard.setStringAsync(bookmark.content.text);


### PR DESCRIPTION
## Summary

- When sharing a link bookmark that has a crawled PDF asset (e.g. an arxiv paper URL), the share button now downloads and shares the actual PDF file instead of just the URL string
- This allows external PDF readers (e.g. NeoReader on Boox e-readers) to open the content directly
- Falls back to sharing the URL when no PDF asset is available

## Context

When bookmarking a URL that points to a PDF (like `https://arxiv.org/pdf/2505.03275`), the crawler stores the PDF as a `linkPdf` asset. However, the share handler for `LINK` bookmarks only shared the URL string, which PDF readers can't open. The `ASSET` type bookmarks already had proper PDF file sharing — this change brings the same behavior to `LINK` bookmarks that have an attached PDF.

## Test plan

- [ ] Bookmark a PDF URL (e.g. an arxiv paper)
- [ ] Wait for crawling to complete
- [ ] Tap share on the bookmark card
- [ ] Verify the native share sheet offers the actual PDF file (not a URL)
- [ ] Verify a PDF reader (e.g. NeoReader) can open the shared file
- [ ] Bookmark a non-PDF URL and verify share still shares the URL as before