### PR TITLE
feat: add agentic search content and bookmark slicing

### DIFF
--- a/apps/cli/src/commands/bookmarks.ts
+++ b/apps/cli/src/commands/bookmarks.ts
@@ -12,7 +12,11 @@ import { getAPIClient } from "@/lib/trpc";
 import { Command } from "@commander-js/extra-typings";
 import chalk from "chalk";
 
-import type { ZBookmark } from "@karakeep/shared/types/bookmarks";
+import type {
+  ZBookmark,
+  ZGetBookmarkContentResponse,
+  ZSearchBookmark,
+} from "@karakeep/shared/types/bookmarks";
 import {
   BookmarkTypes,
   MAX_NUM_BOOKMARKS_PER_PAGE,
@@ -140,6 +144,40 @@ function printBookmarkCard(b: ZBookmark) {
   if (b.favourited) console.log(`  Favourited: yes`);
   if (b.note) console.log(`  Note: ${b.note}`);
   console.log();
+}
+
+function printSearchBookmarkCard(b: ZSearchBookmark) {
+  printBookmarkCard(b);
+
+  if (b.matchedContent) {
+    console.log(
+      chalk.dim(
+        `  Matched content [${b.matchedContent.startOffset}-${b.matchedContent.endOffset}] (match ${b.matchedContent.matchStartOffset}-${b.matchedContent.matchEndOffset}):`,
+      ),
+    );
+    console.log(`  ${b.matchedContent.text}`);
+    console.log();
+  }
+}
+
+function printBookmarkContentSlice(content: ZGetBookmarkContentResponse) {
+  if (getGlobalOptions().json) {
+    printObject(content);
+    return;
+  }
+
+  console.log(
+    chalk.dim(
+      `Offsets: ${content.startOffset}-${content.endOffset} / ${content.totalLength}`,
+    ),
+  );
+  console.log(
+    chalk.dim(
+      `Has more before: ${content.hasMoreBefore ? "yes" : "no"} | Has more after: ${content.hasMoreAfter ? "yes" : "no"}`,
+    ),
+  );
+  console.log();
+  console.log(content.text);
 }
 
 bookmarkCmd
@@ -308,6 +346,38 @@ bookmarkCmd
       .query({ bookmarkId: id, includeContent: opts.includeContent })
       .then(printBookmarkDetail)
       .catch(printError(`Failed to get the bookmark with id "${id}"`));
+  });
+
+bookmarkCmd
+  .command("get-content")
+  .description("fetch a plain-text slice of bookmark content")
+  .argument("<id>", "The id of the bookmark to get content for")
+  .option(
+    "--start-offset <offset>",
+    "zero-based character offset from which to start reading",
+    (val) => parseInt(val, 10),
+    0,
+  )
+  .option(
+    "--max-length <length>",
+    "maximum number of characters to return",
+    (val) => parseInt(val, 10),
+    4000,
+  )
+  .action(async (id, opts) => {
+    const api = getAPIClient();
+    await api.bookmarks.getBookmarkContent
+      .query({
+        bookmarkId: id,
+        startOffset: opts.startOffset,
+        maxLength: opts.maxLength,
+      })
+      .then(printBookmarkContentSlice)
+      .catch(
+        printError(
+          `Failed to get bookmark content for bookmark with id "${id}"`,
+        ),
+      );
   });
 
 function printTagMessage(
@@ -505,6 +575,16 @@ bookmarkCmd
     "include full bookmark content in results",
     false,
   )
