### PR TITLE
fix(mobile): remove double safe-area inset on reader toolbar

### DIFF
--- a/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/[slug]/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { KeyboardAvoidingView, Pressable, View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useKeepAwake } from "expo-keep-awake";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import BookmarkAssetView from "@/components/bookmarks/BookmarkAssetView";
@@ -27,7 +26,6 @@ function KeepScreenOn() {
 }
 
 export default function BookmarkView() {
-  const insets = useSafeAreaInsets();
   const router = useRouter();
   const { slug } = useLocalSearchParams();
   const { colorScheme } = useColorScheme();
@@ -87,13 +85,9 @@ export default function BookmarkView() {
   }
   return (
     <KeyboardAvoidingView
-      // On iOS 26 the toolbar is absolute-positioned so its GlassView has
-      // content behind it; its own bottomMargin handles the safe-area inset,
-      // so padding here would leave a visible gap below the glass pill.
-      style={{
-        flex: 1,
-        paddingBottom: shouldUseGlassPill ? 0 : insets.bottom + 8,
-      }}
+      // ToolbarContainer owns the safe-area inset in all paths (glass pill via
+      // bottomMargin, fallback via paddingBottom). Don't add it again here.
+      style={{ flex: 1 }}
       behavior="height"
     >
       {settings.keepScreenOnWhileReading && <KeepScreenOn />}

--- a/apps/mobile/components/bookmarks/BookmarkTextView.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkTextView.tsx
@@ -4,7 +4,9 @@ import BookmarkTextMarkdown from "@/components/bookmarks/BookmarkTextMarkdown";
 import { Button } from "@/components/ui/Button";
 import { Text } from "@/components/ui/Text";
 import { useToast } from "@/components/ui/Toast";
+import { shouldUseGlassPill } from "@/lib/ios";
 import { useColorScheme } from "nativewind";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useUpdateBookmark } from "@karakeep/shared-react/hooks/bookmarks";
 import { BookmarkTypes, ZBookmark } from "@karakeep/shared/types/bookmarks";
@@ -19,6 +21,7 @@ export default function BookmarkTextView({ bookmark }: BookmarkTextViewProps) {
   }
   const { toast } = useToast();
   const { colorScheme } = useColorScheme();
+  const insets = useSafeAreaInsets();
 
   const [isEditing, setIsEditing] = useState(false);
   const initialText = bookmark.content.text;
@@ -55,7 +58,10 @@ export default function BookmarkTextView({ bookmark }: BookmarkTextViewProps) {
 
   if (isEditing) {
     return (
-      <View className="flex-1 p-4">
+      <View
+        className="flex-1 px-4 pt-4"
+        style={{ paddingBottom: shouldUseGlassPill ? 0 : insets.bottom + 8 }}
+      >
         <View className="flex-row justify-end gap-2 px-4 py-2">
           <Button
             size="sm"


### PR DESCRIPTION
Fixes #2802

## Description

`ToolbarContainer` (introduced in #2527) owns the bottom safe-area inset in all code paths — via `bottomMargin` for the iOS 26 glass pill, and via `paddingBottom: insets.bottom + 16` for the `BlurView`/`View` fallback. The outer `KeyboardAvoidingView` in `BookmarkView` was left with its original `paddingBottom: insets.bottom + 8` from before the toolbar redesign, double-counting the safe-area inset.

The fix removes the redundant `insets.bottom` from the outer container and drops the now-unused `useSafeAreaInsets` call. `ToolbarContainer` already handles the safe-area correctly in all cases. However, after this change the bottom border of the text edit view got truncated. To prevent this `paddingBottom: insets.bottom + 8` was added to that specific view (Android only).

## How Has This Been Tested?

- [x] Tested on Android (gesture navigation) — before/after screenshots below
- [ ] iOS pre-26 (same code path; fix applies but untested by me)

<details><summary><h2>Screenshots</h2></summary>

| Before (broken) | After (fixed) |
|:-:|:-:|
| <img width="400" alt="Toolbar correct height after fix" src="https://github.com/user-attachments/assets/a889f902-38c8-44fb-880b-65004434a1d6" /> | <img width="400" alt="Toolbar double-height before fix" src="https://github.com/user-attachments/assets/c52b2f50-ff9d-4f79-a9b9-ce6b7142e032" /> |

This also changes the spacing though if keyboard is expanded. I'm not sure what's the optimal behavior here, but now it's closer to the keyboard:

Before | After |
|:-:|:-:|
| <img width="400" src="https://github.com/user-attachments/assets/68c5359d-1a3a-4cf3-a414-7d515e881631" /> | <img width="400" src="https://github.com/user-attachments/assets/a18f5129-01de-4614-a666-075b92ed65cf" /> |

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

For daaee53dc4c4d7a4aa6303495e647f3a1db6e60c Claude (Sonnet 4.6 via Claude Code) identified the root cause by tracing the commit history of the two affected files and was used to author the code change. The bug was discovered and verified by the contributor on a physical Android device.

For 00c8f3b10af75bdb77abcc82d9a8066a85444904 I used GPT 5.5 for rubberducking and wrote the fix myself.