### PR TITLE
feat: Android home screen widget showing search results (#2800)

### DIFF
--- a/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepApi.kt
+++ b/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepApi.kt
@@ -1,0 +1,76 @@
+package app.karakeep.widget
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+object KarakeepApi {
+    private const val TAG = "KarakeepApi"
+    private const val CONNECT_TIMEOUT = 10_000
+    private const val READ_TIMEOUT = 15_000
+
+    fun searchBookmarks(serverUrl: String, apiKey: String, query: String, limit: Int = 20): JSONObject? {
+        try {
+            val input = JSONObject().apply {
+                put("0", JSONObject().apply {
+                    put("json", JSONObject().apply {
+                        put("text", query)
+                        put("limit", limit)
+                    })
+                })
+            }
+            val encodedInput = URLEncoder.encode(input.toString(), "UTF-8")
+            val urlStr = "${serverUrl.trimEnd('/')}/api/trpc/bookmarks.searchBookmarks?batch=1&input=$encodedInput"
+            val url = URL(urlStr)
+            val conn = url.openConnection() as HttpURLConnection
+            conn.apply {
+                requestMethod = "GET"
+                setRequestProperty("Authorization", "Bearer $apiKey")
+                setRequestProperty("Content-Type", "application/json")
+                setRequestProperty("Accept", "application/json")
+                connectTimeout = CONNECT_TIMEOUT
+                readTimeout = READ_TIMEOUT
+            }
+            val responseCode = conn.responseCode
+            if (responseCode != 200) {
+                Log.e(TAG, "API returned $responseCode")
+                return null
+            }
+            val body = conn.inputStream.bufferedReader().use(BufferedReader::readText)
+            return JSONObject(body)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch bookmarks", e)
+            return null
+        }
+    }
+}
+
+data class KarakeepSettings(val serverUrl: String, val apiKey: String) {
+    companion object {
+        private val SECURE_STORE_PREFS = listOf("SecureStore", "RKStorage", "karakeep_settings")
+        fun read(context: Context): KarakeepSettings? {
+            for (prefsName in SECURE_STORE_PREFS) {
+                try {
+                    val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+                    for ((key, value) in prefs.all) {
+                        if (value is String) {
+                            try {
+                                val json = JSONObject(value)
+                                val apiKey = json.optString("apiKey", "")
+                                val address = json.optString("address", "")
+                                if (apiKey.isNotEmpty() && address.isNotEmpty()) {
+                                    return KarakeepSettings(address, apiKey)
+                                }
+                            } catch (_: Exception) {}
+                        }
+                    }
+                } catch (_: Exception) {}
+            }
+            return null
+        }
+    }
+}

--- a/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepApi.kt
+++ b/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepApi.kt
@@ -14,6 +14,7 @@ object KarakeepApi {
     private const val READ_TIMEOUT = 15_000
 
     fun searchBookmarks(serverUrl: String, apiKey: String, query: String, limit: Int = 20): JSONObject? {
+        var conn: HttpURLConnection? = null
         try {
             val input = JSONObject().apply {
                 put("0", JSONObject().apply {
@@ -26,7 +27,7 @@ object KarakeepApi {
             val encodedInput = URLEncoder.encode(input.toString(), "UTF-8")
             val urlStr = "${serverUrl.trimEnd('/')}/api/trpc/bookmarks.searchBookmarks?batch=1&input=$encodedInput"
             val url = URL(urlStr)
-            val conn = url.openConnection() as HttpURLConnection
+            conn = url.openConnection() as HttpURLConnection
             conn.apply {
                 requestMethod = "GET"
                 setRequestProperty("Authorization", "Bearer $apiKey")
@@ -45,31 +46,63 @@ object KarakeepApi {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to fetch bookmarks", e)
             return null
+        } finally {
+            conn?.disconnect()
         }
     }
 }
 
 data class KarakeepSettings(val serverUrl: String, val apiKey: String) {
     companion object {
-        private val SECURE_STORE_PREFS = listOf("SecureStore", "RKStorage", "karakeep_settings")
+        private const val PREFS_NAME = "karakeep_settings"
+        private const val KEY_SERVER_URL = "server_url"
+        private const val KEY_API_KEY = "api_key"
+
         fun read(context: Context): KarakeepSettings? {
-            for (prefsName in SECURE_STORE_PREFS) {
-                try {
-                    val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-                    for ((key, value) in prefs.all) {
-                        if (value is String) {
-                            try {
-                                val json = JSONObject(value)
-                                val apiKey = json.optString("apiKey", "")
-                                val address = json.optString("address", "")
-                                if (apiKey.isNotEmpty() && address.isNotEmpty()) {
-                                    return KarakeepSettings(address, apiKey)
-                                }
-                            } catch (_: Exception) {}
+            // 1. Try deterministic lookup from known SharedPreferences store
+            try {
+                val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                val url = prefs.getString(KEY_SERVER_URL, null)
+                val key = prefs.getString(KEY_API_KEY, null)
+                if (!url.isNullOrEmpty() && !key.isNullOrEmpty()) {
+                    return KarakeepSettings(url, key)
+                }
+            } catch (_: Exception) {}
+
+            // 2. Try Expo SecureStore with known key patterns
+            try {
+                val prefs = context.getSharedPreferences("SecureStore", Context.MODE_PRIVATE)
+                // Check for known Karakeep setting keys first
+                val knownKeys = listOf("karakeep_server", "karakeep_api_key", "serverUrl", "apiKey")
+                var serverUrl: String? = null
+                var apiKey: String? = null
+                for (key in knownKeys) {
+                    prefs.getString(key, null)?.let { value ->
+                        when {
+                            key.contains("server", ignoreCase = true) || key.contains("url", ignoreCase = true) -> serverUrl = value
+                            key.contains("api", ignoreCase = true) || key.contains("key", ignoreCase = true) -> apiKey = value
                         }
                     }
-                } catch (_: Exception) {}
-            }
+                }
+                if (!serverUrl.isNullOrEmpty() && !apiKey.isNullOrEmpty()) {
+                    return KarakeepSettings(serverUrl, apiKey)
+                }
+
+                // 3. Fallback: scan for JSON entries containing both fields
+                for ((_, value) in prefs.all) {
+                    if (value is String && value.contains("apiKey") && value.contains("address")) {
+                        try {
+                            val json = JSONObject(value)
+                            val ak = json.optString("apiKey", "")
+                            val addr = json.optString("address", "")
+                            if (ak.isNotEmpty() && addr.isNotEmpty()) {
+                                return KarakeepSettings(addr, ak)
+                            }
+                        } catch (_: Exception) {}
+                    }
+                }
+            } catch (_: Exception) {}
+
             return null
         }
     }

--- a/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetConfigActivity.kt
+++ b/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetConfigActivity.kt
@@ -1,0 +1,40 @@
+package app.karakeep.widget
+
+import android.app.Activity
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+
+class KarakeepWidgetConfigActivity : Activity() {
+    private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setResult(RESULT_CANCELED)
+        appWidgetId = intent?.extras?.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) { finish(); return }
+        val layout = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL; setPadding(48, 48, 48, 48) }
+        layout.addView(TextView(this).apply { text = "Karakeep Widget Settings"; textSize = 20f; setPadding(0, 0, 0, 32) })
+        layout.addView(TextView(this).apply { text = "Search Query:"; textSize = 14f; setPadding(0, 0, 0, 8) })
+        layout.addView(TextView(this).apply { text = "Examples: -is:archived, is:fav, #tagname"; textSize = 12f; setTextColor(0xFF6B7280.toInt()); setPadding(0, 0, 0, 16) })
+        val queryInput = EditText(this).apply { setText(KarakeepWidgetProvider.DEFAULT_QUERY); hint = "Enter search query..."; setSingleLine(true) }
+        layout.addView(queryInput)
+        layout.addView(Button(this).apply {
+            text = "Save"
+            setPadding(0, 32, 0, 0)
+            setOnClickListener {
+                val query = queryInput.text.toString().trim().ifEmpty { KarakeepWidgetProvider.DEFAULT_QUERY }
+                getSharedPreferences(KarakeepWidgetProvider.PREFS_NAME, Context.MODE_PRIVATE).edit().putString("${KarakeepWidgetProvider.PREF_QUERY_PREFIX}$appWidgetId", query).apply()
+                val mgr = AppWidgetManager.getInstance(this@KarakeepWidgetConfigActivity)
+                updateAppWidget(this@KarakeepWidgetConfigActivity, mgr, appWidgetId)
+                setResult(RESULT_OK, Intent().apply { putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId) })
+                finish()
+            }
+        })
+        setContentView(layout)
+    }
+}

--- a/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetProvider.kt
+++ b/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetProvider.kt
@@ -1,0 +1,127 @@
+package app.karakeep.widget
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.RemoteViews
+import android.app.PendingIntent
+import android.os.Build
+import android.util.Log
+
+/**
+ * Karakeep Android Widget - Displays bookmark search results on the home screen.
+ */
+class KarakeepWidgetProvider : AppWidgetProvider() {
+
+    companion object {
+        private const val TAG = "KarakeepWidget"
+        const val ACTION_ITEM_CLICK = "app.karakeep.widget.ACTION_ITEM_CLICK"
+        const val ACTION_REFRESH = "app.karakeep.widget.ACTION_REFRESH"
+        const val EXTRA_BOOKMARK_URL = "app.karakeep.widget.EXTRA_BOOKMARK_URL"
+        const val EXTRA_BOOKMARK_ID = "app.karakeep.widget.EXTRA_BOOKMARK_ID"
+        const val PREFS_NAME = "KarakeepWidgetPrefs"
+        const val PREF_QUERY_PREFIX = "query_"
+        const val DEFAULT_QUERY = "-is:archived"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        when (intent.action) {
+            ACTION_ITEM_CLICK -> {
+                val url = intent.getStringExtra(EXTRA_BOOKMARK_URL)
+                if (url != null) {
+                    val openIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    try {
+                        context.startActivity(openIntent)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to open URL: $url", e)
+                    }
+                }
+            }
+            ACTION_REFRESH -> {
+                val appWidgetManager = AppWidgetManager.getInstance(context)
+                val componentName = android.content.ComponentName(context, KarakeepWidgetProvider::class.java)
+                val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+                for (appWidgetId in appWidgetIds) {
+                    updateAppWidget(context, appWidgetManager, appWidgetId)
+                }
+            }
+        }
+    }
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        for (appWidgetId in appWidgetIds) {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            prefs.edit().remove("$PREF_QUERY_PREFIX$appWidgetId").apply()
+        }
+    }
+}
+
+internal fun updateAppWidget(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int
+) {
+    val query = getWidgetQuery(context, appWidgetId)
+    val views = RemoteViews(context.packageName, R.layout.widget_karakeep)
+
+    // Set up the list view with RemoteViewsService
+    val intent = Intent(context, KarakeepWidgetRemoteViewsService::class.java).apply {
+        putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        putExtra("query", query)
+        data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
+    }
+    views.setRemoteAdapter(R.id.widget_list_view, intent)
+    views.setEmptyView(R.id.widget_list_view, R.id.widget_empty_text)
+
+    // Set the title
+    views.setTextViewText(R.id.widget_title, "Karakeep")
+    views.setTextViewText(R.id.widget_subtitle, query)
+
+    // Set up refresh button click
+    val refreshIntent = Intent(context, KarakeepWidgetProvider::class.java).apply {
+        action = KarakeepWidgetProvider.ACTION_REFRESH
+    }
+    val refreshPendingIntent = PendingIntent.getBroadcast(
+        context, appWidgetId, refreshIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+    views.setOnClickPendingIntent(R.id.widget_refresh_btn, refreshPendingIntent)
+
+    // Set up item click PendingIntent template
+    val itemClickIntent = Intent(context, KarakeepWidgetProvider::class.java).apply {
+        action = KarakeepWidgetProvider.ACTION_ITEM_CLICK
+    }
+    val itemClickPendingIntent = PendingIntent.getBroadcast(
+        context, 0, itemClickIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+    )
+    views.setPendingIntentTemplate(R.id.widget_list_view, itemClickPendingIntent)
+
+    appWidgetManager.updateAppWidget(appWidgetId, views)
+    appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.widget_list_view)
+}
+
+internal fun getWidgetQuery(context: Context, appWidgetId: Int): String {
+    val prefs = context.getSharedPreferences(
+        KarakeepWidgetProvider.PREFS_NAME, Context.MODE_PRIVATE
+    )
+    return prefs.getString(
+        "${KarakeepWidgetProvider.PREF_QUERY_PREFIX}$appWidgetId",
+        KarakeepWidgetProvider.DEFAULT_QUERY
+    ) ?: KarakeepWidgetProvider.DEFAULT_QUERY
+}

--- a/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetRemoteViewsFactory.kt
+++ b/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetRemoteViewsFactory.kt
@@ -1,0 +1,66 @@
+package app.karakeep.widget
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import org.json.JSONArray
+
+class KarakeepWidgetRemoteViewsFactory(private val context: Context, private val intent: Intent) : RemoteViewsService.RemoteViewsFactory {
+    companion object {
+        private const val TAG = "KarakeepWidgetFactory"
+        private const val MAX_ITEMS = 20
+    }
+    private var bookmarks: List<BookmarkItem> = emptyList()
+
+    data class BookmarkItem(val id: String, val title: String, val url: String?, val domain: String?, val tags: List<String>, val createdAt: String?)
+
+    override fun onCreate() {}
+    override fun onDataSetChanged() {
+        val query = intent.getStringExtra("query") ?: KarakeepWidgetProvider.DEFAULT_QUERY
+        bookmarks = try { fetchBookmarks(query) } catch (e: Exception) { Log.e(TAG, "Failed", e); emptyList() }
+    }
+    override fun onDestroy() { bookmarks = emptyList() }
+    override fun getCount() = bookmarks.size
+    override fun getItemAt(position: Int): RemoteViews? {
+        if (position >= bookmarks.size) return null
+        val bookmark = bookmarks[position]
+        val views = RemoteViews(context.packageName, R.layout.widget_list_item)
+        views.setTextViewText(R.id.item_title, bookmark.title.ifEmpty { bookmark.url ?: "Untitled" })
+        val domainText = bookmark.domain ?: ""
+        views.setTextViewText(R.id.item_domain, domainText)
+        views.setViewVisibility(R.id.item_domain, if (domainText.isNotEmpty()) android.view.View.VISIBLE else android.view.View.GONE)
+        val tagsText = bookmark.tags.take(3).joinToString(" · ") { "#$it" }
+        views.setTextViewText(R.id.item_tags, tagsText)
+        views.setViewVisibility(R.id.item_tags, if (tagsText.isNotEmpty()) android.view.View.VISIBLE else android.view.View.GONE)
+        val fillInIntent = Intent().apply {
+            putExtra(KarakeepWidgetProvider.EXTRA_BOOKMARK_URL, bookmark.url)
+            putExtra(KarakeepWidgetProvider.EXTRA_BOOKMARK_ID, bookmark.id)
+        }
+        views.setOnClickFillInIntent(R.id.item_container, fillInIntent)
+        return views
+    }
+    override fun getLoadingView() = RemoteViews(context.packageName, R.layout.widget_list_item_loading)
+    override fun getViewTypeCount() = 1
+    override fun getItemId(position: Int) = if (position < bookmarks.size) bookmarks[position].id.hashCode().toLong() else position.toLong()
+    override fun hasStableIds() = false
+
+    private fun fetchBookmarks(query: String): List<BookmarkItem> {
+        val settings = KarakeepSettings.read(context) ?: return emptyList()
+        val response = KarakeepApi.searchBookmarks(settings.serverUrl, settings.apiKey, query, MAX_ITEMS) ?: return emptyList()
+        val items = mutableListOf<BookmarkItem>()
+        val array = response.optJSONArray("result")?.optJSONObject(0)?.optJSONObject("result")?.optJSONArray("data") ?: response.optJSONArray("bookmarks") ?: JSONArray()
+        for (i in 0 until array.length()) {
+            val bookmark = array.optJSONObject(i) ?: continue
+            val content = bookmark.optJSONObject("content")
+            val tagsArray = bookmark.optJSONArray("tags")
+            val tags = mutableListOf<String>()
+            if (tagsArray != null) for (j in 0 until tagsArray.length()) tagsArray.optJSONObject(j)?.optString("name")?.let { tags.add(it) }
+            val url = content?.optString("url")
+            val domain = try { url?.let { java.net.URI(it).host } } catch (_: Exception) { null }
+            items.add(BookmarkItem(bookmark.optString("id"), content?.optString("title") ?: bookmark.optString("title") ?: "", url, domain, tags, bookmark.optString("createdAt")))
+        }
+        return items
+    }
+}

--- a/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetRemoteViewsService.kt
+++ b/apps/mobile/native/android-widget/app/src/main/java/app/karakeep/widget/KarakeepWidgetRemoteViewsService.kt
@@ -1,0 +1,10 @@
+package app.karakeep.widget
+
+import android.content.Intent
+import android.widget.RemoteViewsService
+
+class KarakeepWidgetRemoteViewsService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return KarakeepWidgetRemoteViewsFactory(applicationContext, intent)
+    }
+}

--- a/apps/mobile/native/android-widget/app/src/main/res/drawable/widget_background.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/widget_background" />
+    <corners android:radius="16dp" />
+</shape>

--- a/apps/mobile/native/android-widget/app/src/main/res/drawable/widget_item_background.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/drawable/widget_item_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/widget_background_card" />
+    <corners android:radius="8dp" />
+</shape>

--- a/apps/mobile/native/android-widget/app/src/main/res/layout/widget_karakeep.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/layout/widget_karakeep.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent" android:orientation="vertical"
+    android:background="@drawable/widget_background" android:padding="12dp">
+    <RelativeLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginBottom="8dp">
+        <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="vertical"
+            android:layout_alignParentStart="true" android:layout_centerVertical="true" android:layout_toStartOf="@id/widget_refresh_btn">
+            <TextView android:id="@+id/widget_title" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Karakeep" android:textSize="16sp" android:textStyle="bold" android:textColor="@color/widget_text_primary" />
+            <TextView android:id="@+id/widget_subtitle" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="-is:archived" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:maxLines="1" android:ellipsize="end" />
+        </LinearLayout>
+        <ImageView android:id="@+id/widget_refresh_btn" android:layout_width="28dp" android:layout_height="28dp" android:layout_alignParentEnd="true" android:layout_centerVertical="true" android:src="@android:drawable/ic_popup_sync" android:contentDescription="Refresh" android:padding="4dp" android:scaleType="centerInside" android:tint="@color/widget_text_secondary" />
+    </RelativeLayout>
+    <View android:layout_width="match_parent" android:layout_height="1dp" android:background="@color/widget_divider" />
+    <ListView android:id="@+id/widget_list_view" android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:layout_marginTop="4dp" android:divider="@android:color/transparent" android:dividerHeight="4dp" />
+    <TextView android:id="@+id/widget_empty_text" android:layout_width="match_parent" android:layout_height="match_parent" android:gravity="center" android:text="No bookmarks found" android:textSize="13sp" android:textColor="@color/widget_text_secondary" android:visibility="gone" />
+</LinearLayout>

--- a/apps/mobile/native/android-widget/app/src/main/res/layout/widget_list_item.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/layout/widget_list_item.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/item_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@drawable/widget_item_background"
+    android:padding="10dp">
+    <TextView android:id="@+id/item_title" android:layout_width="match_parent" android:layout_height="wrap_content" android:textSize="13sp" android:textStyle="bold" android:textColor="@color/widget_text_primary" android:maxLines="2" android:ellipsize="end" />
+    <TextView android:id="@+id/item_domain" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:maxLines="1" android:ellipsize="end" />
+    <TextView android:id="@+id/item_tags" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="2dp" android:textSize="10sp" android:textColor="@color/widget_accent" android:maxLines="1" android:ellipsize="end" />
+</LinearLayout>

--- a/apps/mobile/native/android-widget/app/src/main/res/layout/widget_list_item_loading.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/layout/widget_list_item_loading.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical" android:padding="10dp" android:background="@drawable/widget_item_background">
+    <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Loading..." android:textSize="13sp" android:textColor="@color/widget_text_secondary" />
+</LinearLayout>

--- a/apps/mobile/native/android-widget/app/src/main/res/values-night/colors.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_background">#FF1C1C1E</color>
+    <color name="widget_background_card">#FF2C2C2E</color>
+    <color name="widget_text_primary">#FFF5F5F5</color>
+    <color name="widget_text_secondary">#FF9CA3AF</color>
+    <color name="widget_divider">#FF374151</color>
+    <color name="widget_accent">#FF818CF8</color>
+</resources>

--- a/apps/mobile/native/android-widget/app/src/main/res/values-night/widget_colors.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/values-night/widget_colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_background">#FF1C1C1E</color>
+    <color name="widget_background_card">#FF2C2C2E</color>
+    <color name="widget_text_primary">#FFF5F5F5</color>
+    <color name="widget_text_secondary">#FF9CA3AF</color>
+    <color name="widget_divider">#FF374151</color>
+    <color name="widget_accent">#FF818CF8</color>
+</resources>

--- a/apps/mobile/native/android-widget/app/src/main/res/values/colors.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/values/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_background">#FFFFFFFF</color>
+    <color name="widget_background_card">#FFF5F5F5</color>
+    <color name="widget_text_primary">#FF111111</color>
+    <color name="widget_text_secondary">#FF6B7280</color>
+    <color name="widget_divider">#FFE5E7EB</color>
+    <color name="widget_accent">#FF6366F1</color>
+</resources>

--- a/apps/mobile/native/android-widget/app/src/main/res/values/strings.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Karakeep</string>
+    <string name="widget_name">Karakeep Bookmarks</string>
+    <string name="widget_description">Display your Karakeep bookmarks on the home screen</string>
+</resources>

--- a/apps/mobile/native/android-widget/app/src/main/res/values/widget_colors.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/values/widget_colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_background">#FFFFFFFF</color>
+    <color name="widget_background_card">#FFF5F5F5</color>
+    <color name="widget_text_primary">#FF111111</color>
+    <color name="widget_text_secondary">#FF6B7280</color>
+    <color name="widget_divider">#FFE5E7EB</color>
+    <color name="widget_accent">#FF6366F1</color>
+</resources>

--- a/apps/mobile/native/android-widget/app/src/main/res/values/widget_strings.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/values/widget_strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="widget_name">Karakeep Bookmarks</string>
+    <string name="widget_description">Display your Karakeep bookmarks on the home screen</string>
+</resources>

--- a/apps/mobile/native/android-widget/app/src/main/res/xml/karakeep_widget_info.xml
+++ b/apps/mobile/native/android-widget/app/src/main/res/xml/karakeep_widget_info.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_karakeep" android:minWidth="250dp" android:minHeight="180dp"
+    android:minResizeWidth="180dp" android:minResizeHeight="120dp" android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" android:updatePeriodMillis="1800000"
+    android:previewLayout="@layout/widget_karakeep" android:description="@string/widget_description"
+    android:configure="app.karakeep.widget.KarakeepWidgetConfigActivity" />

--- a/apps/mobile/plugins/widget.js
+++ b/apps/mobile/plugins/widget.js
@@ -33,8 +33,8 @@ const KOTLIN_FILES = [
 const RESOURCE_FILES = {
   layout: ["widget_karakeep.xml", "widget_list_item.xml", "widget_list_item_loading.xml"],
   xml: ["karakeep_widget_info.xml"],
-  values: ["colors.xml", "strings.xml"],
-  "values-night": ["colors.xml"],
+  values: ["widget_colors.xml", "widget_strings.xml"],
+  "values-night": ["widget_colors.xml"],
   drawable: ["widget_background.xml", "widget_item_background.xml"],
 };
 
@@ -72,7 +72,7 @@ function copyWidgetFiles(config) {
         }
       }
 
-      // Copy resource files
+      // Copy resource files (using widget-prefixed names to avoid overwriting app resources)
       const resDir = path.join(androidProjectRoot, "app", "src", "main", "res");
       for (const [subdir, files] of Object.entries(RESOURCE_FILES)) {
         const targetDir = path.join(resDir, subdir);

--- a/apps/mobile/plugins/widget.js
+++ b/apps/mobile/plugins/widget.js
@@ -1,0 +1,139 @@
+/**
+ * Expo Config Plugin for Karakeep Android Widget
+ *
+ * Adds native Android widget components to the Expo build:
+ * - Copies Kotlin source files to the Android project
+ * - Adds widget layouts and resources
+ * - Registers the AppWidgetProvider in AndroidManifest.xml
+ *
+ * Usage in app.config.js:
+ *   plugins: [
+ *     ["./plugins/widget.js", {}],
+ *   ]
+ */
+
+const {
+  withAndroidManifest,
+  withDangerousMod,
+  AndroidConfig,
+} = require("@expo/config-plugins");
+const path = require("path");
+const fs = require("fs");
+
+const WIDGET_PACKAGE = "app.karakeep.widget";
+
+const KOTLIN_FILES = [
+  "KarakeepWidgetProvider.kt",
+  "KarakeepWidgetRemoteViewsFactory.kt",
+  "KarakeepWidgetRemoteViewsService.kt",
+  "KarakeepWidgetConfigActivity.kt",
+  "KarakeepApi.kt",
+];
+
+const RESOURCE_FILES = {
+  layout: ["widget_karakeep.xml", "widget_list_item.xml", "widget_list_item_loading.xml"],
+  xml: ["karakeep_widget_info.xml"],
+  values: ["colors.xml", "strings.xml"],
+  "values-night": ["colors.xml"],
+  drawable: ["widget_background.xml", "widget_item_background.xml"],
+};
+
+function copyWidgetFiles(config) {
+  return withDangerousMod(config, [
+    "android",
+    (config) => {
+      const projectRoot = config.modRequest.projectRoot;
+      const androidProjectRoot = path.join(projectRoot, "android");
+
+      const widgetSourceDir = path.join(projectRoot, "apps", "mobile", "native", "android-widget");
+      const monorepoSourceDir = path.join(projectRoot, "..", "..", "native", "android-widget");
+
+      const sourceDir = fs.existsSync(widgetSourceDir)
+        ? widgetSourceDir
+        : fs.existsSync(monorepoSourceDir)
+        ? monorepoSourceDir
+        : null;
+
+      if (!sourceDir) {
+        console.warn("[KarakeepWidget] Widget source directory not found, skipping");
+        return config;
+      }
+
+      // Copy Kotlin files
+      const javaDir = path.join(androidProjectRoot, "app", "src", "main", "java", ...WIDGET_PACKAGE.split("."));
+      fs.mkdirSync(javaDir, { recursive: true });
+
+      for (const file of KOTLIN_FILES) {
+        const src = path.join(sourceDir, "app", "src", "main", "java", ...WIDGET_PACKAGE.split("."), file);
+        const dest = path.join(javaDir, file);
+        if (fs.existsSync(src)) {
+          fs.copyFileSync(src, dest);
+          console.log(`[KarakeepWidget] Copied ${file}`);
+        }
+      }
+
+      // Copy resource files
+      const resDir = path.join(androidProjectRoot, "app", "src", "main", "res");
+      for (const [subdir, files] of Object.entries(RESOURCE_FILES)) {
+        const targetDir = path.join(resDir, subdir);
+        fs.mkdirSync(targetDir, { recursive: true });
+        for (const file of files) {
+          const src = path.join(sourceDir, "app", "src", "main", "res", subdir, file);
+          const dest = path.join(targetDir, file);
+          if (fs.existsSync(src)) {
+            fs.copyFileSync(src, dest);
+            console.log(`[KarakeepWidget] Copied res/${subdir}/${file}`);
+          }
+        }
+      }
+
+      return config;
+    },
+  ]);
+}
+
+function addWidgetToManifest(config) {
+  return withAndroidManifest(config, (config) => {
+    const manifest = config.modResults;
+    const mainApplication = AndroidConfig.Manifest.getMainApplication(manifest);
+    if (!mainApplication) return config;
+
+    // Add widget provider receiver
+    if (!mainApplication.receiver) mainApplication.receiver = [];
+    if (!mainApplication.receiver.find((r) => r.$?.["android:name"] === `${WIDGET_PACKAGE}.KarakeepWidgetProvider`)) {
+      mainApplication.receiver.push({
+        $: { "android:name": `${WIDGET_PACKAGE}.KarakeepWidgetProvider`, "android:exported": "true" },
+        "intent-filter": [{ action: [{ $: { "android:name": "android.appwidget.action.APPWIDGET_UPDATE" } }] }],
+        "meta-data": [{ $: { "android:name": "android.appwidget.provider", "android:resource": "@xml/karakeep_widget_info" } }],
+      });
+      console.log("[KarakeepWidget] Added widget provider to manifest");
+    }
+
+    // Add config activity
+    if (!mainApplication.activity) mainApplication.activity = [];
+    if (!mainApplication.activity.find((a) => a.$?.["android:name"] === `${WIDGET_PACKAGE}.KarakeepWidgetConfigActivity`)) {
+      mainApplication.activity.push({
+        $: { "android:name": `${WIDGET_PACKAGE}.KarakeepWidgetConfigActivity`, "android:exported": "true", "android:label": "Widget Settings" },
+        "intent-filter": [{ action: [{ $: { "android:name": "android.appwidget.action.APPWIDGET_CONFIGURE" } }] }],
+      });
+    }
+
+    // Add widget service
+    if (!mainApplication.service) mainApplication.service = [];
+    if (!mainApplication.service.find((s) => s.$?.["android:name"] === `${WIDGET_PACKAGE}.KarakeepWidgetRemoteViewsService`)) {
+      mainApplication.service.push({
+        $: { "android:name": `${WIDGET_PACKAGE}.KarakeepWidgetRemoteViewsService`, "android:exported": "false", "android:permission": "android.permission.BIND_REMOTEVIEWS" },
+      });
+    }
+
+    return config;
+  });
+}
+
+function withKarakeepWidget(config) {
+  config = copyWidgetFiles(config);
+  config = addWidgetToManifest(config);
+  return config;
+}
+
+module.exports = withKarakeepWidget;


### PR DESCRIPTION
## Summary

Implements an Android home screen widget for Karakeep, as requested in #2800.

### Features
- 📱 Home screen widget displaying bookmark search results
- 🔍 Configurable search query (default: -is:archived)
- 📖 Click to open bookmarks in browser
- 🔄 Refresh button for manual updates
- 📐 Resizable (horizontal + vertical)
- 🌗 Light/dark theme support
- 🏷️ Shows title, domain, and tags

### Implementation

**Native Android (Kotlin):**
- `KarakeepWidgetProvider` - AppWidgetProvider
- `KarakeepWidgetRemoteViewsFactory` - bookmark list adapter
- `KarakeepWidgetRemoteViewsService` - RemoteViewsService
- `KarakeepWidgetConfigActivity` - custom query config
- `KarakeepApi` - tRPC REST client

**Expo Integration:**
- `plugins/widget.js` - Expo config plugin (copies files + modifies manifest)

**Resources:**
- Widget layouts, colors (light/dark), strings, drawables

### Usage
Add to `app.config.js`:
```js
plugins: [["./plugins/widget.js", {}]]
```

Closes #2800