### PR TITLE
fix: invalidate existing password reset tokens before issuing a new one

### DIFF
--- a/packages/trpc/models/users.ts
+++ b/packages/trpc/models/users.ts
@@ -291,10 +291,17 @@ export class User {
       const token = randomBytes(32).toString("hex");
       const expires = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
-      await ctx.db.insert(passwordResetTokens).values({
-        userId: user.id,
-        token,
-        expires,
+      await ctx.db.transaction(async (tx) => {
+        // Invalidate any existing reset tokens for this user
+        await tx
+          .delete(passwordResetTokens)
+          .where(eq(passwordResetTokens.userId, user.id));
+
+        await tx.insert(passwordResetTokens).values({
+          userId: user.id,
+          token,
+          expires,
+        });
       });
 
       await sendPasswordResetEmail(email, user.name, token);


### PR DESCRIPTION
- Wrap reset token replacement in a transaction
- Delete any prior tokens for the user before inserting the new token