### PR TITLE
Preserve formatting in saved highlights

### DIFF
--- a/apps/web/components/dashboard/highlights/HighlightCard.tsx
+++ b/apps/web/components/dashboard/highlights/HighlightCard.tsx
@@ -69,7 +69,7 @@ export default function HighlightCard({
             HIGHLIGHT_COLOR_MAP["border-l"][highlight.color],
           )}
         >
-          <p>{highlight.text}</p>
+          <p className="whitespace-pre-wrap break-words">{highlight.text}</p>
         </blockquote>
         {highlight.note && (
           <span className="text-sm text-muted-foreground">

--- a/apps/web/components/dashboard/highlights/highlight-text.test.ts
+++ b/apps/web/components/dashboard/highlights/highlight-text.test.ts
@@ -11,6 +11,16 @@ function selectElementContents(element: HTMLElement) {
 }
 
 describe("getHighlightTextFromRange", () => {
+  test("preserves consecutive structural breaks", () => {
+    document.body.innerHTML = "<p>First<br><br>Second</p>";
+
+    const paragraph = document.querySelector("p") as HTMLElement;
+
+    expect(getHighlightTextFromRange(selectElementContents(paragraph))).toBe(
+      "First\n\nSecond",
+    );
+  });
+
   test("preserves block breaks between selected paragraphs", () => {
     document.body.innerHTML = `
       <article>
@@ -44,6 +54,16 @@ describe("getHighlightTextFromRange", () => {
 
     expect(getHighlightTextFromRange(selectElementContents(paragraph))).toBe(
       "Before\n[Image: architecture diagram]\nafter",
+    );
+  });
+
+  test("uses a concise marker for selected images without labels", () => {
+    document.body.innerHTML = '<p>Before <img src="/diagram.png"> after</p>';
+
+    const paragraph = document.querySelector("p") as HTMLElement;
+
+    expect(getHighlightTextFromRange(selectElementContents(paragraph))).toBe(
+      "Before\n[Image]\nafter",
     );
   });
 });

--- a/apps/web/components/dashboard/highlights/highlight-text.test.ts
+++ b/apps/web/components/dashboard/highlights/highlight-text.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, expect, test } from "vitest";
+
+import { getHighlightTextFromRange } from "@karakeep/shared-react/components/highlight-text";
+
+function selectElementContents(element: HTMLElement) {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  return range;
+}
+
+describe("getHighlightTextFromRange", () => {
+  test("preserves block breaks between selected paragraphs", () => {
+    document.body.innerHTML = `
+      <article>
+        <p>First line</p>
+        <p>Second <strong>line</strong></p>
+      </article>
+    `;
+
+    const article = document.querySelector("article") as HTMLElement;
+
+    expect(getHighlightTextFromRange(selectElementContents(article))).toBe(
+      "First line\nSecond line",
+    );
+  });
+
+  test("preserves explicit line breaks", () => {
+    document.body.innerHTML = "<p>First<br>Second</p>";
+
+    const paragraph = document.querySelector("p") as HTMLElement;
+
+    expect(getHighlightTextFromRange(selectElementContents(paragraph))).toBe(
+      "First\nSecond",
+    );
+  });
+
+  test("keeps a readable marker for selected images", () => {
+    document.body.innerHTML =
+      '<p>Before <img alt="architecture diagram" src="/diagram.png"> after</p>';
+
+    const paragraph = document.querySelector("p") as HTMLElement;
+
+    expect(getHighlightTextFromRange(selectElementContents(paragraph))).toBe(
+      "Before\n[Image: architecture diagram]\nafter",
+    );
+  });
+});

--- a/apps/web/components/dashboard/highlights/highlight-text.test.ts
+++ b/apps/web/components/dashboard/highlights/highlight-text.test.ts
@@ -57,6 +57,17 @@ describe("getHighlightTextFromRange", () => {
     );
   });
 
+  test("uses title attribute for image labels when alt is missing", () => {
+    document.body.innerHTML =
+      '<p>Before <img title="system overview" src="/diagram.png"> after</p>';
+
+    const paragraph = document.querySelector("p") as HTMLElement;
+
+    expect(getHighlightTextFromRange(selectElementContents(paragraph))).toBe(
+      "Before\n[Image: system overview]\nafter",
+    );
+  });
+
   test("uses a concise marker for selected images without labels", () => {
     document.body.innerHTML = '<p>Before <img src="/diagram.png"> after</p>';
 

--- a/packages/shared-react/components/BookmarkHtmlHighlighter.tsx
+++ b/packages/shared-react/components/BookmarkHtmlHighlighter.tsx
@@ -15,6 +15,7 @@ import {
 } from "@karakeep/shared/types/highlights";
 
 import { HIGHLIGHT_COLOR_MAP } from "./highlights";
+import { getHighlightTextFromRange } from "./highlight-text";
 import { Button } from "./ui/button";
 import { Popover, PopoverContent } from "./ui/popover";
 import { Textarea } from "./ui/textarea";
@@ -338,7 +339,7 @@ const BookmarkHTMLHighlighter = forwardRef<
       startOffset,
       endOffset,
       color,
-      text: range.toString(),
+      text: getHighlightTextFromRange(range),
     };
 
     applyHighlightByOffset(highlight);

--- a/packages/shared-react/components/highlight-text.ts
+++ b/packages/shared-react/components/highlight-text.ts
@@ -42,18 +42,30 @@ function appendLineBreak(parts: string[]) {
   }
 }
 
+function appendExplicitLineBreak(parts: string[]) {
+  parts.push("\n");
+}
+
 function getImageLabel(element: HTMLElement) {
   const label =
     element.getAttribute("alt")?.trim() ||
-    element.getAttribute("title")?.trim() ||
-    "Image";
+    element.getAttribute("title")?.trim();
 
-  return `[Image: ${label}]`;
+  return label ? `[Image: ${label}]` : "[Image]";
 }
 
 function visitHighlightNode(node: Node, parts: string[]) {
   if (node.nodeType === Node.TEXT_NODE) {
-    parts.push(node.textContent ?? "");
+    const text = node.textContent ?? "";
+    if (/^[\t\f\v \r\n\u00a0]*$/.test(text) && /\r|\n/.test(text)) {
+      const last = parts[parts.length - 1];
+      if (parts.length > 0 && last !== "\n" && !/\s$/.test(last ?? "")) {
+        parts.push(" ");
+      }
+      return;
+    }
+
+    parts.push(text);
     return;
   }
 
@@ -65,7 +77,7 @@ function visitHighlightNode(node: Node, parts: string[]) {
   const tagName = element.tagName;
 
   if (tagName === "BR") {
-    appendLineBreak(parts);
+    appendExplicitLineBreak(parts);
     return;
   }
 
@@ -77,10 +89,6 @@ function visitHighlightNode(node: Node, parts: string[]) {
   }
 
   const isBlock = BLOCK_TAGS.has(tagName);
-  if (isBlock && parts.length > 0) {
-    appendLineBreak(parts);
-  }
-
   for (const child of Array.from(element.childNodes)) {
     visitHighlightNode(child, parts);
   }
@@ -96,7 +104,7 @@ export function normalizeHighlightText(text: string) {
     .split("\n")
     .map((line) => line.replace(/[\t\f\v \u00a0]+/g, " ").trim())
     .join("\n")
-    .replace(/\n{2,}/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 

--- a/packages/shared-react/components/highlight-text.ts
+++ b/packages/shared-react/components/highlight-text.ts
@@ -1,0 +1,112 @@
+const BLOCK_TAGS = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "DD",
+  "DIV",
+  "DL",
+  "DT",
+  "FIGCAPTION",
+  "FIGURE",
+  "FOOTER",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "LI",
+  "MAIN",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "TBODY",
+  "TD",
+  "TFOOT",
+  "TH",
+  "THEAD",
+  "TR",
+  "UL",
+]);
+
+function appendLineBreak(parts: string[]) {
+  const last = parts[parts.length - 1];
+  if (last !== "\n") {
+    parts.push("\n");
+  }
+}
+
+function getImageLabel(element: HTMLElement) {
+  const label =
+    element.getAttribute("alt")?.trim() ||
+    element.getAttribute("title")?.trim() ||
+    "Image";
+
+  return `[Image: ${label}]`;
+}
+
+function visitHighlightNode(node: Node, parts: string[]) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    parts.push(node.textContent ?? "");
+    return;
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+
+  const element = node as HTMLElement;
+  const tagName = element.tagName;
+
+  if (tagName === "BR") {
+    appendLineBreak(parts);
+    return;
+  }
+
+  if (tagName === "IMG") {
+    appendLineBreak(parts);
+    parts.push(getImageLabel(element));
+    appendLineBreak(parts);
+    return;
+  }
+
+  const isBlock = BLOCK_TAGS.has(tagName);
+  if (isBlock && parts.length > 0) {
+    appendLineBreak(parts);
+  }
+
+  for (const child of Array.from(element.childNodes)) {
+    visitHighlightNode(child, parts);
+  }
+
+  if (isBlock) {
+    appendLineBreak(parts);
+  }
+}
+
+export function normalizeHighlightText(text: string) {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[\t\f\v \u00a0]+/g, " ").trim())
+    .join("\n")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+}
+
+export function getHighlightTextFromRange(range: Range) {
+  const fragment = range.cloneContents();
+  const parts: string[] = [];
+
+  for (const child of Array.from(fragment.childNodes)) {
+    visitHighlightNode(child, parts);
+  }
+
+  return normalizeHighlightText(parts.join(""));
+}


### PR DESCRIPTION
## Description

Preserves readable formatting when highlight text is created from a browser selection:

- extracts selected content with `getHighlightTextFromRange(range)` instead of `Range.toString()`
- preserves explicit line breaks, structural block breaks, and intentional blank lines
- emits readable image markers from `alt`/`title` metadata, or `[Image]` when an image has no label
- renders saved highlight text with preserved whitespace and long-word wrapping in highlight cards

This addresses the newline/image-text portions of #1485. It intentionally avoids the broader highlight-rendering rewrite that is already being discussed in #1457.

Partially addresses #1485.

## How Has This Been Tested?

- [x] `corepack pnpm --filter @karakeep/web test -- --run components/dashboard/highlights/highlight-text.test.ts`
- [x] `corepack pnpm --filter @karakeep/shared-react typecheck`
- [x] `corepack pnpm --filter @karakeep/web typecheck`
- [x] `corepack pnpm --filter @karakeep/shared-react lint`
- [x] `corepack pnpm --filter @karakeep/web lint`
- [x] `corepack pnpm exec oxfmt --check packages/shared-react/components/highlight-text.ts packages/shared-react/components/BookmarkHtmlHighlighter.tsx apps/web/components/dashboard/highlights/HighlightCard.tsx apps/web/components/dashboard/highlights/highlight-text.test.ts`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable; this change updates saved highlight text extraction/rendering behavior and is covered by the tests above.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help draft and iterate the implementation, tests, and review responses. I reviewed the changes and validated them with the checks listed above.
