### PR TITLE
Render Distill math in reader view

### DIFF
--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -28,6 +28,7 @@
     "https-proxy-agent": "^7.0.6",
     "ipaddr.js": "^2.2.0",
     "jsdom": "^24.0.0",
+    "katex": "^0.16.45",
     "liteque": "^0.8.0",
     "lru-cache": "^11.2.2",
     "metascraper": "^5.50.0",
@@ -62,6 +63,7 @@
   "devDependencies": {
     "@types/archiver": "^7.0.0",
     "@types/jsdom": "^21.1.6",
+    "@types/katex": "^0.16.8",
     "@types/node-cron": "^3.0.11",
     "tsdown": "^0.12.9",
     "vitest": "^3.2.4"

--- a/apps/workers/scripts/htmlMath.test.ts
+++ b/apps/workers/scripts/htmlMath.test.ts
@@ -49,7 +49,7 @@ describe("sanitizeReadableHtml", () => {
       "https://example.com/article",
     );
 
-    expect(html).toBe("<p>before   after</p>");
+    expect(html).toMatch(/^<p>before\s+after<\/p>$/);
     expect(html).not.toContain("<d-math");
   });
 });

--- a/apps/workers/scripts/htmlMath.test.ts
+++ b/apps/workers/scripts/htmlMath.test.ts
@@ -26,4 +26,25 @@ describe("sanitizeReadableHtml", () => {
     );
     expect(html).not.toContain("<d-math");
   });
+
+  test("falls back to plain text for invalid math", () => {
+    const html = sanitizeReadableHtml(
+      `<p><d-math>\\UNDEFINED{</d-math></p>`,
+      "https://example.com/article",
+    );
+
+    expect(html).toContain("\\UNDEFINED{");
+    expect(html).not.toContain("<math");
+    expect(html).not.toContain("<d-math");
+  });
+
+  test("drops empty Distill math elements during sanitization", () => {
+    const html = sanitizeReadableHtml(
+      `<p>before <d-math> </d-math> after</p>`,
+      "https://example.com/article",
+    );
+
+    expect(html).toBe("<p>before   after</p>");
+    expect(html).not.toContain("<d-math");
+  });
 });

--- a/apps/workers/scripts/htmlMath.test.ts
+++ b/apps/workers/scripts/htmlMath.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { JSDOM } from "jsdom";
 
 import { sanitizeReadableHtml } from "./htmlMath";
 
