### PR TITLE
fix(mobile): bookmark card taps after scrolling

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkCard.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkCard.tsx
@@ -3,10 +3,12 @@ import {
   Alert,
   Linking,
   Platform,
-  Pressable,
   ScrollView,
   View,
 } from "react-native";
+// RNGH Pressable coordinates with the FlatList's native scroll gesture, so taps
+// right after a scroll aren't eaten by the scroll-stop on iOS/Android.
+import { Pressable } from "react-native-gesture-handler";
 import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";
 import { router, useRouter } from "expo-router";

--- a/apps/mobile/components/bookmarks/BookmarkCard.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkCard.tsx
@@ -6,8 +6,6 @@ import {
   ScrollView,
   View,
 } from "react-native";
-// RNGH Pressable coordinates with the FlatList's native scroll gesture, so taps
-// right after a scroll aren't eaten by the scroll-stop on iOS/Android.
 import { Pressable } from "react-native-gesture-handler";
 import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";

--- a/apps/mobile/components/bookmarks/BookmarkList.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkList.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { ActivityIndicator, Keyboard, View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
 import Animated, { LinearTransition } from "react-native-reanimated";
 import EmptyState from "@/components/ui/EmptyState";
 import { useScrollToTop } from "@react-navigation/native";
@@ -31,6 +32,7 @@ export default function BookmarkList({
     <Animated.FlatList
       ref={flatListRef}
       itemLayoutAnimation={LinearTransition}
+      renderScrollComponent={(props) => <ScrollView {...props} />}
       contentInsetAdjustmentBehavior="automatic"
       ListHeaderComponent={header}
       contentContainerStyle={{


### PR DESCRIPTION
Fixes #2808

## Description

Tapping a `BookmarkCard` immediately after a fling-scroll often does nothing on Android: while the `FlatList` is decelerating, the native `ScrollView` consumes the first touch to stop the scroll, and `Pressable` (which resolves touches via the JS-side responder system) never sees `onPress`.

The fix puts the card's press recognizer and the list's scroll recognizer into the same native gesture tree so they can arbitrate against each other:

- `BookmarkCard` uses `Pressable` from `react-native-gesture-handler` instead of `react-native`.
- `BookmarkList` passes RNGH's `ScrollView` via `renderScrollComponent`, so the underlying scrollable view is RNGH-managed.

The native gesture arbitration then decides: if the finger pans past the scroll threshold, the press is cancelled and the list scrolls; if the finger stays put, the press wins on lift-off. Both ends must be RNGH — using only the RNGH `Pressable` while the parent stays an RN scroll leaves the two recognizers in separate systems, which causes drags from a card to both scroll and fire a press.

`Animated.FlatList` is preserved so `itemLayoutAnimation` (the gap-fill transition on delete/archive) still animates. `GestureHandlerRootView` is already mounted in `app/_layout.tsx`, so no setup is needed.

### Scope

`BookmarkCard` is the only place in the app using RNGH `Pressable`; every other list (`HighlightList`, `BookmarkSearchResults`, the tabs, settings ScrollViews, etc.) renders children that use RN `Pressable`. Those lists are internally consistent (RN/RN), so they don't have the "scroll triggers a tap" symptom. They may still have the original tap-after-fling issue on Android, but addressing that is a broader migration and is out of scope here.

## How Has This Been Tested?

- [x] Tested on Android (Pixel 6a) — bug reproduces consistently before, fixed after; no false-positive taps when starting a scroll from a card
- [ ] iOS not tested by me, but the same gesture-tree mechanism applies and the RNGH path should resolve it identically

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary (`react-native-gesture-handler` is already a direct dependency).
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (Opus 4.7 via Claude Code) helped diagnose the root cause and author the change. The bug was discovered and the fix verified on a physical Android device by the contributor.