### PR TITLE
fix(docker): add `ffmpeg` as required by `yt-dlp`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,6 +123,7 @@ RUN apt-get update \
         graphicsmagick \
         ghostscript \
         libjemalloc2 \
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH


### PR DESCRIPTION
Fixes https://github.com/karakeep-app/karakeep/issues/2638 https://github.com/karakeep-app/karakeep/issues/775

`ffmpeg` is required, otherwise the video quality downloaded by `yt-dlp` is very low.

According to @TobiX (https://github.com/karakeep-app/karakeep/issues/2638#issuecomment-4276770494):

> Until 0.30.0, ffmpeg was part of the default image. This was probably "broken" by the switch from Alpine to Debian (https://github.com/karakeep-app/karakeep/commit/b0036ef193831531fe8daf8588720a4520ed9ccc)