### PR TITLE
Fix BROWSER_WEB_URL IPv6 host resolution

### DIFF
--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -73,6 +73,7 @@ import {
 } from "@karakeep/shared/assetdb";
 import serverConfig from "@karakeep/shared/config";
 import logger from "@karakeep/shared/logger";
+import { setUrlHostnameFromResolvedAddress } from "@karakeep/shared/utils/url";
 import {
   DequeuedJob,
   DequeuedJobError,
@@ -281,7 +282,7 @@ async function startBrowserInstance() {
 
     const webUrl = new URL(serverConfig.crawler.browserWebUrl);
     const { address } = await dns.promises.lookup(webUrl.hostname);
-    webUrl.hostname = address;
+    setUrlHostnameFromResolvedAddress(webUrl, address);
     logger.info(
       `[Crawler] Successfully resolved IP address, new address: ${redactUrlCredentials(webUrl.toString())}`,
     );

--- a/packages/shared/utils/url.test.ts
+++ b/packages/shared/utils/url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { setUrlHostnameFromResolvedAddress } from "./url";
+
+describe("setUrlHostnameFromResolvedAddress", () => {
+  it("sets IPv4 addresses as URL hostnames", () => {
+    const url = new URL("http://chrome:9222");
+
+    setUrlHostnameFromResolvedAddress(url, "172.18.0.3");
+
+    expect(url.toString()).toBe("http://172.18.0.3:9222/");
+    expect(url.hostname).toBe("172.18.0.3");
+  });
+
+  it("brackets IPv6 addresses before assigning them to URL hostnames", () => {
+    const url = new URL("http://chrome:9222");
+
+    setUrlHostnameFromResolvedAddress(url, "fd3a:d485:7e1d:e::3");
+
+    expect(url.toString()).toBe("http://[fd3a:d485:7e1d:e::3]:9222/");
+    expect(url.hostname).toBe("[fd3a:d485:7e1d:e::3]");
+  });
+
+  it("preserves the existing path and query", () => {
+    const url = new URL("http://chrome:9222/json/version?check=true");
+
+    setUrlHostnameFromResolvedAddress(url, "fd3a:d485:7e1d:e::3");
+
+    expect(url.toString()).toBe(
+      "http://[fd3a:d485:7e1d:e::3]:9222/json/version?check=true",
+    );
+  });
+});

--- a/packages/shared/utils/url.ts
+++ b/packages/shared/utils/url.ts
@@ -1,0 +1,3 @@
+export function setUrlHostnameFromResolvedAddress(url: URL, address: string) {
+  url.hostname = address.includes(":") ? `[${address}]` : address;
+}

--- a/packages/trpc/routers/admin.ts
+++ b/packages/trpc/routers/admin.ts
@@ -30,6 +30,7 @@ import {
   zAdminCreateUserSchema,
 } from "@karakeep/shared/types/admin";
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
+import { setUrlHostnameFromResolvedAddress } from "@karakeep/shared/utils/url";
 import { getVectorStoreClient } from "@karakeep/shared/vectorStore";
 
 import { generatePasswordSalt, hashPassword } from "../auth";
@@ -663,7 +664,7 @@ export const adminAppRouter = router({
           if (serverConfig.crawler.browserWebUrl) {
             const webUrl = new URL(serverConfig.crawler.browserWebUrl);
             const { address } = await dns.promises.lookup(webUrl.hostname);
-            webUrl.hostname = address;
+            setUrlHostnameFromResolvedAddress(webUrl, address);
             webUrl.pathname = "/json/version";
             const response = await fetch(`${webUrl.toString()}`, {
               signal: AbortSignal.timeout(5000),


### PR DESCRIPTION
Fixes #2766.

## Summary

- Add a small shared helper for assigning DNS-resolved addresses back into `URL.hostname`.
- Bracket IPv6 literals before assignment so WHATWG URL accepts them instead of silently leaving the hostname unchanged.
- Use the helper in both the crawler CDP connection path and the admin browser status check.
- Add focused coverage for IPv4, IPv6, and path/query preservation.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @karakeep/shared exec vitest run utils/url.test.ts`
- `pnpm --filter @karakeep/shared run typecheck`
- `pnpm --filter @karakeep/shared run lint`
- `pnpm --filter @karakeep/shared run format`
- `pnpm --filter @karakeep/workers run typecheck`
- `pnpm --filter @karakeep/workers run lint`
- `pnpm --filter @karakeep/workers run format`
- `pnpm --filter @karakeep/trpc run typecheck`
- `pnpm --filter @karakeep/trpc run lint`
- `pnpm --filter @karakeep/trpc run format`
- Commit hook ran `turbo run --no-daemon typecheck lint format` successfully.

## LLM disclosure

Codex was used to help identify the duplicate URL-host assignment path, implement the patch, and prepare the PR text. I reviewed the diff and ran the validation above.