### PR TITLE
fix(mobile): use optimistic UI for toolbar favourite button

### DIFF
--- a/apps/mobile/components/bookmarks/BottomActions.tsx
+++ b/apps/mobile/components/bookmarks/BottomActions.tsx
@@ -130,7 +130,7 @@ function useToolbarActions(bookmark: ZBookmark) {
       },
     });
 
-  const { mutate: favouriteBookmark, isPending: isFavouritePending } =
+  const { mutate: favouriteBookmark, variables: favouriteVariables } =
     useUpdateBookmark({
       onError: () => {
         toast({
@@ -218,7 +218,9 @@ function useToolbarActions(bookmark: ZBookmark) {
     },
     favourite: {
       id: "favourite",
-      icon: bookmark.favourited
+      icon: (
+        favouriteVariables ? favouriteVariables.favourited : bookmark.favourited
+      )
         ? makeIcon(Star, "#ebb434", "#ebb434")
         : makeIcon(Star),
       shouldRender: isOwner,
@@ -226,10 +228,12 @@ function useToolbarActions(bookmark: ZBookmark) {
         triggerHaptic();
         favouriteBookmark({
           bookmarkId: bookmark.id,
-          favourited: !bookmark.favourited,
+          favourited: !(favouriteVariables
+            ? favouriteVariables.favourited
+            : bookmark.favourited),
         });
       },
-      disabled: isFavouritePending,
+      disabled: false,
     },
     archive: {
       id: "archive",


### PR DESCRIPTION
Fixes #2810

## Description

The favourite toolbar button in `BottomActions.tsx` rendered its icon from `bookmark.favourited` directly and set `disabled: isFavouritePending`. As a result, tapping the star showed no visible change until the mutation response came back, and rapid taps were silently dropped while the button was disabled.

Mirror the pattern already used by `BookmarkCard`'s `ActionBar`:
- Pull `variables` out of `useUpdateBookmark` and prefer `variables.favourited` over `bookmark.favourited` when present, so the icon reflects the in-flight value immediately.
- Drop `disabled: isFavouritePending` so subsequent taps register and toggle.

The mutation's `onError` toast still surfaces failures, so the optimistic flip remains safe.

## How Has This Been Tested?

- [x] Tested on Android (Pixel 6a) — star now flips on tap; rapid double-tap toggles cleanly

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (Opus 4.7 via Claude Code) identified the discrepancy with `BookmarkCard`'s `ActionBar` and authored the change. The bug was discovered and verified on a physical Android device by the contributor.