### PR TITLE
feat(browser-extension): request host permission at runtime for client side crawling

### DIFF
--- a/apps/browser-extension/manifest.json
+++ b/apps/browser-extension/manifest.json
@@ -45,7 +45,7 @@
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
   "permissions": ["storage", "tabs", "contextMenus", "activeTab", "scripting"],
-  "host_permissions": ["<all_urls>"],
+  "optional_host_permissions": ["<all_urls>"],
   "content_scripts": [
     {
       "matches": ["https://karakeep.invalid/*"],

--- a/apps/browser-extension/src/OptionsPage.tsx
+++ b/apps/browser-extension/src/OptionsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
@@ -14,6 +14,11 @@ import {
 import { Switch } from "./components/ui/switch";
 import Logo from "./Logo";
 import Spinner from "./Spinner";
+import {
+  hasHostPermission,
+  removeHostPermission,
+  requestHostPermission,
+} from "./utils/permissions";
 import usePluginSettings, {
   DEFAULT_BADGE_CACHE_EXPIRE_MS,
 } from "./utils/settings";
@@ -26,6 +31,40 @@ export default function OptionsPage() {
   const navigate = useNavigate();
   const { settings, setSettings } = usePluginSettings();
   const { setTheme, theme } = useTheme();
+
+  // `<all_urls>` is an optional host permission that the user grants when they
+  // opt in to client-side crawling. Keep the switch in sync with whether it's
+  // actually granted (it can be revoked from the browser's extension settings).
+  const [hostPermissionGranted, setHostPermissionGranted] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    hasHostPermission().then((granted) => {
+      if (!cancelled) setHostPermissionGranted(granted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const clientSideCrawlingEnabled =
+    settings.useSingleFile && hostPermissionGranted;
+
+  const onToggleClientSideCrawling = async (checked: boolean) => {
+    if (checked) {
+      // Must run synchronously off the user gesture — don't await anything else
+      // before requesting the permission.
+      const granted = await requestHostPermission();
+      if (!granted) {
+        return;
+      }
+      setHostPermissionGranted(true);
+      await setSettings((s) => ({ ...s, useSingleFile: true }));
+    } else {
+      await setSettings((s) => ({ ...s, useSingleFile: false }));
+      await removeHostPermission();
+      setHostPermissionGranted(false);
+    }
+  };
 
   const { data: whoami, error: whoAmIError } = useQuery(
     api.users.whoami.queryOptions(undefined, {
@@ -131,17 +170,16 @@ export default function OptionsPage() {
           </div>
           <span className="text-xs text-gray-500">
             Captures the page in the browser instead of on the server. Slower,
-            but captures the page more accurately as you see it.
+            but captures the page more accurately as you see it. Enabling this
+            asks for permission to read the content of pages you save.
           </span>
         </div>
         <Switch
-          checked={settings.useSingleFile}
-          onCheckedChange={(checked) =>
-            setSettings((s) => ({ ...s, useSingleFile: checked }))
-          }
+          checked={clientSideCrawlingEnabled}
+          onCheckedChange={onToggleClientSideCrawling}
         />
       </div>
-      {settings.useSingleFile && (
+      {clientSideCrawlingEnabled && (
         <div className="flex items-start justify-between gap-2 pl-4">
           <div className="flex flex-col">
             <span className="text-sm font-medium">Include images</span>

--- a/apps/browser-extension/src/SavePage.tsx
+++ b/apps/browser-extension/src/SavePage.tsx
@@ -13,6 +13,7 @@ import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
 import { Textarea } from "./components/ui/textarea";
 import Spinner from "./Spinner";
+import { hasHostPermission } from "./utils/permissions";
 import usePluginSettings from "./utils/settings";
 import {
   capturePageWithSingleFile,
@@ -129,7 +130,10 @@ export default function SavePage() {
       bookmark.type === BookmarkTypes.LINK &&
       !bookmark.precrawledArchiveId &&
       currentTabUrl !== undefined &&
-      bookmark.url === currentTabUrl
+      bookmark.url === currentTabUrl &&
+      // The `<all_urls>` host permission is optional and only granted when the
+      // user opts in to client-side crawling; it may have been revoked since.
+      (await hasHostPermission())
     ) {
       try {
         setIsCapturing(true);

--- a/apps/browser-extension/src/utils/permissions.ts
+++ b/apps/browser-extension/src/utils/permissions.ts
@@ -1,0 +1,25 @@
+/**
+ * Host-permission helpers for the client-side crawling feature.
+ *
+ * `<all_urls>` is declared as an *optional* host permission so it isn't granted
+ * at install time. It's only needed when the user opts in to client-side
+ * crawling (capturing pages in the browser via SingleFile), at which point we
+ * ask for it via `chrome.permissions.request()` — which must be called from a
+ * user gesture (e.g. flipping the settings switch).
+ */
+
+const HOST_PERMISSIONS: chrome.permissions.Permissions = {
+  origins: ["<all_urls>"],
+};
+
+export function hasHostPermission(): Promise<boolean> {
+  return chrome.permissions.contains(HOST_PERMISSIONS);
+}
+
+export function requestHostPermission(): Promise<boolean> {
+  return chrome.permissions.request(HOST_PERMISSIONS);
+}
+
+export function removeHostPermission(): Promise<boolean> {
+  return chrome.permissions.remove(HOST_PERMISSIONS);
+}


### PR DESCRIPTION
Move `<all_urls>` from `host_permissions` to `optional_host_permissions` so it isn't requested at install time. The permission is now requested via `chrome.permissions.request()` when the user enables client-side crawling in the extension settings, and removed when they disable it. The settings toggle and the capture path both gate on whether the permission is actually granted.

Fixes #2782