### PR TITLE
fix: Netscape to export nested structures

### DIFF
--- a/apps/web/app/api/bookmarks/export/route.tsx
+++ b/apps/web/app/api/bookmarks/export/route.tsx
@@ -47,41 +47,41 @@ export async function GET(request: NextRequest) {
     bookmarks = [...bookmarks, ...resp.bookmarks];
   }
 
+  // Fetch lists and bookmark-to-list memberships (used by both JSON and Netscape)
+  const listsResp = await caller.lists.list();
+  const ownedLists = listsResp.lists.filter((l) => l.userRole === "owner");
+
+  const manualLists = ownedLists.filter((l) => l.type === "manual");
+  const manualListIds = manualLists.map((l) => l.id);
+
+  let memberships: { bookmarkId: string; listId: string }[] = [];
+  if (manualListIds.length > 0) {
+    memberships = await db
+      .select({
+        bookmarkId: bookmarksInLists.bookmarkId,
+        listId: bookmarksInLists.listId,
+      })
+      .from(bookmarksInLists)
+      .innerJoin(
+        bookmarksTable,
+        eq(bookmarksTable.id, bookmarksInLists.bookmarkId),
+      )
+      .where(
+        and(
+          inArray(bookmarksInLists.listId, manualListIds),
+          eq(bookmarksTable.userId, ctx.user.id),
+        ),
+      );
+  }
+
+  const bookmarkListMap = new Map<string, string[]>();
+  for (const m of memberships) {
+    const existing = bookmarkListMap.get(m.bookmarkId) ?? [];
+    existing.push(m.listId);
+    bookmarkListMap.set(m.bookmarkId, existing);
+  }
+
   if (format === "json") {
-    // Fetch lists and bookmark-to-list memberships
-    const listsResp = await caller.lists.list();
-    const ownedLists = listsResp.lists.filter((l) => l.userRole === "owner");
-
-    const manualLists = ownedLists.filter((l) => l.type === "manual");
-    const manualListIds = manualLists.map((l) => l.id);
-
-    let memberships: { bookmarkId: string; listId: string }[] = [];
-    if (manualListIds.length > 0) {
-      memberships = await db
-        .select({
-          bookmarkId: bookmarksInLists.bookmarkId,
-          listId: bookmarksInLists.listId,
-        })
-        .from(bookmarksInLists)
-        .innerJoin(
-          bookmarksTable,
-          eq(bookmarksTable.id, bookmarksInLists.bookmarkId),
-        )
-        .where(
-          and(
-            inArray(bookmarksInLists.listId, manualListIds),
-            eq(bookmarksTable.userId, ctx.user.id),
-          ),
-        );
-    }
-
-    const bookmarkListMap = new Map<string, string[]>();
-    for (const m of memberships) {
-      const existing = bookmarkListMap.get(m.bookmarkId) ?? [];
-      existing.push(m.listId);
-      bookmarkListMap.set(m.bookmarkId, existing);
-    }
-
     const exportData: z.infer<typeof zExportSchema> = {
       bookmarks: bookmarks
         .map((b) => toExportFormat(b, bookmarkListMap.get(b.id) ?? []))
@@ -98,7 +98,11 @@ export async function GET(request: NextRequest) {
     });
   } else if (format === "netscape") {
     // Netscape format
-    const netscapeContent = toNetscapeFormat(bookmarks);
+    const netscapeContent = toNetscapeFormat(
+      bookmarks,
+      manualLists.map(toExportListFormat),
+      bookmarkListMap,
+    );
 
     return new Response(netscapeContent, {
       status: 200,

--- a/packages/shared/import-export/exporters.ts
+++ b/packages/shared/import-export/exporters.ts
@@ -90,40 +90,84 @@ export function toExportListFormat(
   };
 }
 
-export function toNetscapeFormat(bookmarks: ZBookmark[]): string {
+export function toNetscapeFormat(
+  bookmarks: ZBookmark[],
+  lists: z.infer<typeof zExportListSchema>[] = [],
+  bookmarkListMap = new Map<string, string[]>(),
+): string {
   const header = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
 <!-- This is an automatically generated file.
      It will be read and overwritten.
      DO NOT EDIT! -->
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
 <TITLE>Bookmarks</TITLE>
-<H1>Bookmarks</H1>
-<DL><p>`;
+<H1>Bookmarks</H1>`;
 
-  const footer = `</DL><p>`;
+  // Group lists by parentId for tree traversal
+  const listChildren = new Map<
+    string | null,
+    z.infer<typeof zExportListSchema>[]
+  >();
+  for (const list of lists) {
+    const parent = list.parentId;
+    if (!listChildren.has(parent)) listChildren.set(parent, []);
+    listChildren.get(parent)!.push(list);
+  }
 
-  const bookmarkEntries = bookmarks
-    .map((bookmark) => {
-      if (bookmark.content?.type !== BookmarkTypes.LINK) {
-        return "";
-      }
-      const addDate = bookmark.createdAt
-        ? `ADD_DATE="${Math.floor(bookmark.createdAt.getTime() / 1000)}"`
-        : "";
+  // Build reverse map: listId -> bookmarks in that list
+  const bookmarkById = new Map(bookmarks.map((b) => [b.id, b]));
+  const listBookmarks = new Map<string, ZBookmark[]>();
+  for (const [bookmarkId, listIds] of bookmarkListMap) {
+    const bookmark = bookmarkById.get(bookmarkId);
+    if (!bookmark) continue;
+    for (const listId of listIds) {
+      if (!listBookmarks.has(listId)) listBookmarks.set(listId, []);
+      listBookmarks.get(listId)!.push(bookmark);
+    }
+  }
 
-      const tagNames = bookmark.tags.map((t) => t.name).join(",");
-      const tags = tagNames.length > 0 ? `TAGS="${tagNames}"` : "";
+  // Bookmarks not in any list appear at the root level
+  const bookmarksInAnyList = new Set(
+    [...bookmarkListMap.entries()]
+      .filter(([, ids]) => ids.length > 0)
+      .map(([id]) => id),
+  );
+  const rootBookmarks = bookmarks.filter((b) => !bookmarksInAnyList.has(b.id));
 
-      const encodedUrl = encodeURI(bookmark.content.url);
-      const displayTitle = bookmark.title ?? bookmark.content.url;
-      const encodedTitle = escapeHtml(displayTitle);
+  function renderBookmark(bookmark: ZBookmark, indent: string): string {
+    if (bookmark.content?.type !== BookmarkTypes.LINK) return "";
+    const addDate = bookmark.createdAt
+      ? `ADD_DATE="${Math.floor(bookmark.createdAt.getTime() / 1000)}"`
+      : "";
+    const tagNames = bookmark.tags.map((t) => t.name).join(",");
+    const tags = tagNames.length > 0 ? `TAGS="${tagNames}"` : "";
+    const encodedUrl = encodeURI(bookmark.content.url);
+    const encodedTitle = escapeHtml(bookmark.title ?? bookmark.content.url);
+    return `${indent}<DT><A HREF="${encodedUrl}" ${addDate} ${tags}>${encodedTitle}</A>\n`;
+  }
 
-      return `    <DT><A HREF="${encodedUrl}" ${addDate} ${tags}>${encodedTitle}</A>`;
-    })
-    .filter(Boolean)
-    .join("\n");
+  // Render the folders using recursion
+  function renderFolder(listId: string | null, depth: number): string {
+    const indent = "    ".repeat(depth);
+    let output = "";
 
-  return `${header}\n${bookmarkEntries}\n${footer}`;
+    const booksHere =
+      listId === null ? rootBookmarks : (listBookmarks.get(listId) ?? []);
+    for (const bookmark of booksHere) {
+      output += renderBookmark(bookmark, indent);
+    }
+
+    for (const child of listChildren.get(listId) ?? []) {
+      output += `${indent}<DT><H3>${escapeHtml(child.name)}</H3>\n`;
+      output += `${indent}<DL><p>\n`;
+      output += renderFolder(child.id, depth + 1);
+      output += `${indent}</DL><p>\n`;
+    }
+
+    return output;
+  }
+
+  return `${header}\n<DL><p>\n${renderFolder(null, 1)}</DL><p>`;
 }
 
 function escapeHtml(input: string): string {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I'm trying to fix the issue that exporting in netscape format does not export the hierarchical structure of the folders but instead a flattened list.
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1981 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I've pasted a few link. I created a list called "open source project issues" which is the parent list and "frosty", "karakeep" which are the children list. I put the issue links under specific lists. Then, I export using User Settings -> Import Export -> Export using netscape

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="1442" height="727" alt="截屏2026-04-30 00 48 46" src="https://github.com/user-attachments/assets/a8d014bb-eb97-4843-973c-4c5dcc51d741" />
<img width="842" height="447" alt="截屏2026-04-30 00 32 06" src="https://github.com/user-attachments/assets/27ab43e8-dbb2-46e6-a7cc-1174f8f3246e" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable -no new docs
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary. -no new dependency
- [ ] I have written tests for new code (if applicable) -no