### PR TITLE
fix(web): render PDFs via <embed> so Safari can display them

### DIFF
--- a/apps/web/components/dashboard/preview/AssetContentSection.tsx
+++ b/apps/web/components/dashboard/preview/AssetContentSection.tsx
@@ -56,8 +56,9 @@ function PDFContentSection({ bookmark }: { bookmark: ZBookmark }) {
         />
       </div>
     ) : (
-      <iframe
+      <embed
         title={bookmark.content.assetId}
+        type="application/pdf"
         className="h-full w-full"
         src={getAssetUrl(bookmark.content.assetId)}
       />


### PR DESCRIPTION
## Summary

PDF previews stay blank in Safari (desktop and iOS); fine in Chrome / Firefox. Root cause is Safari's rendering of PDFs inside `<iframe src=...>`. Swapping the iframe for `<embed type="application/pdf" src=...>` fixes Safari without changing anything for the other browsers.

## Reproduction (current `main`)

1. Upload a PDF bookmark to a Karakeep instance.
2. Open the bookmark in Safari 17 (macOS or iOS).
3. The preview pane stays blank.
4. Right-click the empty pane → "Open frame in new tab" → the same asset URL renders fine as a top-level tab.

## Root cause

`apps/web/components/dashboard/preview/AssetContentSection.tsx::PDFContentSection` renders the PDF via:

```tsx
<iframe title={...} className="h-full w-full" src={getAssetUrl(...)} />
```

When the iframe `src` resolves to a `Content-Type: application/pdf` response, Safari synthesises a wrapper document around it:

```html
<html>
  <head><style>...</style></head>
  <body>
    <embed name="plugin" src="<asset-url>" type="application/pdf">
  </body>
</html>
```

That synthesised embed fails to render the PDF plugin viewer inside the surrounding iframe context — known long-standing WebKit behaviour. Chrome's pdfium-based viewer follows a different code path and is unaffected, which is why this never showed up against Chromium.

This is **not** a CSP problem. I initially suspected the bare `sandbox` directive emitted by `serveAsset` (`packages/api/utils/assets.ts`) and tested by temporarily dropping `sandbox` from the asset response header on a running instance — Safari still showed a blank pane. The wrapper-inside-iframe issue happens upstream of the CSP enforcement.

## Fix

Two-line change in `AssetContentSection.tsx`: swap `<iframe>` for `<embed type="application/pdf">`. Same `src`, same class, same title attribute — the browser renders the PDF directly without Safari's synthesised wrapper.

```diff
-      <iframe
+      <embed
         title={bookmark.content.assetId}
+        type="application/pdf"
         className="h-full w-full"
         src={getAssetUrl(bookmark.content.assetId)}
       />
```

`<embed>` is a void element so the closing `</iframe>` is dropped; everything else is preserved.

## Verification

Tested against a self-hosted instance on `release`:

- **Safari 17 / macOS:** PDF now renders inline in the preview pane; switching between "Screenshot" and "PDF" in the existing selector still works; PDF loads at the same speed as the existing "Open frame in new tab" workaround.
- **Chrome 121 / macOS:** unchanged — still renders as before, no visible difference.

Verified the markup swap in Safari Web Inspector first (live-edited a single bookmark page) before forking and authoring the patch, so this is an empirically-validated fix rather than a speculative one.

## Notes

- No CSP changes — the existing `serveAsset` hardening is preserved unchanged.
- No new dependencies.
- Touches one file, two lines net.
- Does not affect the image / screenshot rendering paths, which already use `<Image>` from `next/image`.