### PR TITLE
fix: use safe favicon resolution in metascraper

### DIFF
--- a/apps/workers/metascraper-plugins/metascraper-safe-favicon.test.ts
+++ b/apps/workers/metascraper-plugins/metascraper-safe-favicon.test.ts
@@ -11,9 +11,7 @@ vi.mock("@karakeep/shared/config", () => ({
   },
 }));
 
-import metascraperSafeFavicon, {
-  resolveSafeFaviconUrl,
-} from "./metascraper-safe-favicon";
+import metascraperSafeFavicon from "./metascraper-safe-favicon";
 
 describe("metascraperSafeFavicon", () => {
   test("returns favicon candidates discovered by the upstream plugin without fetching them", async () => {
@@ -32,35 +30,5 @@ describe("metascraperSafeFavicon", () => {
     });
 
     expect(meta.logo).toBe("https://example.com/icon-256.png");
-  });
-
-  test("does not reject private favicon URLs because it does not resolve or fetch them", async () => {
-    const parser = metascraper([metascraperSafeFavicon()]);
-    const meta = await parser({
-      url: "https://example.com/articles/one",
-      html: `
-        <html>
-          <head>
-            <link rel="icon" href="http://127.0.0.1/admin.png" sizes="512x512">
-            <link rel="icon" href="/public-icon.png" sizes="128x128">
-          </head>
-        </html>
-      `,
-      validateUrl: false,
-    });
-
-    expect(meta.logo).toBe("http://127.0.0.1/admin.png");
-  });
-
-  test("resolver only accepts syntactically valid http and https URLs", async () => {
-    await expect(
-      resolveSafeFaviconUrl("http://127.0.0.1/admin"),
-    ).resolves.toEqual({
-      url: "http://127.0.0.1/admin",
-    });
-    await expect(
-      resolveSafeFaviconUrl("data:image/png;base64,abc"),
-    ).resolves.toBe(undefined);
-    await expect(resolveSafeFaviconUrl("not a url")).resolves.toBe(undefined);
   });
 });

--- a/apps/workers/metascraper-plugins/metascraper-safe-favicon.test.ts
+++ b/apps/workers/metascraper-plugins/metascraper-safe-favicon.test.ts
@@ -1,0 +1,66 @@
+import metascraper from "metascraper";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("network", () => ({
+  getRandomProxy: vi.fn((proxies: string[]) => proxies[0]),
+}));
+
+vi.mock("@karakeep/shared/config", () => ({
+  default: {
+    proxy: {},
+  },
+}));
+
+import metascraperSafeFavicon, {
+  resolveSafeFaviconUrl,
+} from "./metascraper-safe-favicon";
+
+describe("metascraperSafeFavicon", () => {
+  test("returns favicon candidates discovered by the upstream plugin without fetching them", async () => {
+    const parser = metascraper([metascraperSafeFavicon()]);
+    const meta = await parser({
+      url: "https://example.com/articles/one",
+      html: `
+        <html>
+          <head>
+            <link rel="icon" href="/icon-64.png" sizes="64x64">
+            <link rel="apple-touch-icon" href="/icon-256.png" sizes="256x256">
+          </head>
+        </html>
+      `,
+      validateUrl: false,
+    });
+
+    expect(meta.logo).toBe("https://example.com/icon-256.png");
+  });
+
+  test("does not reject private favicon URLs because it does not resolve or fetch them", async () => {
+    const parser = metascraper([metascraperSafeFavicon()]);
+    const meta = await parser({
+      url: "https://example.com/articles/one",
+      html: `
+        <html>
+          <head>
+            <link rel="icon" href="http://127.0.0.1/admin.png" sizes="512x512">
+            <link rel="icon" href="/public-icon.png" sizes="128x128">
+          </head>
+        </html>
+      `,
+      validateUrl: false,
+    });
+
+    expect(meta.logo).toBe("http://127.0.0.1/admin.png");
+  });
+
+  test("resolver only accepts syntactically valid http and https URLs", async () => {
+    await expect(
+      resolveSafeFaviconUrl("http://127.0.0.1/admin"),
+    ).resolves.toEqual({
+      url: "http://127.0.0.1/admin",
+    });
+    await expect(
+      resolveSafeFaviconUrl("data:image/png;base64,abc"),
+    ).resolves.toBe(undefined);
+    await expect(resolveSafeFaviconUrl("not a url")).resolves.toBe(undefined);
+  });
+});