@@ -21,10 +22,14 @@ describe("sanitizeReadableHtml", () => {
       "https://example.com/article",
     );
 
-    expect(html).toContain(
-      '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">',
-    );
+    const dom = new JSDOM(`<body>${html}</body>`);
+    const math = dom.window.document.querySelector("math");
+
+    expect(math?.namespaceURI).toBe("http://www.w3.org/1998/Math/MathML");
+    expect(math?.getAttribute("display")).toBe("block");
     expect(html).not.toContain("<d-math");
+
+    dom.window.close();
   });
 
   test("falls back to plain text for invalid math", () => {

--- a/apps/workers/scripts/htmlMath.test.ts
+++ b/apps/workers/scripts/htmlMath.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { sanitizeReadableHtml } from "./htmlMath";
+
+describe("sanitizeReadableHtml", () => {
+  test("renders Distill inline math as native MathML before sanitizing", () => {
+    const html = sanitizeReadableHtml(
+      `<p>where <d-math>W_{enc}^{\\ell}</d-math> is the encoder matrix.</p>`,
+      "https://transformer-circuits.pub/2025/attribution-graphs/methods.html",
+    );
+
+    expect(html).toContain("<math");
+    expect(html).toContain("<msubsup>");
+    expect(html).not.toContain("<d-math");
+    expect(html).not.toContain("<annotation");
+  });
+
+  test("preserves Distill display math mode", () => {
+    const html = sanitizeReadableHtml(
+      `<d-math block>\\sum_i x_i</d-math>`,
+      "https://example.com/article",
+    );
+
+    expect(html).toContain(
+      '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">',
+    );
+    expect(html).not.toContain("<d-math");
+  });
+});

--- a/apps/workers/scripts/htmlMath.ts
+++ b/apps/workers/scripts/htmlMath.ts
@@ -8,6 +8,7 @@ function renderDistillMath(document: Document): void {
   for (const mathElement of mathElements) {
     const tex = mathElement.textContent?.trim();
     if (!tex) {
+      mathElement.remove();
       continue;
     }
 

--- a/apps/workers/scripts/htmlMath.ts
+++ b/apps/workers/scripts/htmlMath.ts
@@ -2,6 +2,8 @@ import DOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 import katex from "katex";
 
+import logger from "@karakeep/shared/logger";
+
 function renderDistillMath(document: Document): void {
   const mathElements = Array.from(document.querySelectorAll("d-math"));
 
@@ -32,7 +34,11 @@ function renderDistillMath(document: Document): void {
         .forEach((annotation) => annotation.remove());
 
       mathElement.replaceWith(...Array.from(template.content.childNodes));
-    } catch {
+    } catch (error) {
+      logger.warn(
+        "[Crawler] Failed to render Distill math; falling back to plain text",
+        { error, tex, mathHtml: mathElement.outerHTML },
+      );
       mathElement.replaceWith(document.createTextNode(tex));
     }
   }

--- a/apps/workers/scripts/htmlMath.ts
+++ b/apps/workers/scripts/htmlMath.ts
@@ -37,7 +37,11 @@ function renderDistillMath(document: Document): void {
     } catch (error) {
       logger.warn(
         "[Crawler] Failed to render Distill math; falling back to plain text",
-        { error, tex, mathHtml: mathElement.outerHTML },
+        {
+          error,
+          texLength: tex.length,
+          texPreview: tex.slice(0, 120),
+        },
       );
       mathElement.replaceWith(document.createTextNode(tex));
     }

--- a/apps/workers/scripts/htmlMath.ts
+++ b/apps/workers/scripts/htmlMath.ts
@@ -24,13 +24,13 @@ function renderDistillMath(document: Document): void {
         trust: false,
       });
 
-      const temp = document.createElement("div");
-      temp.innerHTML = rendered;
-      temp
+      const template = document.createElement("template");
+      template.innerHTML = rendered;
+      template.content
         .querySelectorAll("annotation")
         .forEach((annotation) => annotation.remove());
 
-      mathElement.replaceWith(...Array.from(temp.childNodes));
+      mathElement.replaceWith(...Array.from(template.content.childNodes));
     } catch {
       mathElement.replaceWith(document.createTextNode(tex));
     }

--- a/apps/workers/scripts/htmlMath.ts
+++ b/apps/workers/scripts/htmlMath.ts
@@ -20,25 +20,17 @@ function renderDistillMath(document: Document): void {
         displayMode,
         output: "mathml",
         strict: "ignore",
-        throwOnError: false,
+        throwOnError: true,
         trust: false,
       });
 
-      const renderedDom = new JSDOM(rendered);
-      try {
-        renderedDom.window.document
-          .querySelectorAll("annotation")
-          .forEach((annotation) => annotation.remove());
+      const temp = document.createElement("div");
+      temp.innerHTML = rendered;
+      temp
+        .querySelectorAll("annotation")
+        .forEach((annotation) => annotation.remove());
 
-        const replacementNodes = Array.from(
-          renderedDom.window.document.body.childNodes,
-          (node) => document.importNode(node, true),
-        );
-
-        mathElement.replaceWith(...replacementNodes);
-      } finally {
-        renderedDom.window.close();
-      }
+      mathElement.replaceWith(...Array.from(temp.childNodes));
     } catch {
       mathElement.replaceWith(document.createTextNode(tex));
     }

--- a/apps/workers/scripts/htmlMath.ts
+++ b/apps/workers/scripts/htmlMath.ts
@@ -1,0 +1,58 @@
+import DOMPurify from "dompurify";
+import { JSDOM } from "jsdom";
+import katex from "katex";
+
+function renderDistillMath(document: Document): void {
+  const mathElements = Array.from(document.querySelectorAll("d-math"));
+
+  for (const mathElement of mathElements) {
+    const tex = mathElement.textContent?.trim();
+    if (!tex) {
+      continue;
+    }
+
+    const displayMode =
+      mathElement.hasAttribute("block") ||
+      mathElement.getAttribute("display") === "block";
+
+    try {
+      const rendered = katex.renderToString(tex, {
+        displayMode,
+        output: "mathml",
+        strict: "ignore",
+        throwOnError: false,
+        trust: false,
+      });
+
+      const renderedDom = new JSDOM(rendered);
+      try {
+        renderedDom.window.document
+          .querySelectorAll("annotation")
+          .forEach((annotation) => annotation.remove());
+
+        const replacementNodes = Array.from(
+          renderedDom.window.document.body.childNodes,
+          (node) => document.importNode(node, true),
+        );
+
+        mathElement.replaceWith(...replacementNodes);
+      } finally {
+        renderedDom.window.close();
+      }
+    } catch {
+      mathElement.replaceWith(document.createTextNode(tex));
+    }
+  }
+}
+
+export function sanitizeReadableHtml(htmlContent: string, url: string): string {
+  const dom = new JSDOM(`<body>${htmlContent}</body>`, { url });
+  try {
+    renderDistillMath(dom.window.document);
+
+    const purify = DOMPurify(dom.window);
+    return purify.sanitize(dom.window.document.body.innerHTML);
+  } finally {
+    dom.window.close();
+  }
+}

