### PR TITLE
fix(mobile): fix insets on new iOS settings formSheet modal

### DIFF
--- a/apps/mobile/app/dashboard/settings/index.tsx
+++ b/apps/mobile/app/dashboard/settings/index.tsx
@@ -12,6 +12,7 @@ import {
 import Slider from "@react-native-community/slider";
 import Constants from "expo-constants";
 import { Link } from "expo-router";
+import { useHeaderHeight } from "@react-navigation/elements";
 import { UserProfileHeader } from "@/components/settings/UserProfileHeader";
 import ChevronRight from "@/components/ui/ChevronRight";
 import { Divider } from "@/components/ui/Divider";
@@ -33,6 +34,7 @@ function SectionHeader({ title }: { title: string }) {
 
 export default function Settings() {
   const { logout } = useSession();
+  const headerHeight = useHeaderHeight();
   const {
     settings,
     setSettings,
@@ -107,7 +109,10 @@ export default function Settings() {
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 40 }}
+      contentContainerStyle={{
+        paddingHorizontal: 16,
+        paddingBottom: 40 + headerHeight,
+      }}
     >
       <UserProfileHeader
         image={data?.image}


### PR DESCRIPTION
## Summary

The settings screen is presented as an iOS `formSheet` with an opaque, non-large header (changed in 649efb87). On iOS, the formSheet's inner content view is sized ~`headerHeight` pixels taller than the visible sheet area, so the bottom of the settings list was clipped behind the sheet's bottom edge.

`contentInsetAdjustmentBehavior="automatic"` correctly handles the **top** (it adds the right top inset to clear the opaque header), but it does not add a corresponding **bottom** inset for the formSheet's invisible bottom region. Adding `useHeaderHeight()` to `paddingBottom` pushes the trailing content up to a visible position.

## Test plan

- [x] iOS simulator: open Settings — profile header sits flush below the native header (no extra top gap)
- [x] iOS simulator: scroll to bottom — Server Version row (and the rounded card around it) is fully visible above the sheet's bottom edge with breathing room
- [ ] iOS simulator: tap into Theme / Reader Settings / Toolbar Buttons — large transparent title still has correct inset (those screens were not changed; sanity check for no regression)
- [ ] Android: settings modal still renders correctly (no Android code path was changed; `useHeaderHeight()` is cross-platform)