### PR TITLE
feat(mobile): tablet/iPad UI polish for toolbar and FAB

### DIFF
--- a/apps/mobile/components/bookmarks/BottomActions.tsx
+++ b/apps/mobile/components/bookmarks/BottomActions.tsx
@@ -32,7 +32,7 @@ import {
 import { useWhoAmI } from "@karakeep/shared-react/hooks/users";
 import { BookmarkTypes, ZBookmark } from "@karakeep/shared/types/bookmarks";
 
-const MAX_TOOLBAR_CONTENT_WIDTH = 360;
+const TOOLBAR_ICON_GAP = 28;
 
 function triggerHaptic() {
   Haptics.selectionAsync().catch(() => {
@@ -301,12 +301,10 @@ function ToolbarContainer({
   const innerRow = (
     <View
       style={{
-        width: "100%",
-        maxWidth: MAX_TOOLBAR_CONTENT_WIDTH,
         alignSelf: "center",
         flexDirection: "row",
         alignItems: "center",
-        justifyContent: "space-between",
+        gap: TOOLBAR_ICON_GAP,
       }}
     >
       {children}

--- a/apps/mobile/components/bookmarks/BottomActions.tsx
+++ b/apps/mobile/components/bookmarks/BottomActions.tsx
@@ -32,6 +32,8 @@ import {
 import { useWhoAmI } from "@karakeep/shared-react/hooks/users";
 import { BookmarkTypes, ZBookmark } from "@karakeep/shared/types/bookmarks";
 
+const MAX_TOOLBAR_CONTENT_WIDTH = 360;
+
 function triggerHaptic() {
   Haptics.selectionAsync().catch(() => {
     // Ignore — haptics unavailable (e.g. simulator)
@@ -296,6 +298,21 @@ function ToolbarContainer({
   bottomMargin: number;
   bottomInset: number;
 }) {
+  const innerRow = (
+    <View
+      style={{
+        width: "100%",
+        maxWidth: MAX_TOOLBAR_CONTENT_WIDTH,
+        alignSelf: "center",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
+    >
+      {children}
+    </View>
+  );
+
   if (shouldUseGlassPill) {
     return (
       <GlassView
@@ -303,23 +320,18 @@ function ToolbarContainer({
         style={{
           borderRadius: 22,
           marginHorizontal: 16,
+          alignSelf: "center",
           marginBottom: bottomMargin,
           paddingVertical: 10,
           paddingHorizontal: 20,
-          flexDirection: "row",
-          alignItems: "center",
-          justifyContent: "space-between",
         }}
       >
-        {children}
+        {innerRow}
       </GlassView>
     );
   }
 
   const fallbackStyle = {
-    flexDirection: "row" as const,
-    alignItems: "center" as const,
-    justifyContent: "space-between" as const,
     paddingHorizontal: 40,
     paddingTop: 16,
     paddingBottom: bottomInset + 16,
@@ -328,14 +340,14 @@ function ToolbarContainer({
   if (Platform.OS === "ios") {
     return (
       <BlurView tint="systemMaterial" intensity={80} style={fallbackStyle}>
-        {children}
+        {innerRow}
       </BlurView>
     );
   }
 
   return (
     <View className="bg-background" style={fallbackStyle}>
-      {children}
+      {innerRow}
     </View>
   );
 }

--- a/apps/mobile/components/ui/FAB/FAB.ios.tsx
+++ b/apps/mobile/components/ui/FAB/FAB.ios.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BlurView } from "expo-blur";
 import { GlassView, isGlassEffectAPIAvailable } from "expo-glass-effect";
-import { isIOS26 } from "@/lib/ios";
+import { isIOS26, isIPad } from "@/lib/ios";
 
 const shouldUseGlass = isIOS26 && isGlassEffectAPIAvailable();
 const SIZE = 62;
@@ -16,7 +16,7 @@ export function FAB({ children }: { children: ReactNode }) {
       style={[
         styles.container,
         {
-          bottom: insets.bottom + (isIOS26 ? 57 : 60),
+          bottom: insets.bottom + (isIPad ? 0 : isIOS26 ? 57 : 60),
           right: isIOS26 ? 21 : 16,
         },
       ]}

--- a/apps/mobile/lib/ios.ts
+++ b/apps/mobile/lib/ios.ts
@@ -4,4 +4,6 @@ import { isGlassEffectAPIAvailable } from "expo-glass-effect";
 export const isIOS26 =
   Platform.OS === "ios" && parseInt(Platform.Version as string, 10) >= 26;
 
+export const isIPad = Platform.OS === "ios" && Platform.isPad;
+
 export const shouldUseGlassPill = isIOS26 && isGlassEffectAPIAvailable();


### PR DESCRIPTION
## Description

Two small visual polish changes for the tablet/iPad experience:

1. **Reader toolbar spacing on tablets** — The bottom action toolbar's icon row (`BottomActions.tsx`) now uses an intrinsic 28pt `gap` between icons and `alignSelf: center`, instead of stretching edge-to-edge across the viewport with `justify-content: space-between`. On iOS ≥ 26 the `GlassView` pill hugs its contents and floats centered; on older iOS / Android the translucent background still spans full-width but the inner icon row is centered with comfortable spacing. On phones this is visually close to the previous look; on iPad the toolbar no longer looks stretched.

2. **Remove FAB bottom inset on iPad** — The iOS FAB was inset from the bottom so it would float above the tab bar, but the native tab bar is on the top in iPadOS (not just in iPadOS 26). This removes that inset on iPads so it aligns with the bottom.

No linked issue.

## How Has This Been Tested?

- [x] Manually verified on iPad simulator (iPadOS 26) — toolbar hugs its contents with comfortable icon spacing, FAB sits flush above the safe area.
- [x] Manually verified on iPhone simulator — no visible change to toolbar or FAB position.
- [ ] No automated tests added; both changes are layout-only and there is no existing test coverage for these components.

<details><summary><h2>Screenshots</h2></summary>

<!-- Add before/after iPad screenshots here before submitting. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (N/A — no user-facing docs for these components)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (No new dependencies.)
- [ ] I have written tests for new code (if applicable) — N/A, layout-only changes.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The code changes were written by me. An LLM (Claude Code) was used to draft this PR description and review the diff for consistency.