### PR TITLE
fix: sanitize user names before storing them

### DIFF
--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -75,14 +75,13 @@ async function isAdmin(email: string): Promise<boolean> {
   return res?.role == "admin";
 }
 
-function normalizeSafeDisplayName(
-  name: string | null | undefined,
-  email: string,
-): string {
+const DEFAULT_DISPLAY_NAME = "User";
+
+function normalizeSafeDisplayName(name: string | null | undefined): string {
   const normalizedName = normalizeUserNameInput(name ?? "");
   return !containsUnsafeUserNameMarkup(name ?? "") && normalizedName
     ? normalizedName
-    : email;
+    : DEFAULT_DISPLAY_NAME;
 }
 
 const CustomProvider = (): Adapter => {
@@ -97,7 +96,7 @@ const CustomProvider = (): Adapter => {
     ...adapter,
     createUser: async (user: Omit<AdapterUser, "id">) => {
       return await User.createRaw(db, {
-        name: normalizeSafeDisplayName(user.name, user.email),
+        name: normalizeSafeDisplayName(user.name),
         email: user.email,
         emailVerified: user.emailVerified,
       });
@@ -154,7 +153,7 @@ if (oauth.wellKnownUrl) {
 
       return {
         id: profile.sub,
-        name: normalizeSafeDisplayName(profile.name, profile.email),
+        name: normalizeSafeDisplayName(profile.name),
         email: profile.email,
         role: admin || firstUser ? "admin" : "user",
       };

--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -18,7 +18,10 @@ import {
   verificationTokens,
 } from "@karakeep/db/schema";
 import serverConfig from "@karakeep/shared/config";
-import { sanitizePlainTextInput } from "@karakeep/shared/utils/htmlUtils";
+import {
+  containsUnsafeUserNameMarkup,
+  normalizeUserNameInput,
+} from "@karakeep/shared/utils/userName";
 import { validatePassword } from "@karakeep/trpc/auth";
 import { User } from "@karakeep/trpc/models/users";
 
@@ -72,6 +75,16 @@ async function isAdmin(email: string): Promise<boolean> {
   return res?.role == "admin";
 }
 
+function normalizeSafeDisplayName(
+  name: string | null | undefined,
+  email: string,
+): string {
+  const normalizedName = normalizeUserNameInput(name ?? "");
+  return !containsUnsafeUserNameMarkup(name ?? "") && normalizedName
+    ? normalizedName
+    : email;
+}
+
 const CustomProvider = (): Adapter => {
   const adapter = DrizzleAdapter(db, {
     usersTable: users,
@@ -83,11 +96,8 @@ const CustomProvider = (): Adapter => {
   return {
     ...adapter,
     createUser: async (user: Omit<AdapterUser, "id">) => {
-      const sanitizedName =
-        sanitizePlainTextInput(user.name ?? "") || user.email;
-
       return await User.createRaw(db, {
-        name: sanitizedName,
+        name: normalizeSafeDisplayName(user.name, user.email),
         email: user.email,
         emailVerified: user.emailVerified,
       });
@@ -141,12 +151,10 @@ if (oauth.wellKnownUrl) {
         isAdmin(profile.email),
         isFirstUser(),
       ]);
-      const sanitizedName =
-        sanitizePlainTextInput(profile.name || "") || profile.email;
 
       return {
         id: profile.sub,
-        name: sanitizedName,
+        name: normalizeSafeDisplayName(profile.name, profile.email),
         email: profile.email,
         role: admin || firstUser ? "admin" : "user",
       };

--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -18,6 +18,7 @@ import {
   verificationTokens,
 } from "@karakeep/db/schema";
 import serverConfig from "@karakeep/shared/config";
+import { sanitizePlainTextInput } from "@karakeep/shared/utils/htmlUtils";
 import { validatePassword } from "@karakeep/trpc/auth";
 import { User } from "@karakeep/trpc/models/users";
 
@@ -82,8 +83,11 @@ const CustomProvider = (): Adapter => {
   return {
     ...adapter,
     createUser: async (user: Omit<AdapterUser, "id">) => {
+      const sanitizedName =
+        sanitizePlainTextInput(user.name ?? "") || user.email;
+
       return await User.createRaw(db, {
-        name: user.name ?? "",
+        name: sanitizedName,
         email: user.email,
         emailVerified: user.emailVerified,
       });
@@ -137,9 +141,12 @@ if (oauth.wellKnownUrl) {
         isAdmin(profile.email),
         isFirstUser(),
       ]);
+      const sanitizedName =
+        sanitizePlainTextInput(profile.name || "") || profile.email;
+
       return {
         id: profile.sub,
-        name: profile.name || profile.email,
+        name: sanitizedName,
         email: profile.email,
         role: admin || firstUser ? "admin" : "user",
       };

--- a/packages/shared/types/users.ts
+++ b/packages/shared/types/users.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import { sanitizePlainTextInput } from "../utils/htmlUtils";
+import {
+  containsUnsafeUserNameMarkup,
+  normalizeUserNameInput,
+} from "../utils/userName";
 import { zBookmarkSourceSchema } from "./bookmarks";
 
 export const PASSWORD_MIN_LENGTH = 8;
@@ -19,10 +22,10 @@ export type ZTagStyle = z.infer<typeof zTagStyleSchema>;
 
 export const zUserNameSchema = z
   .string()
-  .transform(sanitizePlainTextInput)
-  .refine((value) => !/[<>]/.test(value), {
+  .refine((value) => !containsUnsafeUserNameMarkup(value), {
     message: "Name contains invalid characters",
   })
+  .transform(normalizeUserNameInput)
   .pipe(z.string().min(1, { message: "Name can't be empty" }));
 
 export const zSignUpSchema = z

--- a/packages/shared/types/users.ts
+++ b/packages/shared/types/users.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { sanitizePlainTextInput } from "../utils/htmlUtils";
 import { zBookmarkSourceSchema } from "./bookmarks";
 
 export const PASSWORD_MIN_LENGTH = 8;
@@ -16,9 +17,14 @@ export const zTagStyleSchema = z.enum([
 ]);
 export type ZTagStyle = z.infer<typeof zTagStyleSchema>;
 
+export const zUserNameSchema = z
+  .string()
+  .transform(sanitizePlainTextInput)
+  .pipe(z.string().min(1, { message: "Name can't be empty" }));
+
 export const zSignUpSchema = z
   .object({
-    name: z.string().min(1, { message: "Name can't be empty" }),
+    name: zUserNameSchema,
     email: z.string().email(),
     password: z.string().min(PASSWORD_MIN_LENGTH).max(PASSWORD_MAX_LENGTH),
     confirmPassword: z.string(),

--- a/packages/shared/types/users.ts
+++ b/packages/shared/types/users.ts
@@ -20,6 +20,9 @@ export type ZTagStyle = z.infer<typeof zTagStyleSchema>;
 export const zUserNameSchema = z
   .string()
   .transform(sanitizePlainTextInput)
+  .refine((value) => !/[<>]/.test(value), {
+    message: "Name contains invalid characters",
+  })
   .pipe(z.string().min(1, { message: "Name can't be empty" }));
 
 export const zSignUpSchema = z

--- a/packages/shared/utils/htmlUtils.ts
+++ b/packages/shared/utils/htmlUtils.ts
@@ -15,3 +15,14 @@ export function htmlToPlainText(htmlContent: string): string {
   // TODO, we probably should also remove singlefile inline images from the content
   return compiledConvert(htmlContent);
 }
+
+/**
+ * Sanitizes HTML-ish input down to a single-line plain-text value.
+ */
+export function sanitizePlainTextInput(input: string): string {
+  if (!input) {
+    return "";
+  }
+
+  return htmlToPlainText(input).replace(/\s+/g, " ").trim();
+}

--- a/packages/shared/utils/htmlUtils.ts
+++ b/packages/shared/utils/htmlUtils.ts
@@ -15,14 +15,3 @@ export function htmlToPlainText(htmlContent: string): string {
   // TODO, we probably should also remove singlefile inline images from the content
   return compiledConvert(htmlContent);
 }
-
-/**
- * Sanitizes HTML-ish input down to a single-line plain-text value.
- */
-export function sanitizePlainTextInput(input: string): string {
-  if (!input) {
-    return "";
-  }
-
-  return htmlToPlainText(input).replace(/\s+/g, " ").trim();
-}

--- a/packages/shared/utils/userName.ts
+++ b/packages/shared/utils/userName.ts
@@ -1,0 +1,7 @@
+export function normalizeUserNameInput(input: string): string {
+  return input.trim();
+}
+
+export function containsUnsafeUserNameMarkup(input: string): boolean {
+  return /[<>]/.test(input);
+}

--- a/packages/trpc/models/users.ts
+++ b/packages/trpc/models/users.ts
@@ -29,6 +29,7 @@ import {
   zWhoAmIResponseSchema,
   zWrappedStatsResponseSchema,
 } from "@karakeep/shared/types/users";
+import { sanitizePlainTextInput } from "@karakeep/shared/utils/htmlUtils";
 
 import { AuthedContext, Context } from "..";
 import { generatePasswordSalt, hashPassword, validatePassword } from "../auth";
@@ -78,7 +79,7 @@ export class User {
       try {
         await sendVerificationEmail(
           input.email,
-          input.name,
+          user.name,
           token,
           input.redirectUrl,
         );
@@ -101,6 +102,8 @@ export class User {
       emailVerified?: Date | null;
     },
   ) {
+    const sanitizedName = sanitizePlainTextInput(input.name);
+
     return await db.transaction(async (trx) => {
       let userRole = input.role;
       if (!userRole) {
@@ -114,7 +117,7 @@ export class User {
         const [result] = await trx
           .insert(users)
           .values({
-            name: input.name,
+            name: sanitizedName,
             email: input.email,
             password: input.password,
             salt: input.salt,

--- a/packages/trpc/models/users.ts
+++ b/packages/trpc/models/users.ts
@@ -29,7 +29,6 @@ import {
   zWhoAmIResponseSchema,
   zWrappedStatsResponseSchema,
 } from "@karakeep/shared/types/users";
-import { sanitizePlainTextInput } from "@karakeep/shared/utils/htmlUtils";
 
 import { AuthedContext, Context } from "..";
 import { generatePasswordSalt, hashPassword, validatePassword } from "../auth";
@@ -102,8 +101,6 @@ export class User {
       emailVerified?: Date | null;
     },
   ) {
-    const sanitizedName = sanitizePlainTextInput(input.name);
-
     return await db.transaction(async (trx) => {
       let userRole = input.role;
       if (!userRole) {
@@ -117,7 +114,7 @@ export class User {
         const [result] = await trx
           .insert(users)
           .values({
-            name: sanitizedName,
+            name: input.name,
             email: input.email,
             password: input.password,
             salt: input.salt,

--- a/packages/trpc/routers/invites.test.ts
+++ b/packages/trpc/routers/invites.test.ts
@@ -370,6 +370,71 @@ describe("Invites Router", () => {
     expect(result.name).toBe("New User");
   });
 
+  test<CustomTestContext>("invite accept sanitizes html in name", async ({
+    db,
+    unauthedAPICaller,
+  }) => {
+    const admin = await unauthedAPICaller.users.create({
+      name: "Admin User",
+      email: "admin@test.com",
+      password: "pass1234",
+      confirmPassword: "pass1234",
+    });
+
+    const adminCaller = getApiCaller(db, admin.id, admin.email, "admin");
+
+    const invite = await adminCaller.invites.create({
+      email: "invite-sanitized@test.com",
+    });
+
+    const dbInvite = await db.query.invites.findFirst({
+      where: eq(invites.id, invite.id),
+    });
+
+    const result = await unauthedAPICaller.invites.accept({
+      token: dbInvite!.token,
+      name: "<b>Invited</b> <User>",
+      password: "newpass123",
+    });
+
+    expect(result.name).toBe("Invited");
+
+    const createdUser = await db.query.users.findFirst({
+      where: eq(users.email, "invite-sanitized@test.com"),
+    });
+    expect(createdUser?.name).toBe("Invited");
+  });
+
+  test<CustomTestContext>("invite accept rejects normalized angle-bracket markup", async ({
+    db,
+    unauthedAPICaller,
+  }) => {
+    const admin = await unauthedAPICaller.users.create({
+      name: "Admin User",
+      email: "admin@test.com",
+      password: "pass1234",
+      confirmPassword: "pass1234",
+    });
+
+    const adminCaller = getApiCaller(db, admin.id, admin.email, "admin");
+
+    const invite = await adminCaller.invites.create({
+      email: "invite-reject@test.com",
+    });
+
+    const dbInvite = await db.query.invites.findFirst({
+      where: eq(invites.id, invite.id),
+    });
+
+    await expect(() =>
+      unauthedAPICaller.invites.accept({
+        token: dbInvite!.token,
+        name: "&lt;img src=x onerror=1&gt;",
+        password: "newpass123",
+      }),
+    ).rejects.toThrow(/Name contains invalid characters/);
+  });
+
   test<CustomTestContext>("cannot accept used invite (deleted)", async ({
     db,
     unauthedAPICaller,

--- a/packages/trpc/routers/invites.test.ts
+++ b/packages/trpc/routers/invites.test.ts
@@ -370,7 +370,7 @@ describe("Invites Router", () => {
     expect(result.name).toBe("New User");
   });
 
-  test<CustomTestContext>("invite accept sanitizes html in name", async ({
+  test<CustomTestContext>("invite accept rejects raw html in name", async ({
     db,
     unauthedAPICaller,
   }) => {
@@ -391,45 +391,10 @@ describe("Invites Router", () => {
       where: eq(invites.id, invite.id),
     });
 
-    const result = await unauthedAPICaller.invites.accept({
-      token: dbInvite!.token,
-      name: "<b>Invited</b> <User>",
-      password: "newpass123",
-    });
-
-    expect(result.name).toBe("Invited");
-
-    const createdUser = await db.query.users.findFirst({
-      where: eq(users.email, "invite-sanitized@test.com"),
-    });
-    expect(createdUser?.name).toBe("Invited");
-  });
-
-  test<CustomTestContext>("invite accept rejects normalized angle-bracket markup", async ({
-    db,
-    unauthedAPICaller,
-  }) => {
-    const admin = await unauthedAPICaller.users.create({
-      name: "Admin User",
-      email: "admin@test.com",
-      password: "pass1234",
-      confirmPassword: "pass1234",
-    });
-
-    const adminCaller = getApiCaller(db, admin.id, admin.email, "admin");
-
-    const invite = await adminCaller.invites.create({
-      email: "invite-reject@test.com",
-    });
-
-    const dbInvite = await db.query.invites.findFirst({
-      where: eq(invites.id, invite.id),
-    });
-
     await expect(() =>
       unauthedAPICaller.invites.accept({
         token: dbInvite!.token,
-        name: "&lt;img src=x onerror=1&gt;",
+        name: "<b>Invited</b> <User>",
         password: "newpass123",
       }),
     ).rejects.toThrow(/Name contains invalid characters/);

--- a/packages/trpc/routers/invites.ts
+++ b/packages/trpc/routers/invites.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { invites, users } from "@karakeep/db/schema";
+import { zUserNameSchema } from "@karakeep/shared/types/users";
 
 import { generatePasswordSalt, hashPassword } from "../auth";
 import { sendInviteEmail } from "../email";
@@ -158,7 +159,7 @@ export const invitesAppRouter = router({
     .input(
       z.object({
         token: z.string(),
-        name: z.string().min(1),
+        name: zUserNameSchema,
         password: z.string().min(8),
       }),
     )

--- a/packages/trpc/routers/users.test.ts
+++ b/packages/trpc/routers/users.test.ts
@@ -60,39 +60,26 @@ describe("User Routes", () => {
     expect(user.email).toEqual("test123@test.com");
   });
 
-  test<CustomTestContext>("create user sanitizes html in name", async ({
+  test<CustomTestContext>("create user trims surrounding whitespace in name", async ({
     unauthedAPICaller,
   }) => {
     const user = await unauthedAPICaller.users.create({
-      name: "  <b>Test</b>\n<User>  ",
+      name: "  Test \n User  ",
       email: "sanitized@test.com",
       password: "pass1234",
       confirmPassword: "pass1234",
     });
 
-    expect(user.name).toEqual("Test");
+    expect(user.name).toEqual("Test \n User");
   });
 
-  test<CustomTestContext>("create user rejects html-only name", async ({
+  test<CustomTestContext>("create user rejects raw html in name", async ({
     unauthedAPICaller,
   }) => {
     await expect(() =>
       unauthedAPICaller.users.create({
         name: "<script>alert('xss')</script>",
         email: "html-only@test.com",
-        password: "pass1234",
-        confirmPassword: "pass1234",
-      }),
-    ).rejects.toThrow(/Name can't be empty/);
-  });
-
-  test<CustomTestContext>("create user rejects normalized angle-bracket markup", async ({
-    unauthedAPICaller,
-  }) => {
-    await expect(() =>
-      unauthedAPICaller.users.create({
-        name: "&lt;script&gt;alert('xss')&lt;/script&gt;",
-        email: "encoded-markup@test.com",
         password: "pass1234",
         confirmPassword: "pass1234",
       }),

--- a/packages/trpc/routers/users.test.ts
+++ b/packages/trpc/routers/users.test.ts
@@ -12,6 +12,7 @@ import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
 
 import type { CustomTestContext } from "../testUtils";
 import * as emailModule from "../email";
+import { User } from "../models/users";
 import { defaultBeforeEach, getApiCaller } from "../testUtils";
 
 // Mock server config with email settings
@@ -58,6 +59,43 @@ describe("User Routes", () => {
 
     expect(user.name).toEqual("Test User");
     expect(user.email).toEqual("test123@test.com");
+  });
+
+  test<CustomTestContext>("create user sanitizes html in name", async ({
+    unauthedAPICaller,
+  }) => {
+    const user = await unauthedAPICaller.users.create({
+      name: "  <b>Test</b>\n<User>  ",
+      email: "sanitized@test.com",
+      password: "pass1234",
+      confirmPassword: "pass1234",
+    });
+
+    expect(user.name).toEqual("Test");
+  });
+
+  test<CustomTestContext>("create user rejects html-only name", async ({
+    unauthedAPICaller,
+  }) => {
+    await expect(() =>
+      unauthedAPICaller.users.create({
+        name: "<script>alert('xss')</script>",
+        email: "html-only@test.com",
+        password: "pass1234",
+        confirmPassword: "pass1234",
+      }),
+    ).rejects.toThrow(/Name can't be empty/);
+  });
+
+  test<CustomTestContext>("createRaw sanitizes html in name", async ({
+    db,
+  }) => {
+    const user = await User.createRaw(db, {
+      name: "<strong>OAuth User</strong>",
+      email: "oauth-sanitized@test.com",
+    });
+
+    expect(user.name).toEqual("OAuth User");
   });
 
   test<CustomTestContext>("first user is admin", async ({

--- a/packages/trpc/routers/users.test.ts
+++ b/packages/trpc/routers/users.test.ts
@@ -12,7 +12,6 @@ import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
 
 import type { CustomTestContext } from "../testUtils";
 import * as emailModule from "../email";
-import { User } from "../models/users";
 import { defaultBeforeEach, getApiCaller } from "../testUtils";
 
 // Mock server config with email settings
@@ -87,15 +86,17 @@ describe("User Routes", () => {
     ).rejects.toThrow(/Name can't be empty/);
   });
 
-  test<CustomTestContext>("createRaw sanitizes html in name", async ({
-    db,
+  test<CustomTestContext>("create user rejects normalized angle-bracket markup", async ({
+    unauthedAPICaller,
   }) => {
-    const user = await User.createRaw(db, {
-      name: "<strong>OAuth User</strong>",
-      email: "oauth-sanitized@test.com",
-    });
-
-    expect(user.name).toEqual("OAuth User");
+    await expect(() =>
+      unauthedAPICaller.users.create({
+        name: "&lt;script&gt;alert('xss')&lt;/script&gt;",
+        email: "encoded-markup@test.com",
+        password: "pass1234",
+        confirmPassword: "pass1234",
+      }),
+    ).rejects.toThrow(/Name contains invalid characters/);
   });
 
   test<CustomTestContext>("first user is admin", async ({


### PR DESCRIPTION
- Strip HTML from signup and OAuth display names
- Enforce non-empty plain-text names in validation