### PR TITLE
feat(mcp): add update-bookmark tool

### DIFF
--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -143,6 +143,88 @@ mcpServer.tool(
 );
 
 mcpServer.tool(
+  "update-bookmark",
+  `Update fields on an existing bookmark. Only the fields you pass are modified; omitted fields stay unchanged. Returns the updated bookmark.`,
+  {
+    bookmarkId: z.string().describe(`The bookmarkId to update.`),
+    title: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(`The bookmark's user-set title. Pass null to clear it.`),
+    note: z.string().optional().describe(`A free-form note on the bookmark.`),
+    summary: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(`The bookmark's summary. Pass null to clear it.`),
+    archived: z
+      .boolean()
+      .optional()
+      .describe(`Whether the bookmark is archived.`),
+    favourited: z
+      .boolean()
+      .optional()
+      .describe(`Whether the bookmark is favourited.`),
+    url: z.string().url().optional().describe(`New URL for a link bookmark.`),
+    description: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(`Link description. Pass null to clear it.`),
+    author: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(`Link author. Pass null to clear it.`),
+    publisher: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(`Link publisher. Pass null to clear it.`),
+    createdAt: z
+      .string()
+      .datetime()
+      .optional()
+      .describe(`Override the bookmark's createdAt timestamp (ISO 8601).`),
+  },
+  async ({ bookmarkId, ...fields }): Promise<CallToolResult> => {
+    const patchRes = await karakeepClient.PATCH(`/bookmarks/{bookmarkId}`, {
+      params: {
+        path: {
+          bookmarkId,
+        },
+      },
+      body: fields,
+    });
+    if (!patchRes.data) {
+      return toMcpToolError(patchRes.error);
+    }
+    const getRes = await karakeepClient.GET(`/bookmarks/{bookmarkId}`, {
+      params: {
+        path: {
+          bookmarkId,
+        },
+        query: {
+          includeContent: false,
+        },
+      },
+    });
+    if (!getRes.data) {
+      return toMcpToolError(getRes.error);
+    }
+    return {
+      content: [
+        {
+          type: "text",
+          text: compactBookmark(getRes.data),
+        },
+      ],
+    };
+  },
+);
+
+mcpServer.tool(
   "get-bookmark-content",
   `Get the content of the bookmark in markdown`,
   {


### PR DESCRIPTION
## Summary

Adds an `update-bookmark` MCP tool that wraps the existing `PATCH /bookmarks/{bookmarkId}` REST endpoint. Today the MCP server can create, read, search, tag and list-manage bookmarks, but it cannot modify them — clients have to fall back to the raw REST API to change something as simple as a title, a note, or the archived/favourited flags. This closes that gap.

## Behaviour

- Tool name: `update-bookmark`.
- Required input: `bookmarkId`.
- Optional inputs (all map 1:1 to the PATCH request body): `title`, `note`, `summary`, `archived`, `favourited`, `url`, `description`, `author`, `publisher`, `createdAt`. Nullable fields accept `null` to clear them.
- Only the fields that are passed are sent; omitted fields stay unchanged on the server.
- The PATCH response schema does not include `tags`, `content` or `assets`, so after a successful PATCH the tool issues a follow-up `GET /bookmarks/{bookmarkId}` and returns the full `compactBookmark(...)` view so the LLM sees the final state.

## Design notes

- I intentionally did **not** expose `text`, `assetContent`, `datePublished`, `dateModified`. `text`/`assetContent` can clobber crawler-populated content for link/asset bookmarks, and the date fields are rarely useful to an LLM. The OpenAPI endpoint still supports them; they can be added later if there's demand.
- Style matches the existing `create-bookmark` / `get-bookmark` tools in `apps/mcp/src/bookmarks.ts` (zod schema with per-field `.describe(...)`, `toMcpToolError` on failure, `compactBookmark` on success).

## Checks run locally

- `pnpm --filter @karakeep/mcp typecheck` — clean
- `pnpm --filter @karakeep/mcp lint` — 0 warnings, 0 errors
- `pnpm --filter @karakeep/mcp format` — all files correctly formatted (oxfmt)
- `pnpm preflight` — all 61 tasks green
- pre-commit hook (`pnpm preflight && pnpm exec sherif && pnpm --filter @karakeep/open-api check`) passed without bypass

## Process note

`CONTRIBUTING.md` prefers work on `status/approved` issues. I didn't find an existing issue for this specific gap (`mcp + update/patch bookmark` search returns nothing concrete — only PR #1971, which reworks MCP transport but keeps the tool set unchanged). Since this is strict API-parity with an endpoint that already exists, I opened the PR directly — happy to convert it to an issue-first flow if you'd rather, or to extend it (e.g. expose the remaining patchable fields, add `delete-bookmark`) before merge.