### PR TITLE
fix: use correct env variable syntax for perplexity

### DIFF
--- a/docs/docs/03-configuration/02-different-ai-providers.md
+++ b/docs/docs/03-configuration/02-different-ai-providers.md
@@ -87,8 +87,8 @@ INFERENCE_IMAGE_MODEL=meta-llama/llama-4-scout
 ```
 OPENAI_BASE_URL: https://api.perplexity.ai
 OPENAI_API_KEY: Your Perplexity API Key
-INFERENCE_TEXT_MODEL: sonar-pro
-INFERENCE_IMAGE_MODEL: sonar-pro
+INFERENCE_TEXT_MODEL=sonar-pro
+INFERENCE_IMAGE_MODEL=sonar-pro
 ```
 
 ## Azure

--- a/docs/docs/03-configuration/02-different-ai-providers.md
+++ b/docs/docs/03-configuration/02-different-ai-providers.md
@@ -85,8 +85,8 @@ INFERENCE_IMAGE_MODEL=meta-llama/llama-4-scout
 ## Perplexity
 
 ```
-OPENAI_BASE_URL: https://api.perplexity.ai
-OPENAI_API_KEY: Your Perplexity API Key
+OPENAI_BASE_URL=https://api.perplexity.ai
+OPENAI_API_KEY=YOUR_PERPLEXITY_API_KEY
 INFERENCE_TEXT_MODEL=sonar-pro
 INFERENCE_IMAGE_MODEL=sonar-pro
 ```


### PR DESCRIPTION
Replace YAML-style colon separators with equals signs for `INFERENCE_TEXT_MODEL` and `INFERENCE_IMAGE_MODEL`.