### PR TITLE
Fix screenshot preview scrolling

### DIFF
--- a/apps/web/components/dashboard/preview/LinkContentSection.tsx
+++ b/apps/web/components/dashboard/preview/LinkContentSection.tsx
@@ -77,7 +77,7 @@ function FullPageArchiveSection({ link }: { link: ZBookmarkedLink }) {
 
 function ScreenshotSection({ link }: { link: ZBookmarkedLink }) {
   return (
-    <div className="relative h-full min-w-full">
+    <div className="relative h-full min-w-full overflow-y-auto overflow-x-hidden">
       <Image
         alt="screenshot"
         src={`/api/assets/${link.screenshotAssetId}`}


### PR DESCRIPTION
Fixes #2817.

## Summary

- makes the screenshot preview pane vertically scrollable when a screenshot is taller than the preview viewport
- keeps horizontal overflow hidden so wide screenshots still fit the existing preview layout

## Before / After

- Before: long screenshots could be clipped inside the previewer with no scrollbar.
- After: the screenshot section owns its vertical overflow, so long screenshots can be scrolled without changing the other preview modes.

## Validation

- `pnpm exec oxfmt --ignore-path=.gitignore --check apps/web/components/dashboard/preview/LinkContentSection.tsx`
- `pnpm --filter @karakeep/web run lint`
- `pnpm --filter @karakeep/web run typecheck`
- `TZ=UTC pnpm --filter @karakeep/web run test -- --run`
- `git diff --check upstream/main...HEAD`
- pre-commit hook: `turbo run --no-daemon typecheck lint format`
