### PR TITLE
fix: debounce bulk query invalidations

### DIFF
--- a/packages/shared-react/hooks/bookmarks.ts
+++ b/packages/shared-react/hooks/bookmarks.ts
@@ -5,6 +5,7 @@ import { getBookmarkRefreshInterval } from "@karakeep/shared/utils/bookmarkUtils
 import { useTRPC } from "../trpc";
 import { useBookmarkGridContext } from "./bookmark-grid-context";
 import { useAddBookmarkToList } from "./lists";
+import { scheduleInvalidateQueries } from "./query-invalidation";
 
 type TRPCApi = ReturnType<typeof useTRPC>;
 
@@ -81,14 +82,18 @@ export function useDeleteBookmark(
     api.bookmarks.deleteBookmark.mutationOptions({
       ...opts,
       onSuccess: (res, req, meta, context) => {
-        queryClient.invalidateQueries(api.bookmarks.getBookmarks.pathFilter());
-        queryClient.invalidateQueries(
+        scheduleInvalidateQueries(
+          queryClient,
+          api.bookmarks.getBookmarks.pathFilter(),
+        );
+        scheduleInvalidateQueries(
+          queryClient,
           api.bookmarks.searchBookmarks.pathFilter(),
         );
         queryClient.removeQueries(
           api.bookmarks.getBookmark.queryFilter({ bookmarkId: req.bookmarkId }),
         );
-        queryClient.invalidateQueries(api.lists.stats.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.lists.stats.pathFilter());
         return opts?.onSuccess?.(res, req, meta, context);
       },
     }),
@@ -106,14 +111,18 @@ export function useUpdateBookmark(
     api.bookmarks.updateBookmark.mutationOptions({
       ...opts,
       onSuccess: (res, req, meta, context) => {
-        queryClient.invalidateQueries(api.bookmarks.getBookmarks.pathFilter());
-        queryClient.invalidateQueries(
+        scheduleInvalidateQueries(
+          queryClient,
+          api.bookmarks.getBookmarks.pathFilter(),
+        );
+        scheduleInvalidateQueries(
+          queryClient,
           api.bookmarks.searchBookmarks.pathFilter(),
         );
         queryClient.invalidateQueries(
           api.bookmarks.getBookmark.queryFilter({ bookmarkId: req.bookmarkId }),
         );
-        queryClient.invalidateQueries(api.lists.stats.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.lists.stats.pathFilter());
         return opts?.onSuccess?.(res, req, meta, context);
       },
     }),
@@ -181,15 +190,17 @@ export function useUpdateBookmarkTags(
           queryClient.invalidateQueries(
             api.tags.get.queryFilter({ tagId: id }),
           );
-          queryClient.invalidateQueries(
+          scheduleInvalidateQueries(
+            queryClient,
             api.bookmarks.getBookmarks.queryFilter({ tagId: id }),
           );
-          queryClient.invalidateQueries(
+          scheduleInvalidateQueries(
+            queryClient,
             api.bookmarks.getBookmarks.infiniteQueryFilter({ tagId: id }),
           );
         });
-        queryClient.invalidateQueries(api.tags.list.pathFilter());
-        queryClient.invalidateQueries(api.lists.stats.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.tags.list.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.lists.stats.pathFilter());
         return opts?.onSuccess?.(res, req, meta, context);
       },
     }),

--- a/packages/shared-react/hooks/lists.ts
+++ b/packages/shared-react/hooks/lists.ts
@@ -7,6 +7,7 @@ import {
 } from "@karakeep/shared/utils/listUtils";
 
 import { useTRPC } from "../trpc";
+import { scheduleInvalidateQueries } from "./query-invalidation";
 
 type TRPCApi = ReturnType<typeof useTRPC>;
 
@@ -89,10 +90,12 @@ export function useAddBookmarkToList(
     api.lists.addToList.mutationOptions({
       ...opts,
       onSuccess: (res, req, meta, context) => {
-        queryClient.invalidateQueries(
+        scheduleInvalidateQueries(
+          queryClient,
           api.bookmarks.getBookmarks.queryFilter({ listId: req.listId }),
         );
-        queryClient.invalidateQueries(
+        scheduleInvalidateQueries(
+          queryClient,
           api.bookmarks.getBookmarks.infiniteQueryFilter({
             listId: req.listId,
           }),
@@ -102,7 +105,7 @@ export function useAddBookmarkToList(
             bookmarkId: req.bookmarkId,
           }),
         );
-        queryClient.invalidateQueries(api.lists.stats.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.lists.stats.pathFilter());
         return opts?.onSuccess?.(res, req, meta, context);
       },
     }),
@@ -118,10 +121,12 @@ export function useRemoveBookmarkFromList(
     api.lists.removeFromList.mutationOptions({
       ...opts,
       onSuccess: (res, req, meta, context) => {
-        queryClient.invalidateQueries(
+        scheduleInvalidateQueries(
+          queryClient,
           api.bookmarks.getBookmarks.queryFilter({ listId: req.listId }),
         );
-        queryClient.invalidateQueries(
+        scheduleInvalidateQueries(
+          queryClient,
           api.bookmarks.getBookmarks.infiniteQueryFilter({
             listId: req.listId,
           }),
@@ -131,7 +136,7 @@ export function useRemoveBookmarkFromList(
             bookmarkId: req.bookmarkId,
           }),
         );
-        queryClient.invalidateQueries(api.lists.stats.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.lists.stats.pathFilter());
         return opts?.onSuccess?.(res, req, meta, context);
       },
     }),

--- a/packages/shared-react/hooks/query-invalidation.ts
+++ b/packages/shared-react/hooks/query-invalidation.ts
@@ -30,6 +30,8 @@ export function scheduleInvalidateQueries(
   debounceMs = DEFAULT_INVALIDATION_DEBOUNCE_MS,
   maxWaitMs = DEFAULT_INVALIDATION_MAX_WAIT_MS,
 ) {
+  // Predicate functions are not hashable; run them immediately to avoid
+  // coalescing different predicate filters under the same structural key.
   if (filters.predicate) {
     void queryClient.invalidateQueries(filters);
     return;

--- a/packages/shared-react/hooks/query-invalidation.ts
+++ b/packages/shared-react/hooks/query-invalidation.ts
@@ -1,0 +1,71 @@
+import { hashKey, QueryClient, QueryFilters } from "@tanstack/react-query";
+
+const DEFAULT_INVALIDATION_DEBOUNCE_MS = 250;
+const DEFAULT_INVALIDATION_MAX_WAIT_MS = 3_000;
+
+interface PendingInvalidation {
+  filters: QueryFilters;
+  timeout: ReturnType<typeof setTimeout>;
+  firstRequestedAt: number;
+}
+
+const pendingInvalidations = new WeakMap<
+  QueryClient,
+  Map<string, PendingInvalidation>
+>();
+
+function getInvalidationKey(filters: QueryFilters) {
+  return hashKey([
+    filters.queryKey ?? null,
+    filters.exact ?? null,
+    filters.type ?? null,
+    filters.stale ?? null,
+    filters.fetchStatus ?? null,
+  ]);
+}
+
+export function scheduleInvalidateQueries(
+  queryClient: QueryClient,
+  filters: QueryFilters,
+  debounceMs = DEFAULT_INVALIDATION_DEBOUNCE_MS,
+  maxWaitMs = DEFAULT_INVALIDATION_MAX_WAIT_MS,
+) {
+  let clientInvalidations = pendingInvalidations.get(queryClient);
+  if (!clientInvalidations) {
+    clientInvalidations = new Map();
+    pendingInvalidations.set(queryClient, clientInvalidations);
+  }
+
+  const key = getInvalidationKey(filters);
+  const now = Date.now();
+  const pendingInvalidation = clientInvalidations.get(key);
+
+  const invalidate = () => {
+    const invalidation = clientInvalidations.get(key);
+    if (!invalidation) {
+      return;
+    }
+
+    clientInvalidations.delete(key);
+    void queryClient.invalidateQueries(invalidation.filters);
+  };
+
+  if (pendingInvalidation) {
+    clearTimeout(pendingInvalidation.timeout);
+
+    const elapsedMs = now - pendingInvalidation.firstRequestedAt;
+    const delayMs = Math.max(0, Math.min(debounceMs, maxWaitMs - elapsedMs));
+
+    pendingInvalidation.filters = filters;
+    pendingInvalidation.timeout = setTimeout(invalidate, delayMs);
+    return;
+  }
+
+  const timeout = setTimeout(invalidate, debounceMs);
+
+  clientInvalidations.set(key, {
+    filters,
+    timeout,
+    firstRequestedAt: now,
+  });
+}

--- a/packages/shared-react/hooks/query-invalidation.ts
+++ b/packages/shared-react/hooks/query-invalidation.ts
@@ -30,6 +30,11 @@ export function scheduleInvalidateQueries(
   debounceMs = DEFAULT_INVALIDATION_DEBOUNCE_MS,
   maxWaitMs = DEFAULT_INVALIDATION_MAX_WAIT_MS,
 ) {
+  if (filters.predicate) {
+    void queryClient.invalidateQueries(filters);
+    return;
+  }
+
   let clientInvalidations = pendingInvalidations.get(queryClient);
   if (!clientInvalidations) {
     clientInvalidations = new Map();

--- a/packages/shared-react/hooks/tags.ts
+++ b/packages/shared-react/hooks/tags.ts
@@ -9,6 +9,7 @@ import {
 import { ZTagListResponse } from "@karakeep/shared/types/tags";
 
 import { useTRPC } from "../trpc";
+import { scheduleInvalidateQueries } from "./query-invalidation";
 
 type TRPCApi = ReturnType<typeof useTRPC>;
 
@@ -135,8 +136,11 @@ export function useDeleteTag(
     api.tags.delete.mutationOptions({
       ...opts,
       onSuccess: (res, req, meta, context) => {
-        queryClient.invalidateQueries(api.tags.list.pathFilter());
-        queryClient.invalidateQueries(api.bookmarks.getBookmark.pathFilter());
+        scheduleInvalidateQueries(queryClient, api.tags.list.pathFilter());
+        scheduleInvalidateQueries(
+          queryClient,
+          api.bookmarks.getBookmark.pathFilter(),
+        );
         return opts?.onSuccess?.(res, req, meta, context);
       },
     }),


### PR DESCRIPTION
Introduce a small debounce for invalidation to avoid sending the server multiple requests on invalidation during bulk actions.


Fixes #2665