### PR TITLE
fix(mobile): enlarge toolbar hit targets with hitSlop

### DIFF
--- a/apps/mobile/components/bookmarks/BottomActions.tsx
+++ b/apps/mobile/components/bookmarks/BottomActions.tsx
@@ -33,6 +33,7 @@ import { useWhoAmI } from "@karakeep/shared-react/hooks/users";
 import { BookmarkTypes, ZBookmark } from "@karakeep/shared/types/bookmarks";
 
 const TOOLBAR_ICON_GAP = 28;
+const TOOLBAR_HIT_SLOP = { top: 13, bottom: 13, left: 13, right: 13 };
 
 function triggerHaptic() {
   Haptics.selectionAsync().catch(() => {
@@ -428,6 +429,7 @@ export default function BottomActions({ bookmark }: BottomActionsProps) {
                 disabled={a.disabled}
                 key={a.id}
                 onPress={a.onClick}
+                hitSlop={TOOLBAR_HIT_SLOP}
                 className="py-auto"
               >
                 {a.icon}
@@ -442,7 +444,7 @@ export default function BottomActions({ bookmark }: BottomActionsProps) {
           actions={menuActionsWithEdit}
           shouldOpenOnLongPress={false}
         >
-          <Pressable onPress={() => triggerHaptic()}>
+          <Pressable hitSlop={TOOLBAR_HIT_SLOP} onPress={() => triggerHaptic()}>
             <TailwindResolver
               className="text-foreground"
               comp={(styles) => (


### PR DESCRIPTION
Fixes #2812

## Description

The `Pressable`s wrapping the 22pt toolbar icons in `BottomActions.tsx` had no `hitSlop`, leaving the touch-responsive area at 22×22pt — below Apple HIG's 44×44 and Material's 48×48 recommended minimums. Taps near an icon's edge were silently missed.

Add a shared `TOOLBAR_HIT_SLOP = { top: 13, bottom: 13, left: 13, right: 13 }` and apply it to the action `Pressable` and the overflow ellipsis `Pressable`. The icons still render at 22pt; only the hit-test area grows to **48×48pt**, meeting both platforms' guidelines.

Horizontal spacing check: `TOOLBAR_ICON_GAP = 28`, so between two adjacent icons there's 28 − 13 − 13 = 2pt of clearance between hit zones — no overlap, no ambiguity in touch routing.

## How Has This Been Tested?

- [x] Tested on Android (Pixel 6a) — taps near icon edges now register; no overlap between adjacent buttons

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (Opus 4.7 via Claude Code) identified the missing `hitSlop` as a likely cause of the perceived unresponsiveness, did the spacing-overlap math, and authored the change. The bug was discovered and verified on a physical Android device by the contributor.