--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -1,5 +1,4 @@
 import { Readability } from "@mozilla/readability";
-import DOMPurify from "dompurify";
 import { HttpProxyAgent } from "http-proxy-agent";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { JSDOM, VirtualConsole } from "jsdom";
@@ -28,6 +27,7 @@ import {
   parseSubprocessInputSchema,
   parseSubprocessOutputSchema,
 } from "../workers/utils/parseHtmlSubprocessIpc";
+import { sanitizeReadableHtml } from "./htmlMath";
 
 // Redirect all log output to stderr so it doesn't interfere with the JSON protocol on stdout.
 logger.clear();
@@ -122,14 +122,7 @@ function extractReadableContent(
       return null;
     }
 
-    const purifyWindow = new JSDOM("").window;
-    try {
-      const purify = DOMPurify(purifyWindow);
-      const purifiedHTML = purify.sanitize(readableContent.content);
-      return { content: purifiedHTML };
-    } finally {
-      purifyWindow.close();
-    }
+    return { content: sanitizeReadableHtml(readableContent.content, url) };
   } finally {
     dom.window.close();
   }
@@ -164,14 +157,9 @@ async function main() {
   if (meta.readableContentHtml) {
     // Sanitize plugin-provided HTML through DOMPurify (the extractReadableContent
     // path already does this, but the direct-content path was missing it).
-    const purifyWindow = new JSDOM("").window;
-    try {
-      const purify = DOMPurify(purifyWindow);
-      const purifiedHTML = purify.sanitize(meta.readableContentHtml);
-      readableContent = { content: purifiedHTML };
-    } finally {
-      purifyWindow.close();
-    }
+    readableContent = {
+      content: sanitizeReadableHtml(meta.readableContentHtml, url),
+    };
   }
 
   if (!readableContent) {

--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -155,8 +155,9 @@ async function main() {
   // Conditionally run readability (skip if metascraper already provided readable content, e.g. Reddit plugin)
   let readableContent: { content: string } | null = null;
   if (meta.readableContentHtml) {
-    // Sanitize plugin-provided HTML through DOMPurify (the extractReadableContent
-    // path already does this, but the direct-content path was missing it).
+    // Run plugin-provided HTML through the shared sanitizer: Distill d-math
+    // rendering followed by DOMPurify. extractReadableContent already uses the
+    // same flow; the direct-content path was previously missing it.
     readableContent = {
       content: sanitizeReadableHtml(meta.readableContentHtml, url),
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -904,6 +904,9 @@ importers:
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
+      katex:
+        specifier: ^0.16.45
+        version: 0.16.45
       liteque:
         specifier: ^0.8.0
         version: 0.8.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.3.0)(kysely@0.28.5)(react@19.2.3)
@@ -1001,6 +1004,9 @@ importers:
       '@types/jsdom':
         specifier: ^21.1.6
         version: 21.1.7
+      '@types/katex':
+        specifier: ^0.16.8
+        version: 0.16.8
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11
@@ -7303,6 +7309,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
@@ -11459,6 +11468,10 @@ packages:
 
   jsonrepair@3.13.3:
     resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
+    hasBin: true
+
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
 
   keyv@4.5.4:
@@ -24600,6 +24613,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/katex@0.16.8': {}
+
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 24.10.3
@@ -29439,6 +29454,10 @@ snapshots:
   jsonpointer@5.0.1: {}
 
   jsonrepair@3.13.3: {}
+
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
## Description

Fixes #1243.

This PR converts Distill-style `<d-math>` tags to native MathML during readable HTML sanitization, so pages like the Transformer Circuits example render math in Karakeep's reader view instead of showing raw TeX. It keeps the change scoped to reader content: Readability output and plugin-provided readable HTML now both use the same `sanitizeReadableHtml` path, which renders Distill math with KaTeX and then runs DOMPurify.

## How Has This Been Tested?

- [x] `pnpm --filter @karakeep/workers run typecheck`
- [x] `pnpm --filter @karakeep/workers run lint`
- [x] `pnpm --filter @karakeep/workers run test`
- [x] `pnpm --filter @karakeep/workers exec oxfmt --check scripts/htmlMath.ts scripts/htmlMath.test.ts scripts/parseHtmlSubprocess.ts`
- [x] Parser smoke test with the `<d-math>W_{enc}^{\ell}</d-math>` sample from #1243

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable; this is worker-side reader HTML processing with unit coverage and a parser smoke test.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was prepared with AI coding assistance and then validated with the worker typecheck, lint, formatter check, test suite, and a parser smoke test.