### PR TITLE
feat(cli): add --description flag to bookmarks update command

### DIFF
--- a/apps/cli/src/commands/bookmarks.ts
+++ b/apps/cli/src/commands/bookmarks.ts
@@ -361,6 +361,10 @@ bookmarkCmd
   .option("--no-archive", "if set, the bookmark will be unarchived")
   .option("--favourite", "if set, the bookmark will be favourited")
   .option("--no-favourite", "if set, the bookmark will be unfavourited")
+  .option(
+    "--description <description>",
+    "if set, the bookmark's description will be updated",
+  )
   .argument("<id>", "the id of the bookmark to update")
   .action(async (id, opts) => {
     const api = getAPIClient();
@@ -371,6 +375,7 @@ bookmarkCmd
         favourited: opts.favourite,
         title: opts.title,
         note: opts.note,
+        description: opts.description,
       })
       .then(printObject)
       .catch(printError(`Failed to update bookmark with id "${id}"`));


### PR DESCRIPTION
## Description

Adds `--description` flag to the `karakeep bookmarks update` CLI command, allowing users to update a bookmark's description field directly from the CLI.

This completes the CLI automation path for bookmark enrichment — tags can already be updated via `update-tags`, and now description can be updated too without falling back to raw API calls.

Fixes #2816

## How Has This Been Tested?

- [x] `karakeep bookmarks update <id> --description "..."` updates the description
- [x] `karakeep bookmarks get <id>` reflects the updated description
- [x] Web UI shows the updated description field (not the note field)

<summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="894" height="806" alt="Screenshot from 2026-05-31 02-14-35" src="https://github.com/user-attachments/assets/a2379a4d-38ab-4354-ab73-14701cfa31dc" />

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (claude.ai) was used as a coding assistant to help structure the PR description only. As the implementation itself is a one-line change following the existing pattern in the codebase.