+  .option(
+    "--include-matched-content",
+    "include matched content excerpts and offsets in results",
+    false,
+  )
+  .option(
+    "--matched-content-length <length>",
+    "maximum length of the matched content excerpt",
+    (val) => parseInt(val, 10),
+  )
   .option("--all", "fetch all results (paginate through all pages)", false)
   .option("--cursor <cursor>", "cursor from a previous request for pagination")
   .action(async (query, opts) => {
@@ -515,6 +595,8 @@ bookmarkCmd
       limit: opts.limit,
       sortOrder: opts.sortOrder as "relevance" | "asc" | "desc",
       includeContent: opts.includeContent,
+      includeMatchedContent: opts.includeMatchedContent,
+      matchedContentLength: opts.matchedContentLength,
       cursor: opts.cursor
         ? JSON.parse(Buffer.from(opts.cursor, "base64").toString(), (k, v) =>
             k === "createdAt" ? new Date(v) : v,
@@ -524,7 +606,7 @@ bookmarkCmd
 
     try {
       let resp = await api.bookmarks.searchBookmarks.query(request);
-      let results: ZBookmark[] = resp.bookmarks;
+      let results: ZSearchBookmark[] = resp.bookmarks;
 
       if (opts.all) {
         while (resp.nextCursor) {
@@ -543,11 +625,17 @@ bookmarkCmd
 
       if (getGlobalOptions().json) {
         printObject(
-          { bookmarks: results.map(normalizeBookmark), nextCursor },
+          {
+            bookmarks: results.map((bookmark) => ({
+              ...normalizeBookmark(bookmark),
+              matchedContent: bookmark.matchedContent ?? null,
+            })),
+            nextCursor,
+          },
           { maxArrayLength: null },
         );
       } else {
-        results.forEach(printBookmarkCard);
+        results.forEach(printSearchBookmarkCard);
         if (nextCursor) {
           console.log(`Next cursor: ${chalk.dim(nextCursor)}`);
         }

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -5,7 +5,8 @@ with Karakeep from other tools.
 
 ## Supported Tools
 
-- Searching bookmarks
+- Searching bookmarks, including optional matched content excerpts for agentic workflows
+- Fetching bookmark content, including optional partial plain-text slices by offset
 - Adding and removing bookmarks from lists
 - Attaching and detaching tags to bookmarks
 - Creating new lists

--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -2,7 +2,12 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 
 import { karakeepClient, mcpServer, turndownService } from "./shared";
-import { compactBookmark, toMcpToolError } from "./utils";
+import {
+  compactBookmark,
+  compactBookmarkContentSlice,
+  compactSearchBookmark,
+  toMcpToolError,
+} from "./utils";
 
 // Tools
 mcpServer.tool(
@@ -40,14 +45,36 @@ machine learning is:fav`),
       .describe(
         `The next cursor to use for pagination. The value for this is returned from a previous call to this tool.`,
       ),
+    includeMatchedContent: z
+      .boolean()
+      .optional()
+      .describe(
+        `If true, include matched content excerpts and offsets from the bookmark's extracted plain-text content.`,
+      )
+      .default(false),
+    matchedContentLength: z
+      .number()
+      .int()
+      .positive()
+      .max(4000)
+      .optional()
+      .describe(`Maximum length of the matched content excerpt to return.`),
   },
-  async ({ query, limit, nextCursor }): Promise<CallToolResult> => {
+  async ({
+    query,
+    limit,
+    nextCursor,
+    includeMatchedContent,
+    matchedContentLength,
+  }): Promise<CallToolResult> => {
     const res = await karakeepClient.GET("/bookmarks/search", {
       params: {
         query: {
           q: query,
           limit: limit,
           includeContent: false,
+          includeMatchedContent,
+          matchedContentLength,
           cursor: nextCursor,
         },
       },
@@ -60,7 +87,7 @@ machine learning is:fav`),
         {
           type: "text",
           text: `
-${res.data.bookmarks.map(compactBookmark).join("\n\n")}
+${res.data.bookmarks.map(compactSearchBookmark).join("\n\n")}
 
 Next cursor: ${res.data.nextCursor ? `'${res.data.nextCursor}'` : "no more pages"}
 `,
@@ -226,11 +253,56 @@ mcpServer.tool(
 
 mcpServer.tool(
   "get-bookmark-content",
-  `Get the content of the bookmark in markdown`,
+  `Get bookmark content. By default this returns the full content in markdown where possible. You can also request a plain-text slice using offsets for agentic retrieval workflows.`,
   {
     bookmarkId: z.string().describe(`The bookmarkId to get content for.`),
+    startOffset: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        `Optional zero-based character offset for partial content retrieval.`,
+      ),
+    maxLength: z
+      .number()
+      .int()
+      .positive()
+      .max(100000)
+      .optional()
+      .describe(
+        `Optional maximum number of characters to return when using partial retrieval.`,
+      ),
   },
-  async ({ bookmarkId }): Promise<CallToolResult> => {
+  async ({ bookmarkId, startOffset, maxLength }): Promise<CallToolResult> => {
+    if (startOffset !== undefined || maxLength !== undefined) {
+      const sliceRes = await karakeepClient.GET(
+        `/bookmarks/{bookmarkId}/content`,
+        {
+          params: {
+            path: {
+              bookmarkId,
+            },
+            query: {
+              startOffset,
+              maxLength,
+            },
+          },
+        },
+      );
+      if (!sliceRes.data) {
+        return toMcpToolError(sliceRes.error);
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text: compactBookmarkContentSlice(sliceRes.data),
+          },
+        ],
+      };
+    }
+
     const res = await karakeepClient.GET(`/bookmarks/{bookmarkId}`, {
       params: {
         path: {
@@ -247,7 +319,7 @@ mcpServer.tool(
     let content;
     if (res.data.content.type === "link") {
       const htmlContent = res.data.content.htmlContent;
-      content = turndownService.turndown(htmlContent);
+      content = htmlContent ? turndownService.turndown(htmlContent) : "";
     } else if (res.data.content.type === "text") {
       content = res.data.content.text;
     } else if (res.data.content.type === "asset") {

--- a/apps/mcp/src/utils.ts
+++ b/apps/mcp/src/utils.ts
@@ -55,3 +55,27 @@ Source URL: ${bookmark.content.sourceUrl ?? ""}`;
   ${content}
   Tags: ${bookmark.tags.map((t) => t.name).join(", ")}`;
 }
+
+export function compactSearchBookmark(
+  bookmark: KarakeepAPISchemas["SearchBookmark"],
+): string {
+  const base = compactBookmark(bookmark);
+  if (!bookmark.matchedContent) {
+    return base;
+  }
+
+  return `${base}
+  Matched content offsets: ${bookmark.matchedContent.startOffset}-${bookmark.matchedContent.endOffset}
+  Match offsets: ${bookmark.matchedContent.matchStartOffset}-${bookmark.matchedContent.matchEndOffset}
+  Matched content: ${bookmark.matchedContent.text}`;
+}
+
+export function compactBookmarkContentSlice(
+  content: KarakeepAPISchemas["BookmarkContentSlice"],
+): string {
+  return `Offsets: ${content.startOffset}-${content.endOffset} / ${content.totalLength}
+Has more before: ${content.hasMoreBefore ? "yes" : "no"}
+Has more after: ${content.hasMoreAfter ? "yes" : "no"}
+
+${content.text}`;
+}

--- a/packages/api/routes/bookmarks.ts
+++ b/packages/api/routes/bookmarks.ts
@@ -14,6 +14,7 @@ import { apiKeyScopeMiddleware } from "../middlewares/apiKeyScopes";
 import { authMiddleware } from "../middlewares/auth";
 import { adaptPagination, zPagination } from "../utils/pagination";
 import {
+  zGetBookmarkContentSearchParamsSchema,
   zGetBookmarkQueryParamsSchema,
   zGetBookmarkSearchParamsSchema,
   zIncludeContentSearchParamsSchema,
@@ -78,7 +79,10 @@ const app = new Hono()
         text: searchParams.q,
         cursor: searchParams.cursor,
         limit: searchParams.limit,
+        sortOrder: searchParams.sortOrder,
         includeContent: searchParams.includeContent,
+        includeMatchedContent: searchParams.includeMatchedContent,
+        matchedContentLength: searchParams.matchedContentLength,
       });
       return c.json(
         {
@@ -214,6 +218,22 @@ const app = new Hono()
         includeContent: searchParams.includeContent,
       });
       return c.json(bookmark, 200);
+    },
+  )
+
+  // GET /bookmarks/[bookmarkId]/content
+  .get(
+    "/:bookmarkId/content",
+    zValidator("query", zGetBookmarkContentSearchParamsSchema),
+    async (c) => {
+      const bookmarkId = c.req.param("bookmarkId");
+      const searchParams = c.req.valid("query");
+      const content = await c.var.api.bookmarks.getBookmarkContent({
+        bookmarkId,
+        startOffset: searchParams.startOffset,
+        maxLength: searchParams.maxLength,
+      });
+      return c.json(content, 200);
     },
   )
 

--- a/packages/api/utils/types.ts
+++ b/packages/api/utils/types.ts
@@ -23,5 +23,23 @@ export const zGetBookmarkQueryParamsSchema = z
 export const zGetBookmarkSearchParamsSchema = z
   .object({
     sortOrder: zSortOrder.optional().default(zSortOrder.enum.relevance),
+    includeMatchedContent: zStringBool.optional().prefault("false"),
+    matchedContentLength: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(4000)
+      .optional(),
   })
   .extend(zIncludeContentSearchParamsSchema.shape);
+
+export const zGetBookmarkContentSearchParamsSchema = z.object({
+  startOffset: z.coerce.number().int().nonnegative().optional().default(0),
+  maxLength: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(100_000)
+    .optional()
+    .default(4000),
+});

--- a/packages/open-api/karakeep-openapi-spec.json
+++ b/packages/open-api/karakeep-openapi-spec.json
@@ -451,6 +451,387 @@
         "type": "string",
         "description": "Cursor from a previous response to fetch the next page."
       },
+      "SearchResults": {
+        "type": "object",
+        "properties": {
+          "bookmarks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchBookmark"
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "nullable": true,
+            "description": "Cursor for the next page, or null if no more results."
+          }
+        },
+        "required": [
+          "bookmarks",
+          "nextCursor"
+        ]
+      },
+      "SearchBookmark": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "archived": {
+            "type": "boolean"
+          },
+          "favourited": {
+            "type": "boolean"
+          },
+          "taggingStatus": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "success",
+              "failure",
+              "pending",
+              null
+            ]
+          },
+          "summarizationStatus": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "success",
+              "failure",
+              "pending",
+              null
+            ]
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "api",
+              "web",
+              "cli",
+              "mobile",
+              "extension",
+              "singlefile",
+              "rss",
+              "import",
+              null
+            ]
+          },
+          "userId": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "attachedBy": {
+                  "type": "string",
+                  "enum": [
+                    "ai",
+                    "human"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "attachedBy"
+              ]
+            }
+          },
+          "content": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "link"
+                    ]
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "description": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "imageUrl": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "imageAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "screenshotAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "pdfAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "fullPageArchiveAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "precrawledArchiveAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "videoAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "favicon": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "htmlContent": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "contentAssetId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "crawledAt": {
+                    "type": "string",
+                    "nullable": true,
+                    "format": "date-time"
+                  },
+                  "crawlStatus": {
+                    "type": "string",
+                    "nullable": true,
+                    "enum": [
+                      "success",
+                      "failure",
+                      "pending",
+                      null
+                    ]
+                  },
+                  "author": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "publisher": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "datePublished": {
+                    "type": "string",
+                    "nullable": true,
+                    "format": "date-time"
+                  },
+                  "dateModified": {
+                    "type": "string",
+                    "nullable": true,
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "type",
+                  "url"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "sourceUrl": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "type",
+                  "text"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "asset"
+                    ]
+                  },
+                  "assetType": {
+                    "type": "string",
+                    "enum": [
+                      "image",
+                      "pdf"
+                    ]
+                  },
+                  "assetId": {
+                    "type": "string"
+                  },
+                  "fileName": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "sourceUrl": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "size": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "content": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "type",
+                  "assetType",
+                  "assetId"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "unknown"
+                    ]
+                  }
+                },
+                "required": [
+                  "type"
+                ]
+              }
+            ]
+          },
+          "assets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "assetType": {
+                  "type": "string",
+                  "enum": [
+                    "linkHtmlContent",
+                    "screenshot",
+                    "pdf",
+                    "assetScreenshot",
+                    "bannerImage",
+                    "fullPageArchive",
+                    "video",
+                    "bookmarkAsset",
+                    "precrawledArchive",
+                    "userUploaded",
+                    "avatar",
+                    "unknown"
+                  ]
+                },
+                "fileName": {
+                  "type": "string",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "id",
+                "assetType"
+              ]
+            }
+          },
+          "matchedContent": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "startOffset": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "endOffset": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "matchStartOffset": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "matchEndOffset": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "text",
+              "startOffset",
+              "endOffset",
+              "matchStartOffset",
+              "matchEndOffset"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "createdAt",
+          "modifiedAt",
+          "archived",
+          "favourited",
+          "taggingStatus",
+          "summarizationStatus",
+          "userId",
+          "tags",
+          "content",
+          "assets"
+        ]
+      },
       "Error": {
         "type": "object",
         "properties": {
@@ -466,6 +847,40 @@
         "required": [
           "code",
           "message"
+        ]
+      },
+      "BookmarkContentSlice": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "startOffset": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "endOffset": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalLength": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "hasMoreBefore": {
+            "type": "boolean"
+          },
+          "hasMoreAfter": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "text",
+          "startOffset",
+          "endOffset",
+          "totalLength",
+          "hasMoreBefore",
+          "hasMoreAfter"
         ]
       },
       "List": {
@@ -1121,6 +1536,30 @@
           },
           {
             "schema": {
+              "type": "boolean",
+              "default": false,
+              "description": "If set to true, each result may include a matched content excerpt with offsets into the bookmark's extracted plain-text content."
+            },
+            "required": false,
+            "description": "If set to true, each result may include a matched content excerpt with offsets into the bookmark's extracted plain-text content.",
+            "name": "includeMatchedContent",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 4000,
+              "description": "Maximum length of the matched content excerpt to return when includeMatchedContent is true."
+            },
+            "required": false,
+            "description": "Maximum length of the matched content excerpt to return when includeMatchedContent is true.",
+            "name": "matchedContentLength",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "number",
               "description": "Maximum number of items to return per page."
             },
@@ -1156,7 +1595,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedBookmarks"
+                  "$ref": "#/components/schemas/SearchResults"
                 }
               }
             }
@@ -1514,6 +1953,85 @@
                     "summarizationStatus",
                     "userId"
                   ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — the Bearer token is missing, invalid, or expired.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bookmark not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bookmarks/{bookmarkId}/content": {
+      "get": {
+        "operationId": "getBookmarkContent",
+        "description": "Retrieve only the extracted plain-text content of a bookmark, optionally as a slice using character offsets.",
+        "summary": "Get bookmark content",
+        "tags": [
+          "Bookmarks"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BookmarkId"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "Zero-based character offset from which to start reading content."
+            },
+            "required": false,
+            "description": "Zero-based character offset from which to start reading content.",
+            "name": "startOffset",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100000,
+              "default": 4000,
+              "description": "Maximum number of characters to return from the requested offset."
+            },
+            "required": false,
+            "description": "Maximum number of characters to return from the requested offset.",
+            "name": "maxLength",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A slice of the bookmark's extracted plain-text content, together with slice and total length metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookmarkContentSlice"
                 }
               }
             }

--- a/packages/open-api/lib/bookmarks.ts
+++ b/packages/open-api/lib/bookmarks.ts
@@ -15,10 +15,12 @@ import { AssetIdSchema } from "./assets";
 import { BearerAuth } from "./common";
 import { ErrorSchema, UnauthorizedResponse } from "./errors";
 import {
+  BookmarkContentSliceSchema,
   BookmarkSchema,
   IncludeContentSearchParamSchema,
   PaginatedBookmarksSchema,
   PaginationSchema,
+  SearchResultsSchema,
 } from "./pagination";
 import { TagIdSchema } from "./tags";
 import { HighlightSchema, ListSchema } from "./types";
@@ -97,6 +99,22 @@ registry.registerPath({
           .describe(
             "Sort order for results. Defaults to 'relevance'. Use 'asc' or 'desc' for date-based sorting.",
           ),
+        includeMatchedContent: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "If set to true, each result may include a matched content excerpt with offsets into the bookmark's extracted plain-text content.",
+          ),
+        matchedContentLength: z
+          .number()
+          .int()
+          .positive()
+          .max(4000)
+          .optional()
+          .describe(
+            "Maximum length of the matched content excerpt to return when includeMatchedContent is true.",
+          ),
       })
       .extend(PaginationSchema.shape)
       .extend(IncludeContentSearchParamSchema.shape),
@@ -106,7 +124,7 @@ registry.registerPath({
       description: "A paginated list of bookmarks matching the search query.",
       content: {
         "application/json": {
-          schema: PaginatedBookmarksSchema,
+          schema: SearchResultsSchema,
         },
       },
     },
@@ -218,6 +236,61 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: BookmarkSchema,
+        },
+      },
+    },
+    401: UnauthorizedResponse,
+    404: {
+      description: "Bookmark not found.",
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  operationId: "getBookmarkContent",
+  method: "get",
+  path: "/bookmarks/{bookmarkId}/content",
+  description:
+    "Retrieve only the extracted plain-text content of a bookmark, optionally as a slice using character offsets.",
+  summary: "Get bookmark content",
+  tags: ["Bookmarks"],
+  security: [{ [BearerAuth.name]: [] }],
+  request: {
+    params: z.object({ bookmarkId: BookmarkIdSchema }),
+    query: z.object({
+      startOffset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .default(0)
+        .describe(
+          "Zero-based character offset from which to start reading content.",
+        ),
+      maxLength: z
+        .number()
+        .int()
+        .positive()
+        .max(100_000)
+        .optional()
+        .default(4000)
+        .describe(
+          "Maximum number of characters to return from the requested offset.",
+        ),
+    }),
+  },
+  responses: {
+    200: {
+      description:
+        "A slice of the bookmark's extracted plain-text content, together with slice and total length metadata.",
+      content: {
+        "application/json": {
+          schema: BookmarkContentSliceSchema,
         },
       },
     },

--- a/packages/open-api/lib/pagination.ts
+++ b/packages/open-api/lib/pagination.ts
@@ -1,7 +1,10 @@
 export {
+  BookmarkContentSliceSchema,
   BookmarkSchema,
   CursorSchema,
   IncludeContentSearchParamSchema,
   PaginatedBookmarksSchema,
   PaginationSchema,
+  SearchBookmarkSchema,
+  SearchResultsSchema,
 } from "./types";

--- a/packages/open-api/lib/types.ts
+++ b/packages/open-api/lib/types.ts
@@ -1,6 +1,10 @@
 import * as z from "zod";
 
-import { zBookmarkSchema } from "@karakeep/shared/types/bookmarks";
+import {
+  zBookmarkSchema,
+  zGetBookmarkContentResponseSchema,
+  zSearchBookmarkSchema,
+} from "@karakeep/shared/types/bookmarks";
 import { zHighlightSchema } from "@karakeep/shared/types/highlights";
 import { zBookmarkListSchema } from "@karakeep/shared/types/lists";
 import { zGetTagResponseSchema } from "@karakeep/shared/types/tags";
@@ -8,6 +12,10 @@ import { zGetTagResponseSchema } from "@karakeep/shared/types/tags";
 export const ListSchema = zBookmarkListSchema.openapi("List");
 
 export const BookmarkSchema = zBookmarkSchema.openapi("Bookmark");
+export const SearchBookmarkSchema =
+  zSearchBookmarkSchema.openapi("SearchBookmark");
+export const BookmarkContentSliceSchema =
+  zGetBookmarkContentResponseSchema.openapi("BookmarkContentSlice");
 
 export const PaginatedBookmarksSchema = z
   .object({
@@ -18,6 +26,16 @@ export const PaginatedBookmarksSchema = z
       .describe("Cursor for the next page, or null if no more results."),
   })
   .openapi("PaginatedBookmarks");
+
+export const SearchResultsSchema = z
+  .object({
+    bookmarks: z.array(SearchBookmarkSchema),
+    nextCursor: z
+      .string()
+      .nullable()
+      .describe("Cursor for the next page, or null if no more results."),
+  })
+  .openapi("SearchResults");
 
 export const CursorSchema = z
   .string()

--- a/packages/plugins/search-meilisearch/src/index.ts
+++ b/packages/plugins/search-meilisearch/src/index.ts
@@ -29,6 +29,45 @@ function filterToMeiliSearchFilter(filter: FilterQuery): string {
   }
 }
 
+function buildMatchedContent(
+  content: string | undefined,
+  matchesPosition:
+    | Record<string, { start: number; length: number }[]>
+    | undefined,
+  requestedLength: number | undefined,
+) {
+  if (!content) {
+    return null;
+  }
+
+  const firstContentMatch = matchesPosition?.content?.[0];
+  if (!firstContentMatch) {
+    return null;
+  }
+
+  const snippetLength = Math.max(
+    requestedLength ?? 400,
+    firstContentMatch.length,
+  );
+  const snippetStart = Math.max(
+    0,
+    Math.min(
+      firstContentMatch.start -
+        Math.floor((snippetLength - firstContentMatch.length) / 2),
+      Math.max(0, content.length - snippetLength),
+    ),
+  );
+  const snippetEnd = Math.min(content.length, snippetStart + snippetLength);
+
+  return {
+    text: content.slice(snippetStart, snippetEnd),
+    startOffset: snippetStart,
+    endOffset: snippetEnd,
+    matchStartOffset: firstContentMatch.start,
+    matchEndOffset: firstContentMatch.start + firstContentMatch.length,
+  };
+}
+
 type PendingOperation =
   | {
       type: "add";
@@ -265,8 +304,11 @@ class MeiliSearchIndexClient implements SearchIndexClient {
       limit: options.limit,
       offset: options.offset,
       sort: options.sort?.map((s) => `${s.field}:${s.order}`),
-      attributesToRetrieve: ["id"],
+      attributesToRetrieve: options.includeMatchedContent
+        ? ["id", "content"]
+        : ["id"],
       showRankingScore: true,
+      showMatchesPosition: options.includeMatchedContent,
       matchingStrategy: "all",
     });
 
@@ -274,6 +316,18 @@ class MeiliSearchIndexClient implements SearchIndexClient {
       hits: result.hits.map((hit) => ({
         id: hit.id,
         score: hit._rankingScore,
+        matchedContent: buildMatchedContent(
+          "content" in hit && typeof hit.content === "string"
+            ? hit.content
+            : undefined,
+          "_matchesPosition" in hit && typeof hit._matchesPosition === "object"
+            ? (hit._matchesPosition as Record<
+                string,
+                { start: number; length: number }[]
+              >)
+            : undefined,
+          options.matchedContentLength,
+        ),
       })),
       totalHits: result.estimatedTotalHits ?? 0,
       processingTimeMs: result.processingTimeMs,

--- a/packages/plugins/search-meilisearch/src/tests/index.test.ts
+++ b/packages/plugins/search-meilisearch/src/tests/index.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+
+import { MeiliSearchProvider } from "../index";
+
+interface TestSearchClient {
+  search: (options: {
+    query: string;
+    includeMatchedContent: boolean;
+    matchedContentLength: number;
+  }) => Promise<{
+    hits: {
+      id: string;
+      matchedContent: {
+        text: string;
+        startOffset: number;
+        endOffset: number;
+        matchStartOffset: number;
+        matchEndOffset: number;
+      } | null;
+    }[];
+  }>;
+}
+
+interface TestProvider {
+  client: {
+    getIndexes: () => Promise<{ results: { uid: string }[] }>;
+    createIndex: () => Promise<{ taskUid: number }>;
+    waitForTask: () => Promise<void>;
+    getIndex: () => Promise<{
+      getSettings: () => Promise<{
+        filterableAttributes: string[];
+        sortableAttributes: string[];
+      }>;
+      updateFilterableAttributes: () => Promise<{ taskUid: number }>;
+      updateSortableAttributes: () => Promise<{ taskUid: number }>;
+      waitForTask: () => Promise<void>;
+      search: () => Promise<{
+        hits: {
+          id: string;
+          content: string;
+          _rankingScore: number;
+          _matchesPosition: {
+            content: { start: number; length: number }[];
+          };
+        }[];
+        estimatedTotalHits: number;
+        processingTimeMs: number;
+      }>;
+    }>;
+  };
+  getClient: () => Promise<TestSearchClient | null>;
+}
+
+describe("MeiliSearchProvider", () => {
+  test("matched content excerpt always encloses the reported match", async () => {
+    const provider = new MeiliSearchProvider() as unknown as TestProvider;
+
+    const fakeIndex = {
+      getSettings: async () => ({
+        filterableAttributes: ["id", "userId"],
+        sortableAttributes: ["createdAt"],
+      }),
+      updateFilterableAttributes: async () => ({ taskUid: 1 }),
+      updateSortableAttributes: async () => ({ taskUid: 2 }),
+      waitForTask: async () => undefined,
+      search: async () => ({
+        hits: [
+          {
+            id: "bookmark-1",
+            content: "0123456789abcdefghij",
+            _rankingScore: 1,
+            _matchesPosition: {
+              content: [{ start: 10, length: 6 }],
+            },
+          },
+        ],
+        estimatedTotalHits: 1,
+        processingTimeMs: 1,
+      }),
+    };
+
+    provider.client = {
+      getIndexes: async () => ({ results: [] }),
+      createIndex: async () => ({ taskUid: 1 }),
+      waitForTask: async () => undefined,
+      getIndex: async () => fakeIndex,
+    };
+
+    const client = await provider.getClient();
+    const result = await client!.search({
+      query: "abc",
+      includeMatchedContent: true,
+      matchedContentLength: 1,
+    });
+
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0]?.matchedContent).toEqual({
+      text: "abcdef",
+      startOffset: 10,
+      endOffset: 16,
+      matchStartOffset: 10,
+      matchEndOffset: 16,
+    });
+  });
+});

--- a/packages/sdk/src/karakeep-api.d.ts
+++ b/packages/sdk/src/karakeep-api.d.ts
@@ -96,6 +96,26 @@ export interface paths {
     patch: operations["updateBookmark"];
     trace?: never;
   };
+  "/bookmarks/{bookmarkId}/content": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get bookmark content
+     * @description Retrieve only the extracted plain-text content of a bookmark, optionally as a slice using character offsets.
+     */
+    get: operations["getBookmarkContent"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/bookmarks/{bookmarkId}/summarize": {
     parameters: {
       query?: never;
@@ -783,9 +803,16 @@ export interface components {
      * @example ieidlxygmwj87oxz5hxttoc8
      */
     FeedId: string;
+    PaginatedBookmarks: {
+      bookmarks: components["schemas"]["Bookmark"][];
+      /** @description Cursor for the next page, or null if no more results. */
+      nextCursor: string | null;
+    };
     Bookmark: {
       id: string;
+      /** Format: date-time */
       createdAt: string;
+      /** Format: date-time */
       modifiedAt: string | null;
       title?: string | null;
       archived: boolean;
@@ -831,12 +858,15 @@ export interface components {
             favicon?: string | null;
             htmlContent?: string | null;
             contentAssetId?: string | null;
+            /** Format: date-time */
             crawledAt?: string | null;
             /** @enum {string|null} */
             crawlStatus?: "success" | "failure" | "pending" | null;
             author?: string | null;
             publisher?: string | null;
+            /** Format: date-time */
             datePublished?: string | null;
+            /** Format: date-time */
             dateModified?: string | null;
           }
         | {
@@ -879,18 +909,134 @@ export interface components {
         fileName?: string | null;
       }[];
     };
-    PaginatedBookmarks: {
-      bookmarks: components["schemas"]["Bookmark"][];
+    /** @description Cursor from a previous response to fetch the next page. */
+    Cursor: string;
+    SearchResults: {
+      bookmarks: components["schemas"]["SearchBookmark"][];
       /** @description Cursor for the next page, or null if no more results. */
       nextCursor: string | null;
     };
-    /** @description Cursor from a previous response to fetch the next page. */
-    Cursor: string;
+    SearchBookmark: {
+      id: string;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      modifiedAt: string | null;
+      title?: string | null;
+      archived: boolean;
+      favourited: boolean;
+      /** @enum {string|null} */
+      taggingStatus: "success" | "failure" | "pending" | null;
+      /** @enum {string|null} */
+      summarizationStatus: "success" | "failure" | "pending" | null;
+      note?: string | null;
+      summary?: string | null;
+      /** @enum {string|null} */
+      source?:
+        | "api"
+        | "web"
+        | "cli"
+        | "mobile"
+        | "extension"
+        | "singlefile"
+        | "rss"
+        | "import"
+        | null;
+      userId: string;
+      tags: {
+        id: string;
+        name: string;
+        /** @enum {string} */
+        attachedBy: "ai" | "human";
+      }[];
+      content:
+        | {
+            /** @enum {string} */
+            type: "link";
+            url: string;
+            title?: string | null;
+            description?: string | null;
+            imageUrl?: string | null;
+            imageAssetId?: string | null;
+            screenshotAssetId?: string | null;
+            pdfAssetId?: string | null;
+            fullPageArchiveAssetId?: string | null;
+            precrawledArchiveAssetId?: string | null;
+            videoAssetId?: string | null;
+            favicon?: string | null;
+            htmlContent?: string | null;
+            contentAssetId?: string | null;
+            /** Format: date-time */
+            crawledAt?: string | null;
+            /** @enum {string|null} */
+            crawlStatus?: "success" | "failure" | "pending" | null;
+            author?: string | null;
+            publisher?: string | null;
+            /** Format: date-time */
+            datePublished?: string | null;
+            /** Format: date-time */
+            dateModified?: string | null;
+          }
+        | {
+            /** @enum {string} */
+            type: "text";
+            text: string;
+            sourceUrl?: string | null;
+          }
+        | {
+            /** @enum {string} */
+            type: "asset";
+            /** @enum {string} */
+            assetType: "image" | "pdf";
+            assetId: string;
+            fileName?: string | null;
+            sourceUrl?: string | null;
+            size?: number | null;
+            content?: string | null;
+          }
+        | {
+            /** @enum {string} */
+            type: "unknown";
+          };
+      assets: {
+        id: string;
+        /** @enum {string} */
+        assetType:
+          | "linkHtmlContent"
+          | "screenshot"
+          | "pdf"
+          | "assetScreenshot"
+          | "bannerImage"
+          | "fullPageArchive"
+          | "video"
+          | "bookmarkAsset"
+          | "precrawledArchive"
+          | "userUploaded"
+          | "avatar"
+          | "unknown";
+        fileName?: string | null;
+      }[];
+      matchedContent?: {
+        text: string;
+        startOffset: number;
+        endOffset: number;
+        matchStartOffset: number;
+        matchEndOffset: number;
+      } | null;
+    };
     Error: {
       /** @description A machine-readable error code. */
       code: string;
       /** @description A human-readable error message. */
       message: string;
+    };
+    BookmarkContentSlice: {
+      text: string;
+      startOffset: number;
+      endOffset: number;
+      totalLength: number;
+      hasMoreBefore: boolean;
+      hasMoreAfter: boolean;
     };
     List: {
       id: string;
@@ -922,6 +1068,7 @@ export interface components {
       note: string | null;
       id: string;
       userId: string;
+      /** Format: date-time */
       createdAt: string;
     };
     Tag: {
@@ -948,7 +1095,6 @@ export interface components {
       /** @description The original file name of the uploaded file. */
       fileName: string;
     };
-    "File to be uploaded": unknown;
     Feed: {
       id: string;
       name: string;
@@ -972,12 +1118,19 @@ export interface components {
   };
   responses: never;
   parameters: {
+    /** @description The unique identifier of the bookmark. */
     BookmarkId: components["schemas"]["BookmarkId"];
+    /** @description The unique identifier of the list. */
     ListId: components["schemas"]["ListId"];
+    /** @description The unique identifier of the tag. */
     TagId: components["schemas"]["TagId"];
+    /** @description The unique identifier of the highlight. */
     HighlightId: components["schemas"]["HighlightId"];
+    /** @description The unique identifier of the asset. */
     AssetId: components["schemas"]["AssetId"];
+    /** @description The unique identifier of the backup. */
     BackupId: components["schemas"]["BackupId"];
+    /** @description The unique identifier of the feed. */
     FeedId: components["schemas"]["FeedId"];
   };
   requestBodies: never;
@@ -1044,7 +1197,8 @@ export interface operations {
           favourited?: boolean;
           note?: string;
           summary?: string;
-          createdAt?: string | null;
+          /** Format: date-time */
+          createdAt?: string;
           /** @enum {string} */
           crawlPriority?: "low" | "normal";
           importSessionId?: string;
@@ -1130,6 +1284,10 @@ export interface operations {
         q: string;
         /** @description Sort order for results. Defaults to 'relevance'. Use 'asc' or 'desc' for date-based sorting. */
         sortOrder?: "asc" | "desc" | "relevance";
+        /** @description If set to true, each result may include a matched content excerpt with offsets into the bookmark's extracted plain-text content. */
+        includeMatchedContent?: boolean;
+        /** @description Maximum length of the matched content excerpt to return when includeMatchedContent is true. */
+        matchedContentLength?: number;
         /** @description Maximum number of items to return per page. */
         limit?: number;
         /** @description Cursor from a previous response to fetch the next page. */
@@ -1149,7 +1307,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["PaginatedBookmarks"];
+          "application/json": components["schemas"]["SearchResults"];
         };
       };
       /** @description Unauthorized — the Bearer token is missing, invalid, or expired. */
@@ -1206,6 +1364,7 @@ export interface operations {
       };
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1246,6 +1405,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1284,6 +1444,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1297,13 +1458,16 @@ export interface operations {
           summary?: string | null;
           note?: string;
           title?: string | null;
-          createdAt?: string | null;
+          /** Format: date-time */
+          createdAt?: string;
           /** Format: uri */
           url?: string;
           description?: string | null;
           author?: string | null;
           publisher?: string | null;
+          /** Format: date-time */
           datePublished?: string | null;
+          /** Format: date-time */
           dateModified?: string | null;
           text?: string | null;
           assetContent?: string | null;
@@ -1319,7 +1483,9 @@ export interface operations {
         content: {
           "application/json": {
             id: string;
+            /** Format: date-time */
             createdAt: string;
+            /** Format: date-time */
             modifiedAt: string | null;
             title?: string | null;
             archived: boolean;
@@ -1365,11 +1531,58 @@ export interface operations {
       };
     };
   };
+  getBookmarkContent: {
+    parameters: {
+      query?: {
+        /** @description Zero-based character offset from which to start reading content. */
+        startOffset?: number;
+        /** @description Maximum number of characters to return from the requested offset. */
+        maxLength?: number;
+      };
+      header?: never;
+      path: {
+        /** @description The unique identifier of the bookmark. */
+        bookmarkId: components["parameters"]["BookmarkId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description A slice of the bookmark's extracted plain-text content, together with slice and total length metadata. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["BookmarkContentSlice"];
+        };
+      };
+      /** @description Unauthorized — the Bearer token is missing, invalid, or expired. */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** @description Bookmark not found. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Error"];
+        };
+      };
+    };
+  };
   summarizeBookmark: {
     parameters: {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1384,7 +1597,9 @@ export interface operations {
         content: {
           "application/json": {
             id: string;
+            /** Format: date-time */
             createdAt: string;
+            /** Format: date-time */
             modifiedAt: string | null;
             title?: string | null;
             archived: boolean;
@@ -1435,6 +1650,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1492,6 +1708,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1549,6 +1766,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1591,6 +1809,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1633,6 +1852,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -1715,7 +1935,9 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
+        /** @description The unique identifier of the asset. */
         assetId: components["parameters"]["AssetId"];
       };
       cookie?: never;
@@ -1762,7 +1984,9 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
+        /** @description The unique identifier of the asset. */
         assetId: components["parameters"]["AssetId"];
       };
       cookie?: never;
@@ -1886,6 +2110,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the list. */
         listId: components["parameters"]["ListId"];
       };
       cookie?: never;
@@ -1926,6 +2151,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the list. */
         listId: components["parameters"]["ListId"];
       };
       cookie?: never;
@@ -1964,6 +2190,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the list. */
         listId: components["parameters"]["ListId"];
       };
       cookie?: never;
@@ -2025,6 +2252,7 @@ export interface operations {
       };
       header?: never;
       path: {
+        /** @description The unique identifier of the list. */
         listId: components["parameters"]["ListId"];
       };
       cookie?: never;
@@ -2065,7 +2293,9 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the list. */
         listId: components["parameters"]["ListId"];
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -2104,7 +2334,9 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the list. */
         listId: components["parameters"]["ListId"];
+        /** @description The unique identifier of the bookmark. */
         bookmarkId: components["parameters"]["BookmarkId"];
       };
       cookie?: never;
@@ -2230,6 +2462,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the tag. */
         tagId: components["parameters"]["TagId"];
       };
       cookie?: never;
@@ -2270,6 +2503,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the tag. */
         tagId: components["parameters"]["TagId"];
       };
       cookie?: never;
@@ -2308,6 +2542,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the tag. */
         tagId: components["parameters"]["TagId"];
       };
       cookie?: never;
@@ -2367,6 +2602,7 @@ export interface operations {
       };
       header?: never;
       path: {
+        /** @description The unique identifier of the tag. */
         tagId: components["parameters"]["TagId"];
       };
       cookie?: never;
@@ -2504,6 +2740,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the highlight. */
         highlightId: components["parameters"]["HighlightId"];
       };
       cookie?: never;
@@ -2544,6 +2781,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the highlight. */
         highlightId: components["parameters"]["HighlightId"];
       };
       cookie?: never;
@@ -2584,6 +2822,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the highlight. */
         highlightId: components["parameters"]["HighlightId"];
       };
       cookie?: never;
@@ -2756,7 +2995,11 @@ export interface operations {
     requestBody?: {
       content: {
         "multipart/form-data": {
-          file: components["schemas"]["File to be uploaded"];
+          /**
+           * Format: binary
+           * @description File to be uploaded
+           */
+          file: string;
         };
       };
     };
@@ -2786,6 +3029,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the asset. */
         assetId: components["parameters"]["AssetId"];
       };
       cookie?: never;
@@ -2815,6 +3059,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The ID of the user to update. */
         userId: string;
       };
       cookie?: never;
@@ -3077,6 +3322,7 @@ export interface operations {
               id: string;
               userId: string;
               assetId: string | null;
+              /** Format: date-time */
               createdAt: string;
               size: number;
               bookmarkCount: number;
@@ -3117,6 +3363,7 @@ export interface operations {
             id: string;
             userId: string;
             assetId: string | null;
+            /** Format: date-time */
             createdAt: string;
             size: number;
             bookmarkCount: number;
@@ -3142,6 +3389,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the backup. */
         backupId: components["parameters"]["BackupId"];
       };
       cookie?: never;
@@ -3158,6 +3406,7 @@ export interface operations {
             id: string;
             userId: string;
             assetId: string | null;
+            /** Format: date-time */
             createdAt: string;
             size: number;
             bookmarkCount: number;
@@ -3192,6 +3441,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the backup. */
         backupId: components["parameters"]["BackupId"];
       };
       cookie?: never;
@@ -3230,6 +3480,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the backup. */
         backupId: components["parameters"]["BackupId"];
       };
       cookie?: never;
@@ -3242,7 +3493,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/zip": unknown;
+          "application/zip": string;
         };
       };
       /** @description Unauthorized — the Bearer token is missing, invalid, or expired. */
@@ -3351,6 +3602,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the feed. */
         feedId: components["parameters"]["FeedId"];
       };
       cookie?: never;
@@ -3391,6 +3643,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the feed. */
         feedId: components["parameters"]["FeedId"];
       };
       cookie?: never;
@@ -3429,6 +3682,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the feed. */
         feedId: components["parameters"]["FeedId"];
       };
       cookie?: never;
@@ -3480,6 +3734,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
+        /** @description The unique identifier of the feed. */
         feedId: components["parameters"]["FeedId"];
       };
       cookie?: never;

--- a/packages/shared/search.ts
+++ b/packages/shared/search.ts
@@ -40,9 +40,18 @@ export type FilterQuery =
       values: string[];
     };
 
+export interface SearchMatchExcerpt {
+  text: string;
+  startOffset: number;
+  endOffset: number;
+  matchStartOffset: number;
+  matchEndOffset: number;
+}
+
 export interface SearchResult {
   id: string;
   score?: number;
+  matchedContent?: SearchMatchExcerpt | null;
 }
 
 export interface SearchOptions {
@@ -52,6 +61,8 @@ export interface SearchOptions {
   limit?: number;
   offset?: number;
   sort?: { field: SortableAttributes; order: SortOrder }[];
+  includeMatchedContent?: boolean;
+  matchedContentLength?: number;
 }
 
 export interface SearchResponse {

--- a/packages/shared/types/bookmarks.ts
+++ b/packages/shared/types/bookmarks.ts
@@ -125,6 +125,22 @@ export const zBookmarkSchema = zBareBookmarkSchema.extend(
 );
 export type ZBookmark = z.infer<typeof zBookmarkSchema>;
 
+export const zBookmarkMatchedContentSchema = z.object({
+  text: z.string(),
+  startOffset: z.number().int().nonnegative(),
+  endOffset: z.number().int().nonnegative(),
+  matchStartOffset: z.number().int().nonnegative(),
+  matchEndOffset: z.number().int().nonnegative(),
+});
+export type ZBookmarkMatchedContent = z.infer<
+  typeof zBookmarkMatchedContentSchema
+>;
+
+export const zSearchBookmarkSchema = zBookmarkSchema.extend({
+  matchedContent: zBookmarkMatchedContentSchema.nullable().optional(),
+});
+export type ZSearchBookmark = z.infer<typeof zSearchBookmarkSchema>;
+
 const zBookmarkTypeLinkSchema = zBareBookmarkSchema.extend(
   z.object({
     tags: z.array(zBookmarkTagSchema),
@@ -277,7 +293,38 @@ export const zSearchBookmarksRequestSchema = z.object({
   cursor: zSearchBookmarksCursor.nullish(),
   sortOrder: zSortOrder.optional().default("relevance"),
   includeContent: z.boolean().optional().default(false),
+  includeMatchedContent: z.boolean().optional().default(false),
+  matchedContentLength: z.number().int().positive().max(4000).optional(),
 });
+
+export const zSearchBookmarksResponseSchema = z.object({
+  bookmarks: z.array(zSearchBookmarkSchema),
+  nextCursor: zSearchBookmarksCursor.nullable(),
+});
+export type ZSearchBookmarksResponse = z.infer<
+  typeof zSearchBookmarksResponseSchema
+>;
+
+export const zGetBookmarkContentRequestSchema = z.object({
+  bookmarkId: z.string(),
+  startOffset: z.number().int().nonnegative().optional().default(0),
+  maxLength: z.number().int().positive().max(100_000).optional().default(4000),
+});
+export type ZGetBookmarkContentRequest = z.infer<
+  typeof zGetBookmarkContentRequestSchema
+>;
+
+export const zGetBookmarkContentResponseSchema = z.object({
+  text: z.string(),
+  startOffset: z.number().int().nonnegative(),
+  endOffset: z.number().int().nonnegative(),
+  totalLength: z.number().int().nonnegative(),
+  hasMoreBefore: z.boolean(),
+  hasMoreAfter: z.boolean(),
+});
+export type ZGetBookmarkContentResponse = z.infer<
+  typeof zGetBookmarkContentResponseSchema
+>;
 
 export const zPublicBookmarkSchema = z.object({
   id: z.string(),

--- a/packages/trpc/models/bookmarks.ts
+++ b/packages/trpc/models/bookmarks.ts
@@ -40,6 +40,7 @@ import {
   ZBareBookmark,
   ZBookmark,
   ZBookmarkContent,
+  ZGetBookmarkContentResponse,
   zGetBookmarksRequestSchema,
   ZPublicBookmark,
 } from "@karakeep/shared/types/bookmarks";
@@ -903,6 +904,70 @@ export class Bookmark extends BareBookmark {
       return null;
     }
     return htmlToPlainText(content);
+  }
+
+  static async getBookmarkContentText(ctx: AuthedContext, bookmarkId: string) {
+    const bookmark = await ctx.db.query.bookmarks.findFirst({
+      where: eq(bookmarks.id, bookmarkId),
+      with: {
+        link: true,
+        text: true,
+        asset: true,
+      },
+    });
+
+    if (!bookmark) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Bookmark not found",
+      });
+    }
+
+    if (!(await BareBookmark.isAllowedToAccessBookmark(ctx, bookmark))) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Bookmark not found",
+      });
+    }
+
+    if (bookmark.link) {
+      return (
+        (await Bookmark.getBookmarkPlainTextContent(
+          bookmark.link,
+          bookmark.userId,
+        )) ?? ""
+      );
+    }
+    if (bookmark.text) {
+      return bookmark.text.text ?? "";
+    }
+    if (bookmark.asset) {
+      return bookmark.asset.content ?? "";
+    }
+    return "";
+  }
+
+  static async getBookmarkContentSlice(
+    ctx: AuthedContext,
+    bookmarkId: string,
+    startOffset: number,
+    maxLength: number,
+  ): Promise<ZGetBookmarkContentResponse> {
+    const fullText = await Bookmark.getBookmarkContentText(ctx, bookmarkId);
+    const normalizedStartOffset = Math.min(startOffset, fullText.length);
+    const endOffset = Math.min(
+      fullText.length,
+      normalizedStartOffset + maxLength,
+    );
+
+    return {
+      text: fullText.slice(normalizedStartOffset, endOffset),
+      startOffset: normalizedStartOffset,
+      endOffset,
+      totalLength: fullText.length,
+      hasMoreBefore: normalizedStartOffset > 0,
+      hasMoreAfter: endOffset < fullText.length,
+    };
   }
 
   private async cleanupAssets() {

--- a/packages/trpc/routers/bookmarks.test.ts
+++ b/packages/trpc/routers/bookmarks.test.ts
@@ -8,6 +8,7 @@ import {
   tagsOnBookmarks,
   users,
 } from "@karakeep/db/schema";
+import * as sharedSearch from "@karakeep/shared/search";
 import * as sharedServer from "@karakeep/shared-server";
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
 
@@ -34,7 +35,18 @@ vi.mock("@karakeep/shared-server", async (original) => {
   };
 });
 
+vi.mock("@karakeep/shared/search", async (original) => {
+  const mod = (await original()) as typeof import("@karakeep/shared/search");
+  return {
+    ...mod,
+    getSearchClient: vi.fn(),
+  };
+});
+
 beforeEach<CustomTestContext>(defaultBeforeEach(true));
+beforeEach(() => {
+  vi.mocked(sharedSearch.getSearchClient).mockReset();
+});
 
 describe("Bookmark Routes", () => {
   async function createTestTag(api: APICallerType, tagName: string) {
@@ -853,6 +865,87 @@ describe("Bookmark Routes", () => {
     await expect(() =>
       api.getBookmark({ bookmarkId: "non-existent-id" }),
     ).rejects.toThrow(/Bookmark not found/);
+  });
+
+  test<CustomTestContext>("getBookmarkContent returns sliced plain text content", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].bookmarks;
+    const createdBookmark = await api.createBookmark({
+      text: "abcdefghijklmnopqrstuvwxyz",
+      type: BookmarkTypes.TEXT,
+    });
+
+    const content = await api.getBookmarkContent({
+      bookmarkId: createdBookmark.id,
+      startOffset: 5,
+      maxLength: 7,
+    });
+
+    expect(content.text).toBe("fghijkl");
+    expect(content.startOffset).toBe(5);
+    expect(content.endOffset).toBe(12);
+    expect(content.totalLength).toBe(26);
+    expect(content.hasMoreBefore).toBe(true);
+    expect(content.hasMoreAfter).toBe(true);
+  });
+
+  test<CustomTestContext>("searchBookmarks includes matched content when requested", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].bookmarks;
+    const createdBookmark = await api.createBookmark({
+      text: "alpha beta gamma delta epsilon zeta eta theta",
+      type: BookmarkTypes.TEXT,
+    });
+
+    const search = vi.fn().mockResolvedValue({
+      hits: [
+        {
+          id: createdBookmark.id,
+          score: 1,
+          matchedContent: {
+            text: "beta gamma delta",
+            startOffset: 6,
+            endOffset: 22,
+            matchStartOffset: 11,
+            matchEndOffset: 16,
+          },
+        },
+      ],
+      totalHits: 1,
+      processingTimeMs: 1,
+    });
+
+    vi.mocked(sharedSearch.getSearchClient).mockResolvedValue({
+      addDocuments: vi.fn(),
+      deleteDocuments: vi.fn(),
+      clearIndex: vi.fn(),
+      search,
+    });
+
+    const result = await api.searchBookmarks({
+      text: "gamma",
+      includeMatchedContent: true,
+      matchedContentLength: 120,
+    });
+
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "gamma",
+        includeMatchedContent: true,
+        matchedContentLength: 120,
+      }),
+    );
+    expect(result.bookmarks).toHaveLength(1);
+    expect(result.bookmarks[0]?.id).toBe(createdBookmark.id);
+    expect(result.bookmarks[0]?.matchedContent).toEqual({
+      text: "beta gamma delta",
+      startOffset: 6,
+      endOffset: 22,
+      matchStartOffset: 11,
+      matchEndOffset: 16,
+    });
   });
 
   test<CustomTestContext>("getBrokenLinks", async ({ apiCallers, db }) => {

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -42,12 +42,14 @@ import {
   BookmarkTypes,
   DEFAULT_NUM_BOOKMARKS_PER_PAGE,
   zBookmarkSchema,
+  zGetBookmarkContentRequestSchema,
+  zGetBookmarkContentResponseSchema,
   zGetBookmarksRequestSchema,
   zGetBookmarksResponseSchema,
   zManipulatedTagSchema,
   zNewBookmarkRequestSchema,
-  zSearchBookmarksCursor,
   zSearchBookmarksRequestSchema,
+  zSearchBookmarksResponseSchema,
   zUpdateBookmarksRequestSchema,
 } from "@karakeep/shared/types/bookmarks";
 import { ANCHOR_TEXT_MAX_LENGTH } from "@karakeep/shared/utils/reading-progress-dom";
@@ -801,16 +803,24 @@ export const bookmarksAppRouter = router({
         await Bookmark.fromId(ctx, input.bookmarkId, input.includeContent)
       ).asZBookmark();
     }),
+  getBookmarkContent: bookmarksProcedure
+    .use(createBookmarksQueriedMiddleware())
+    .input(zGetBookmarkContentRequestSchema)
+    .output(zGetBookmarkContentResponseSchema)
+    .use(ensureBookmarkAccess)
+    .query(async ({ input, ctx }) => {
+      return Bookmark.getBookmarkContentSlice(
+        ctx,
+        input.bookmarkId,
+        input.startOffset,
+        input.maxLength,
+      );
+    }),
   searchBookmarks: bookmarksProcedure
     .use(createBookmarksQueriedMiddleware())
     .use(createEventLogMiddleware("search.query"))
     .input(zSearchBookmarksRequestSchema)
-    .output(
-      z.object({
-        bookmarks: z.array(zBookmarkSchema),
-        nextCursor: zSearchBookmarksCursor.nullable(),
-      }),
-    )
+    .output(zSearchBookmarksResponseSchema)
     .query(async ({ input, ctx }) => {
       addLogFields<"search.query">({
         "search.has_query": input.text.length > 0,
@@ -852,6 +862,8 @@ export const bookmarksAppRouter = router({
         filter,
         sort: [{ field: "createdAt", order: createdAtSortOrder }],
         limit: input.limit,
+        includeMatchedContent: input.includeMatchedContent,
+        matchedContentLength: input.matchedContentLength,
         ...(input.cursor
           ? {
               offset: input.cursor.offset,
@@ -889,8 +901,15 @@ export const bookmarksAppRouter = router({
           break;
       }
 
+      const idToMatchedContent = new Map(
+        resp.hits.map((hit) => [hit.id, hit.matchedContent ?? null]),
+      );
+
       return {
-        bookmarks: results.map((b) => b.asZBookmark()),
+        bookmarks: results.map((b) => ({
+          ...b.asZBookmark(),
+          matchedContent: idToMatchedContent.get(b.id) ?? null,
+        })),
         nextCursor:
           resp.hits.length + (input.cursor?.offset || 0) >= resp.totalHits
             ? null


### PR DESCRIPTION
## Description

Implements the CLI and MCP portions of #2660, together with the underlying API/search plumbing needed to support them.

This PR adds:
- optional matched-content excerpts with offsets for bookmark search
- a content-only bookmark endpoint with offset/length slicing
- CLI support for matched-content search and a new `bookmarks get-content` command
- MCP support for matched-content search and partial bookmark content retrieval
- OpenAPI + SDK updates

Fixes #2660

## How Has This Been Tested?

- [x] `pnpm --filter @karakeep/trpc test -- bookmarks.test.ts`
- [x] `pnpm --filter @karakeep/trpc typecheck`
- [x] `pnpm --filter @karakeep/api typecheck`
- [x] `pnpm --filter @karakeep/open-api check`
- [x] `pnpm --filter @karakeep/open-api typecheck`
- [x] `pnpm --filter @karakeep/sdk typecheck && pnpm --filter @karakeep/sdk build`
- [x] `pnpm --filter @karakeep/cli typecheck && pnpm --filter @karakeep/cli build && pnpm --filter @karakeep/cli lint`
- [x] `pnpm --filter @karakeep/mcp typecheck && pnpm --filter @karakeep/mcp build && pnpm --filter @karakeep/mcp lint`
- [x] `pnpm --filter @karakeep/plugins typecheck && pnpm --filter @karakeep/plugins lint`
- [x] manual MCP tool schema verification for `search-bookmarks` and `get-bookmark-content`
- [x] manual matched-content boundary probe for the Meilisearch adapter

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used for implementation assistance, repository exploration, and drafting the PR description; all code and validation steps were reviewed and executed locally.