### PR TITLE
feat: redesign list and tag page headers

### DIFF
--- a/apps/web/app/dashboard/tags/[tagId]/page.tsx
+++ b/apps/web/app/dashboard/tags/[tagId]/page.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Bookmarks from "@/components/dashboard/bookmarks/Bookmarks";
-import EditableTagName from "@/components/dashboard/tags/EditableTagName";
-import { TagOptions } from "@/components/dashboard/tags/TagOptions";
-import { Button } from "@/components/ui/button";
+import TagHeader from "@/components/dashboard/tags/TagHeader";
 import { api } from "@/server/api/client";
 import { TRPCError } from "@trpc/server";
-import { MoreHorizontal } from "lucide-react";
 
 export async function generateMetadata(props: {
   params: Promise<{ tagId: string }>;
@@ -53,20 +50,8 @@ export default async function TagPage(props: {
 
   return (
     <Bookmarks
-      header={
-        <div className="flex justify-between">
-          <EditableTagName
-            tag={{ id: tag.id, name: tag.name }}
-            className="text-2xl"
-          />
-
-          <TagOptions tag={tag}>
-            <Button variant="ghost">
-              <MoreHorizontal />
-            </Button>
-          </TagOptions>
-        </div>
-      }
+      header={<TagHeader initialData={tag} />}
+      showDivider={true}
       query={{
         tagId: tag.id,
         archived: !includeArchived ? false : undefined,

--- a/apps/web/components/dashboard/lists/ListHeader.tsx
+++ b/apps/web/components/dashboard/lists/ListHeader.tsx
@@ -10,8 +10,8 @@ import {
 } from "@/components/ui/tooltip";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { useTranslation } from "@/lib/i18n/client";
-import { useQuery } from "@tanstack/react-query";
-import { MoreHorizontal, SearchIcon } from "lucide-react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { Globe, Lock, MoreHorizontal, Sparkles, Users } from "lucide-react";
 
 import { useTRPC } from "@karakeep/shared-react/trpc";
 import { parseSearchQuery } from "@karakeep/shared/searchQueryParser";
@@ -51,6 +51,13 @@ export default function ListHeader({
     ),
   );
 
+  const { data: statsData } = useQuery(
+    api.lists.stats.queryOptions(undefined, {
+      placeholderData: keepPreviousData,
+    }),
+  );
+  const itemCount = statsData?.stats.get(list.id);
+
   const parsedQuery = useMemo(() => {
     if (!list.query) {
       return null;
@@ -65,65 +72,94 @@ export default function ListHeader({
     }
   }
 
+  const privacy = list.public
+    ? { Icon: Globe, label: "Public" }
+    : list.hasCollaborators
+      ? { Icon: Users, label: "Shared" }
+      : { Icon: Lock, label: "Private" };
+  const PrivacyIcon = privacy.Icon;
+
   return (
-    <div className="flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <span className="text-2xl">
-          {list.icon} {list.name}
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex min-w-0 flex-1 items-start gap-4">
+        <span className="flex size-16 shrink-0 items-center justify-center rounded-2xl bg-muted text-4xl">
+          {list.icon}
         </span>
-        {list.hasCollaborators && collaboratorsData && (
-          <div className="group flex">
-            {collaboratorsData.owner && (
-              <Tooltip>
-                <TooltipTrigger>
-                  <div className="-mr-2 transition-all duration-300 ease-out group-hover:mr-1">
-                    <UserAvatar
-                      name={collaboratorsData.owner.name}
-                      image={collaboratorsData.owner.image}
-                      className="size-5 shrink-0 rounded-full ring-2 ring-background"
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>{collaboratorsData.owner.name}</p>
-                </TooltipContent>
-              </Tooltip>
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-2xl font-semibold leading-tight">
+            {list.name}
+          </h1>
+          {list.description && (
+            <p className="mt-1 text-muted-foreground">{list.description}</p>
+          )}
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            {itemCount !== undefined && (
+              <>
+                <span>{itemCount} items</span>
+                <span aria-hidden>·</span>
+              </>
             )}
-            {collaboratorsData.collaborators.map((collab) => (
-              <Tooltip key={collab.userId}>
-                <TooltipTrigger>
-                  <div className="-mr-2 transition-all duration-300 ease-out group-hover:mr-1">
-                    <UserAvatar
-                      name={collab.user.name}
-                      image={collab.user.image}
-                      className="size-5 shrink-0 rounded-full ring-2 ring-background"
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>{collab.user.name}</p>
-                </TooltipContent>
-              </Tooltip>
-            ))}
-          </div>
-        )}
-        {list.description && (
-          <span className="text-lg text-gray-400">{`(${list.description})`}</span>
-        )}
-      </div>
-      <div className="flex items-center">
-        {parsedQuery && (
-          <QueryExplainerTooltip
-            header={
-              <div className="flex items-center justify-center gap-1">
-                <SearchIcon className="size-3" />
-                <span className="text-sm">{t("lists.smart_list")}</span>
+            <span className="flex items-center gap-1">
+              <PrivacyIcon className="size-3.5" />
+              {privacy.label}
+            </span>
+            {parsedQuery && (
+              <>
+                <span aria-hidden>·</span>
+                <QueryExplainerTooltip
+                  parsedSearchQuery={parsedQuery}
+                  trigger={
+                    <button
+                      type="button"
+                      className="inline-flex cursor-help items-center gap-1 transition-colors hover:text-foreground"
+                    >
+                      <Sparkles className="size-3.5" />
+                      {t("lists.smart_list")}
+                    </button>
+                  }
+                />
+              </>
+            )}
+            {list.hasCollaborators && collaboratorsData && (
+              <div className="group flex items-center">
+                {collaboratorsData.owner && (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <div className="-mr-2 transition-all duration-300 ease-out group-hover:mr-1">
+                        <UserAvatar
+                          name={collaboratorsData.owner.name}
+                          image={collaboratorsData.owner.image}
+                          className="size-5 shrink-0 rounded-full ring-2 ring-background"
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{collaboratorsData.owner.name}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {collaboratorsData.collaborators.map((collab) => (
+                  <Tooltip key={collab.userId}>
+                    <TooltipTrigger>
+                      <div className="-mr-2 transition-all duration-300 ease-out group-hover:mr-1">
+                        <UserAvatar
+                          name={collab.user.name}
+                          image={collab.user.image}
+                          className="size-5 shrink-0 rounded-full ring-2 ring-background"
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{collab.user.name}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                ))}
               </div>
-            }
-            parsedSearchQuery={parsedQuery}
-            className="size-6 stroke-foreground"
-          />
-        )}
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center">
         <ListOptions list={list}>
           <Button variant="ghost">
             <MoreHorizontal />

--- a/apps/web/components/dashboard/lists/ListHeader.tsx
+++ b/apps/web/components/dashboard/lists/ListHeader.tsx
@@ -73,10 +73,10 @@ export default function ListHeader({
   }
 
   const privacy = list.public
-    ? { Icon: Globe, label: "Public" }
+    ? { Icon: Globe, label: t("lists.privacy.public") }
     : list.hasCollaborators
-      ? { Icon: Users, label: "Shared" }
-      : { Icon: Lock, label: "Private" };
+      ? { Icon: Users, label: t("lists.privacy.shared") }
+      : { Icon: Lock, label: t("lists.privacy.private") };
   const PrivacyIcon = privacy.Icon;
 
   return (
@@ -95,7 +95,7 @@ export default function ListHeader({
           <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
             {itemCount !== undefined && (
               <>
-                <span>{itemCount} items</span>
+                <span>{t("lists.items_count", { count: itemCount })}</span>
                 <span aria-hidden>·</span>
               </>
             )}

--- a/apps/web/components/dashboard/search/QueryExplainerTooltip.tsx
+++ b/apps/web/components/dashboard/search/QueryExplainerTooltip.tsx
@@ -1,5 +1,10 @@
 import InfoTooltip from "@/components/ui/info-tooltip";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useTranslation } from "@/lib/i18n/client";
 import { match } from "@/lib/utils";
 
@@ -10,10 +15,12 @@ export default function QueryExplainerTooltip({
   parsedSearchQuery,
   header,
   className,
+  trigger,
 }: {
   header?: React.ReactNode;
   parsedSearchQuery: TextAndMatcher & { result: string };
   className?: string;
+  trigger?: React.ReactNode;
 }) {
   const { t } = useTranslation();
   if (parsedSearchQuery.result == "invalid") {
@@ -226,8 +233,8 @@ export default function QueryExplainerTooltip({
     }
   };
 
-  return (
-    <InfoTooltip className={className}>
+  const body = (
+    <>
       {header}
       <Table>
         <TableBody>
@@ -242,6 +249,17 @@ export default function QueryExplainerTooltip({
           )}
         </TableBody>
       </Table>
-    </InfoTooltip>
+    </>
   );
+
+  if (trigger) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        <TooltipContent>{body}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return <InfoTooltip className={className}>{body}</InfoTooltip>;
 }

--- a/apps/web/components/dashboard/tags/RenameTagModal.tsx
+++ b/apps/web/components/dashboard/tags/RenameTagModal.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { ActionButton } from "@/components/ui/action-button";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/sonner";
+import { useTranslation } from "@/lib/i18n/client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { useUpdateTag } from "@karakeep/shared-react/hooks/tags";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1, "Tag name is required"),
+});
+
+export function RenameTagModal({
+  tag,
+  open,
+  setOpen,
+}: {
+  tag: { id: string; name: string };
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}) {
+  const { t } = useTranslation();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: tag.name },
+    values: { name: tag.name },
+  });
+
+  const { mutate: updateTag, isPending } = useUpdateTag({
+    onSuccess: () => {
+      toast({ description: "Tag updated!" });
+      setOpen(false);
+    },
+    onError: (e) => {
+      toast({ variant: "destructive", description: e.message });
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+        if (!isOpen) {
+          form.reset({ name: tag.name });
+        }
+      }}
+    >
+      <DialogContent>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((values) => {
+              updateTag({ tagId: tag.id, name: values.name });
+            })}
+          >
+            <DialogHeader>
+              <DialogTitle>{t("actions.edit")}</DialogTitle>
+            </DialogHeader>
+            <div className="py-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("tags.tag_name")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t("tags.enter_tag_name")}
+                        autoFocus
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  {t("actions.cancel")}
+                </Button>
+              </DialogClose>
+              <ActionButton type="submit" loading={isPending}>
+                {t("actions.save")}
+              </ActionButton>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/dashboard/tags/RenameTagModal.tsx
+++ b/apps/web/components/dashboard/tags/RenameTagModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { ActionButton } from "@/components/ui/action-button";
 import { Button } from "@/components/ui/button";
 import {
@@ -45,8 +46,13 @@ export function RenameTagModal({
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: { name: tag.name },
-    values: { name: tag.name },
   });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ name: tag.name });
+    }
+  }, [open, tag.name, form]);
 
   const { mutate: updateTag, isPending } = useUpdateTag({
     onSuccess: () => {

--- a/apps/web/components/dashboard/tags/RenameTagModal.tsx
+++ b/apps/web/components/dashboard/tags/RenameTagModal.tsx
@@ -50,7 +50,7 @@ export function RenameTagModal({
 
   const { mutate: updateTag, isPending } = useUpdateTag({
     onSuccess: () => {
-      toast({ description: "Tag updated!" });
+      toast({ description: t("toasts.tags.updated") });
       setOpen(false);
     },
     onError: (e) => {
@@ -76,7 +76,7 @@ export function RenameTagModal({
             })}
           >
             <DialogHeader>
-              <DialogTitle>{t("actions.edit")}</DialogTitle>
+              <DialogTitle>{t("tags.rename_tag")}</DialogTitle>
             </DialogHeader>
             <div className="py-4">
               <FormField

--- a/apps/web/components/dashboard/tags/TagHeader.tsx
+++ b/apps/web/components/dashboard/tags/TagHeader.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { TagOptions } from "@/components/dashboard/tags/TagOptions";
+import { Button } from "@/components/ui/button";
+import { useQuery } from "@tanstack/react-query";
+import { Bot, Hash, MoreHorizontal, User } from "lucide-react";
+
+import { useTRPC } from "@karakeep/shared-react/trpc";
+import { ZGetTagResponse } from "@karakeep/shared/types/tags";
+
+export default function TagHeader({
+  initialData,
+}: {
+  initialData: ZGetTagResponse;
+}) {
+  const api = useTRPC();
+  const router = useRouter();
+  const { data: tag, error } = useQuery(
+    api.tags.get.queryOptions({ tagId: initialData.id }, { initialData }),
+  );
+
+  if (error?.data?.code === "NOT_FOUND") {
+    router.push("/dashboard/tags");
+  }
+
+  const aiCount = tag.numBookmarksByAttachedType.ai ?? 0;
+  const humanCount = tag.numBookmarksByAttachedType.human ?? 0;
+
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex min-w-0 flex-1 items-start gap-4">
+        <span className="flex size-16 shrink-0 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
+          <Hash className="size-8" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-2xl font-semibold leading-tight">
+            {tag.name}
+          </h1>
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            <span>{tag.numBookmarks} items</span>
+            {humanCount > 0 && (
+              <>
+                <span aria-hidden>·</span>
+                <span className="flex items-center gap-1">
+                  <User className="size-3.5" />
+                  {humanCount} by you
+                </span>
+              </>
+            )}
+            {aiCount > 0 && (
+              <>
+                <span aria-hidden>·</span>
+                <span className="flex items-center gap-1">
+                  <Bot className="size-3.5" />
+                  {aiCount} by AI
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center">
+        <TagOptions tag={tag}>
+          <Button variant="ghost">
+            <MoreHorizontal />
+          </Button>
+        </TagOptions>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/tags/TagHeader.tsx
+++ b/apps/web/components/dashboard/tags/TagHeader.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { TagOptions } from "@/components/dashboard/tags/TagOptions";
 import { Button } from "@/components/ui/button";
+import { useTranslation } from "@/lib/i18n/client";
 import { useQuery } from "@tanstack/react-query";
 import { Bot, Hash, MoreHorizontal, User } from "lucide-react";
 
@@ -15,6 +16,7 @@ export default function TagHeader({
   initialData: ZGetTagResponse;
 }) {
   const api = useTRPC();
+  const { t } = useTranslation();
   const router = useRouter();
   const { data: tag, error } = useQuery(
     api.tags.get.queryOptions({ tagId: initialData.id }, { initialData }),
@@ -38,13 +40,13 @@ export default function TagHeader({
             {tag.name}
           </h1>
           <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-            <span>{tag.numBookmarks} items</span>
+            <span>{t("tags.items_count", { count: tag.numBookmarks })}</span>
             {humanCount > 0 && (
               <>
                 <span aria-hidden>·</span>
                 <span className="flex items-center gap-1">
                   <User className="size-3.5" />
-                  {humanCount} by you
+                  {t("tags.attached_by_you", { count: humanCount })}
                 </span>
               </>
             )}
@@ -53,7 +55,7 @@ export default function TagHeader({
                 <span aria-hidden>·</span>
                 <span className="flex items-center gap-1">
                   <Bot className="size-3.5" />
-                  {aiCount} by AI
+                  {t("tags.attached_by_ai", { count: aiCount })}
                 </span>
               </>
             )}

--- a/apps/web/components/dashboard/tags/TagOptions.tsx
+++ b/apps/web/components/dashboard/tags/TagOptions.tsx
@@ -9,10 +9,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useShowArchived } from "@/components/utils/useShowArchived";
 import { useTranslation } from "@/lib/i18n/client";
-import { Combine, Square, SquareCheck, Trash2 } from "lucide-react";
+import { Combine, Pencil, Square, SquareCheck, Trash2 } from "lucide-react";
 
 import DeleteTagConfirmationDialog from "./DeleteTagConfirmationDialog";
 import { MergeTagModal } from "./MergeTagModal";
+import { RenameTagModal } from "./RenameTagModal";
 
 export function TagOptions({
   tag,
@@ -26,6 +27,7 @@ export function TagOptions({
 
   const [deleteTagDialogOpen, setDeleteTagDialogOpen] = useState(false);
   const [mergeTagDialogOpen, setMergeTagDialogOpen] = useState(false);
+  const [renameTagDialogOpen, setRenameTagDialogOpen] = useState(false);
 
   return (
     <DropdownMenu>
@@ -39,8 +41,20 @@ export function TagOptions({
         setOpen={setMergeTagDialogOpen}
         tag={tag}
       />
+      <RenameTagModal
+        tag={tag}
+        open={renameTagDialogOpen}
+        setOpen={setRenameTagDialogOpen}
+      />
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
       <DropdownMenuContent>
+        <DropdownMenuItem
+          className="flex gap-2"
+          onClick={() => setRenameTagDialogOpen(true)}
+        >
+          <Pencil className="size-4" />
+          <span>{t("actions.edit")}</span>
+        </DropdownMenuItem>
         <DropdownMenuItem
           className="flex gap-2"
           onClick={() => setMergeTagDialogOpen(true)}

--- a/apps/web/components/dashboard/tags/TagOptions.tsx
+++ b/apps/web/components/dashboard/tags/TagOptions.tsx
@@ -53,7 +53,7 @@ export function TagOptions({
           onClick={() => setRenameTagDialogOpen(true)}
         >
           <Pencil className="size-4" />
-          <span>{t("actions.edit")}</span>
+          <span>{t("actions.rename")}</span>
         </DropdownMenuItem>
         <DropdownMenuItem
           className="flex gap-2"

--- a/apps/web/lib/i18n/locales/en/translation.json
+++ b/apps/web/lib/i18n/locales/en/translation.json
@@ -92,6 +92,7 @@
     "add": "Add",
     "remove": "Remove",
     "edit": "Edit",
+    "rename": "Rename",
     "confirm": "Confirm",
     "open_editor": "Open Editor",
     "create": "Create",
@@ -776,6 +777,12 @@
     "favourites": "Favourites",
     "shared": "Shared",
     "shared_lists": "Shared Lists",
+    "items_count": "{{count}} items",
+    "privacy": {
+      "public": "Public",
+      "shared": "Shared",
+      "private": "Private"
+    },
     "new_list": "New List",
     "edit_list": "Edit List",
     "share_list": "Share List",
@@ -862,6 +869,10 @@
     "your_tags": "Your Tags",
     "your_tags_info": "Tags that were attached at least once by you",
     "ai_tags": "AI Tags",
+    "rename_tag": "Rename Tag",
+    "items_count": "{{count}} items",
+    "attached_by_you": "{{count}} by you",
+    "attached_by_ai": "{{count}} by AI",
     "ai_tags_info": "Tags that were only attached automatically (by AI)",
     "unused_tags": "Unused Tags",
     "unused_tags_info": "Tags that are not attached to any bookmarks",
@@ -1032,7 +1043,9 @@
     },
     "tags": {
       "created": "Tag has been created!",
-      "failed_to_create": "Failed to create tag"
+      "failed_to_create": "Failed to create tag",
+      "updated": "Tag has been updated!",
+      "failed_to_update": "Failed to update tag"
     }
   },
   "banners": {


### PR DESCRIPTION
Adds more info about the list/tag (such as item count). For lists, it also shows whether it's private/shared/public, and if it's a smart list, the matchers are shown there as well.