### PR TITLE
fix(reader): render math in reader view

### DIFF
--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -109,6 +109,18 @@ function normalizeLazyLoadImages(document: Document): void {
   }
 }
 
+function normalizeMathElements(document: Document): void {
+  const mathElements = document.querySelectorAll("d-math");
+  for (const mathElement of mathElements) {
+    const tex = mathElement.textContent ?? "";
+    const isBlock = mathElement.hasAttribute("block");
+    const replacement = document.createElement(isBlock ? "div" : "span");
+    replacement.className = isBlock ? "math math-display" : "math math-inline";
+    replacement.textContent = tex;
+    mathElement.replaceWith(replacement);
+  }
+}
+
 function extractReadableContent(
   htmlContent: string,
   url: string,
@@ -117,6 +129,7 @@ function extractReadableContent(
   const dom = new JSDOM(htmlContent, { url, virtualConsole });
   try {
     normalizeLazyLoadImages(dom.window.document);
+    normalizeMathElements(dom.window.document);
     const readableContent = new Readability(dom.window.document).parse();
     if (!readableContent || typeof readableContent.content !== "string") {
       return null;

--- a/packages/shared-react/components/BookmarkHtmlHighlighter.tsx
+++ b/packages/shared-react/components/BookmarkHtmlHighlighter.tsx
@@ -7,7 +7,10 @@ import React, {
 } from "react";
 import { cn } from "@/lib/utils";
 import { PopoverAnchor } from "@radix-ui/react-popover";
+import katex from "katex";
 import { Check, Trash2 } from "lucide-react";
+
+import "katex/dist/katex.min.css";
 
 import {
   SUPPORTED_HIGHLIGHT_COLORS,
@@ -167,6 +170,54 @@ const BookmarkHTMLHighlighter = forwardRef<
 
   // Expose the content div ref to parent components
   useImperativeHandle(ref, () => contentRef.current!, []);
+
+  const normalizeMathElements = () => {
+    if (!contentRef.current) {
+      return;
+    }
+
+    const mathElements = contentRef.current.querySelectorAll("d-math");
+    for (const mathElement of mathElements) {
+      const tex = mathElement.textContent ?? "";
+      const isBlock = mathElement.hasAttribute("block");
+      const replacement = document.createElement(isBlock ? "div" : "span");
+      replacement.className = isBlock
+        ? "math math-display"
+        : "math math-inline";
+      replacement.textContent = tex;
+      mathElement.replaceWith(replacement);
+    }
+  };
+
+  const renderMathElements = () => {
+    if (!contentRef.current) {
+      return;
+    }
+
+    const mathElements = contentRef.current.querySelectorAll<HTMLElement>(
+      ".math-inline, .math-display",
+    );
+    for (const mathElement of mathElements) {
+      if (mathElement.dataset.katexRendered === "true") {
+        continue;
+      }
+
+      katex.render(mathElement.textContent ?? "", mathElement, {
+        displayMode: mathElement.classList.contains("math-display"),
+        throwOnError: false,
+      });
+      mathElement.dataset.katexRendered = "true";
+    }
+  };
+
+  useEffect(() => {
+    if (!contentRef.current) {
+      return;
+    }
+
+    normalizeMathElements();
+    renderMathElements();
+  }, [htmlContent]);
 
   const [menuPosition, setMenuPosition] = useState<{
     x: number;

--- a/packages/shared-react/katex-css.d.ts
+++ b/packages/shared-react/katex-css.d.ts
@@ -1,0 +1,1 @@
+declare module "katex/dist/katex.min.css";

--- a/packages/shared-react/package.json
+++ b/packages/shared-react/package.json
@@ -14,6 +14,7 @@
     "@trpc/tanstack-react-query": "^11.9.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "katex": "^0.16.25",
     "lucide-react": "^0.501.0",
     "superjson": "^2.2.1",
     "tailwind-merge": "^2.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1396,6 +1396,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      katex:
+        specifier: ^0.16.25
+        version: 0.16.47
       lucide-react:
         specifier: ^0.501.0
         version: 0.501.0(react@19.2.3)
@@ -11499,6 +11502,10 @@ packages:
 
   jsonrepair@3.13.3:
     resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
+    hasBin: true
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
   keyv@4.5.4:
@@ -29247,6 +29254,10 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonrepair@3.13.3: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
## Summary
- Normalize Distill-style `<d-math>` elements into inline/block math containers during readable-content extraction.
- Render saved reader-view math containers with KaTeX.
- Add the KaTeX dependency and CSS module declaration for the shared React package.

## Test Plan
- `node node_modules/typescript/bin/tsc -p packages/shared-react/tsconfig.json --noEmit --pretty false`
- `node node_modules/typescript/bin/tsc -p apps/workers/tsconfig.json --noEmit --pretty false`
- `node node_modules/oxlint/bin/oxlint packages/shared-react/components/BookmarkHtmlHighlighter.tsx apps/workers/scripts/parseHtmlSubprocess.ts`
- `node node_modules/oxfmt/bin/oxfmt --check packages/shared-react/components/BookmarkHtmlHighlighter.tsx apps/workers/scripts/parseHtmlSubprocess.ts packages/shared-react/package.json packages/shared-react/katex-css.d.ts`

Fixes #1243