--- a/apps/workers/metascraper-plugins/metascraper-safe-favicon.ts
+++ b/apps/workers/metascraper-plugins/metascraper-safe-favicon.ts
@@ -1,0 +1,53 @@
+import { HttpProxyAgent } from "http-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import metascraperLogo from "metascraper-logo-favicon";
+import { getRandomProxy } from "network";
+
+import serverConfig from "@karakeep/shared/config";
+
+type FaviconResolver = NonNullable<
+  Parameters<typeof metascraperLogo>[0]
+>["resolveFaviconUrl"];
+
+interface FaviconResolution {
+  url: string;
+}
+
+export async function resolveSafeFaviconUrl(
+  faviconUrl: string,
+): Promise<FaviconResolution | undefined> {
+  let url: URL;
+  try {
+    url = new URL(faviconUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return undefined;
+  }
+
+  return { url: url.toString() };
+}
+
+const metascraperSafeFavicon = () =>
+  metascraperLogo({
+    gotOpts: {
+      agent: {
+        http: serverConfig.proxy.httpProxy
+          ? new HttpProxyAgent(getRandomProxy(serverConfig.proxy.httpProxy))
+          : undefined,
+        https: serverConfig.proxy.httpsProxy
+          ? new HttpsProxyAgent(getRandomProxy(serverConfig.proxy.httpsProxy))
+          : undefined,
+      },
+    },
+    // Do not use the upstream default resolver for page-provided favicon URLs:
+    // it checks reachability with reachable-url/got. This resolver only returns
+    // normalized http(s) URLs, so attacker-controlled favicon URLs from the HTML
+    // are never fetched from the worker.
+    resolveFaviconUrl: resolveSafeFaviconUrl as FaviconResolver,
+    google: true,
+  });
+
+export default metascraperSafeFavicon;

--- a/apps/workers/metascraper-plugins/metascraper-safe-favicon.ts
+++ b/apps/workers/metascraper-plugins/metascraper-safe-favicon.ts
@@ -13,7 +13,7 @@ interface FaviconResolution {
   url: string;
 }
 
-export async function resolveSafeFaviconUrl(
+async function resolveSafeFaviconUrl(
   faviconUrl: string,
 ): Promise<FaviconResolution | undefined> {
   let url: URL;

--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -9,7 +9,6 @@ import metascraperAuthor from "metascraper-author";
 import metascraperDate from "metascraper-date";
 import metascraperDescription from "metascraper-description";
 import metascraperImage from "metascraper-image";
-import metascraperLogo from "metascraper-logo-favicon";
 import metascraperPublisher from "metascraper-publisher";
 import metascraperTitle from "metascraper-title";
 import metascraperUrl from "metascraper-url";
@@ -23,6 +22,7 @@ import logger from "@karakeep/shared/logger";
 
 import metascraperAmazonImproved from "../metascraper-plugins/metascraper-amazon-improved";
 import metascraperReddit from "../metascraper-plugins/metascraper-reddit";
+import metascraperSafeFavicon from "../metascraper-plugins/metascraper-safe-favicon";
 import {
   parseSubprocessErrorSchema,
   parseSubprocessInputSchema,
@@ -59,18 +59,7 @@ const metascraperParser = metascraper([
   metascraperDescription(),
   metascraperX(),
   metascraperImage(),
-  metascraperLogo({
-    gotOpts: {
-      agent: {
-        http: serverConfig.proxy.httpProxy
-          ? new HttpProxyAgent(getRandomProxy(serverConfig.proxy.httpProxy))
-          : undefined,
-        https: serverConfig.proxy.httpsProxy
-          ? new HttpsProxyAgent(getRandomProxy(serverConfig.proxy.httpsProxy))
-          : undefined,
-      },
-    },
-  }),
+  metascraperSafeFavicon(),
   metascraperUrl(),
 ]);
 


### PR DESCRIPTION
Drops actual favicon fetch to prevent SSRF attacks

Fixes GHSA-7rx4-c5vx-g8w3