### PR TITLE
Treat trailing slash links as duplicate bookmarks

### DIFF
--- a/packages/trpc/routers/bookmarks.test.ts
+++ b/packages/trpc/routers/bookmarks.test.ts
@@ -760,6 +760,46 @@ describe("Bookmark Routes", () => {
     expect(bookmark3User1.alreadyExists).toEqual(false);
   });
 
+  test<CustomTestContext>("bookmark links dedup ignores trailing slash", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].bookmarks;
+
+    const bookmark = await api.createBookmark({
+      url: "https://example.com/page/",
+      type: BookmarkTypes.LINK,
+    });
+    expect(bookmark.alreadyExists).toEqual(false);
+
+    const duplicate = await api.createBookmark({
+      url: "https://example.com/page",
+      type: BookmarkTypes.LINK,
+    });
+
+    expect(duplicate.alreadyExists).toEqual(true);
+    expect(duplicate.id).toEqual(bookmark.id);
+  });
+
+  test<CustomTestContext>("bookmark links dedup ignores trailing slash before query string", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].bookmarks;
+
+    const bookmark = await api.createBookmark({
+      url: "https://example.com/page/?ref=import",
+      type: BookmarkTypes.LINK,
+    });
+    expect(bookmark.alreadyExists).toEqual(false);
+
+    const duplicate = await api.createBookmark({
+      url: "https://example.com/page?ref=import",
+      type: BookmarkTypes.LINK,
+    });
+
+    expect(duplicate.alreadyExists).toEqual(true);
+    expect(duplicate.id).toEqual(bookmark.id);
+  });
+
   // Ensure that the pagination returns all the results
   test<CustomTestContext>("pagination", async ({ apiCallers, db }) => {
     const user = await apiCallers[0].users.whoami();
@@ -1484,6 +1524,21 @@ describe("Bookmark Routes", () => {
 
       const result = await api.checkUrl({
         url: "https://example.com/page",
+      });
+      expect(result.bookmarkId).toEqual(bookmark.id);
+    });
+
+    test<CustomTestContext>("matches URL ignoring trailing slash before query string", async ({
+      apiCallers,
+    }) => {
+      const api = apiCallers[0].bookmarks;
+      const bookmark = await api.createBookmark({
+        url: "https://example.com/page/?ref=extension",
+        type: BookmarkTypes.LINK,
+      });
+
+      const result = await api.checkUrl({
+        url: "https://example.com/page?ref=extension",
       });
       expect(result.bookmarkId).toEqual(bookmark.id);
     });

--- a/packages/trpc/routers/bookmarks.test.ts
+++ b/packages/trpc/routers/bookmarks.test.ts
@@ -800,6 +800,26 @@ describe("Bookmark Routes", () => {
     expect(duplicate.id).toEqual(bookmark.id);
   });
 
+  test<CustomTestContext>("bookmark links dedup ignores hash fragments", async ({
+    apiCallers,
+  }) => {
+    const api = apiCallers[0].bookmarks;
+
+    const bookmark = await api.createBookmark({
+      url: "https://example.com/page",
+      type: BookmarkTypes.LINK,
+    });
+    expect(bookmark.alreadyExists).toEqual(false);
+
+    const duplicate = await api.createBookmark({
+      url: "https://example.com/page#section",
+      type: BookmarkTypes.LINK,
+    });
+
+    expect(duplicate.alreadyExists).toEqual(true);
+    expect(duplicate.id).toEqual(bookmark.id);
+  });
+
   // Ensure that the pagination returns all the results
   test<CustomTestContext>("pagination", async ({ apiCallers, db }) => {
     const user = await apiCallers[0].users.whoami();

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -116,7 +116,7 @@ function normalizeUrlForDedup(url: string): string {
 
 function urlDedupSearchCandidates(url: string): string[] {
   const normalized = new URL(normalizeUrlForDedup(url));
-  const candidates = new Set([url.trim(), normalized.toString()]);
+  const candidates = new Set([normalized.toString()]);
 
   if (normalized.pathname !== "/" && !normalized.pathname.endsWith("/")) {
     normalized.pathname = `${normalized.pathname}/`;

--- a/packages/trpc/routers/bookmarks.ts
+++ b/packages/trpc/routers/bookmarks.ts
@@ -105,20 +105,57 @@ export const ensureBookmarkAccess = experimental_trpcMiddleware<{
   });
 });
 
+function normalizeUrlForDedup(url: string): string {
+  const normalized = new URL(url.trim());
+  normalized.hash = "";
+  if (normalized.pathname.endsWith("/") && normalized.pathname !== "/") {
+    normalized.pathname = normalized.pathname.slice(0, -1);
+  }
+  return normalized.toString();
+}
+
+function urlDedupSearchCandidates(url: string): string[] {
+  const normalized = new URL(normalizeUrlForDedup(url));
+  const candidates = new Set([url.trim(), normalized.toString()]);
+
+  if (normalized.pathname !== "/" && !normalized.pathname.endsWith("/")) {
+    normalized.pathname = `${normalized.pathname}/`;
+    candidates.add(normalized.toString());
+  }
+
+  return [...candidates];
+}
+
 async function attemptToDedupLink(ctx: AuthedContext, url: string) {
+  const normalizedUrl = normalizeUrlForDedup(url);
+  const candidates = urlDedupSearchCandidates(url);
   const result = await ctx.db
     .select({
       id: bookmarkLinks.id,
+      url: bookmarkLinks.url,
     })
     .from(bookmarkLinks)
     .leftJoin(bookmarks, eq(bookmarks.id, bookmarkLinks.id))
-    .where(and(eq(bookmarkLinks.url, url), eq(bookmarks.userId, ctx.user.id)));
+    .where(
+      and(
+        eq(bookmarks.userId, ctx.user.id),
+        or(
+          ...candidates.map((candidate) =>
+            like(bookmarkLinks.url, `${candidate}%`),
+          ),
+        ),
+      ),
+    );
 
-  if (result.length == 0) {
+  const existing = result.find(
+    (bookmark) => normalizeUrlForDedup(bookmark.url) === normalizedUrl,
+  );
+
+  if (!existing) {
     return null;
   }
   return (
-    await Bookmark.fromId(ctx, result[0].id, /* includeContent: */ false)
+    await Bookmark.fromId(ctx, existing.id, /* includeContent: */ false)
   ).asZBookmark();
 }
 
@@ -912,20 +949,8 @@ export const bookmarksAppRouter = router({
       }),
     )
     .query(async ({ input, ctx }) => {
-      // Normalize and compare URLs (ignoring hash fragment and trailing slash)
-      function normalizeUrl(url: string): string {
-        const u = new URL(url);
-        u.hash = "";
-        let pathname = u.pathname;
-        if (pathname.endsWith("/") && pathname !== "/") {
-          pathname = pathname.slice(0, -1);
-        }
-        u.pathname = pathname;
-        return u.toString();
-      }
-
-      // Strip hash before querying so the LIKE clause can match
-      const normalizedInput = normalizeUrl(input.url);
+      const normalizedInput = normalizeUrlForDedup(input.url);
+      const candidates = urlDedupSearchCandidates(input.url);
 
       const results = await ctx.db
         .select({ id: bookmarkLinks.id, url: bookmarkLinks.url })
@@ -934,7 +959,11 @@ export const bookmarksAppRouter = router({
         .where(
           and(
             eq(bookmarks.userId, ctx.user.id),
-            like(bookmarkLinks.url, `${normalizedInput}%`),
+            or(
+              ...candidates.map((candidate) =>
+                like(bookmarkLinks.url, `${candidate}%`),
+              ),
+            ),
           ),
         );
 
@@ -943,7 +972,7 @@ export const bookmarksAppRouter = router({
       }
 
       const exactMatch = results.find(
-        (r) => r.url && normalizeUrl(r.url) === normalizedInput,
+        (r) => r.url && normalizeUrlForDedup(r.url) === normalizedInput,
       );
 
       return { bookmarkId: exactMatch?.id ?? null };


### PR DESCRIPTION
Fixes #864.

Bookmark creation was checking duplicate links with the raw URL, so importing https://example.com/page and https://example.com/page/ could still leave two bookmarks. I moved the trailing-slash/hash normalization into the createBookmark dedupe path and reused it for check-url too.

I also covered the query-string version of the same bug: /page/?ref=x vs /page?ref=x.

Checked locally:
- pnpm.cmd --filter @karakeep/trpc exec vitest run routers/bookmarks.test.ts
- pnpm.cmd --filter @karakeep/trpc typecheck
- pnpm.cmd --filter @karakeep/trpc lint
- pnpm.cmd --filter @karakeep/trpc exec oxfmt --ignore-path=../../.gitignore --check routers/bookmarks.ts routers/bookmarks.test.ts

No screenshot for this one since it is API/import behavior.