### PR TITLE
Easy clipboard saving

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
@@ -100,8 +100,17 @@ function useNewBookmarkActions(openNewBookmarkModal: () => void) {
           return;
         }
 
-        sonnerToast.loading("Processing...", { id: toastId });
-        const isUrl = /^[a-z]+:\/\//i.test(contents);
+        let isUrl = false;
+        try {
+          const parsed = new URL(contents);
+          if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+            isUrl = true;
+            sonnerToast.loading("Saving URL...", { id: toastId });
+          }
+        } catch {
+          // not a valid URL — treat as text
+          sonnerToast.loading("Saving text...", { id: toastId });
+        }
 
         const resp = await (isUrl
           ? createBookmark.mutateAsync({

--- a/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { Platform, PlatformColor, View } from "react-native";
 import * as Haptics from "expo-haptics";
 import * as ImagePicker from "expo-image-picker";
+import * as Clipboard from "expo-clipboard";
 import { router } from "expo-router";
 import BookmarkListHeader from "@/components/bookmarks/BookmarkListHeader";
 import UpdatingBookmarkList from "@/components/bookmarks/UpdatingBookmarkList";
@@ -15,11 +16,15 @@ import { useMenuIconColors } from "@/lib/useMenuIconColors";
 import { MenuView } from "@react-native-menu/menu";
 import { Plus } from "lucide-react-native";
 import { toast as sonnerToast } from "sonner-native";
+import { useCreateBookmark } from "@karakeep/shared-react/hooks/bookmarks";
+import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
 
 function useNewBookmarkActions(openNewBookmarkModal: () => void) {
   const { settings } = useAppSettings();
   const { menuIconColor } = useMenuIconColors();
   const uploadToastIdRef = useRef<string | number | null>(null);
+  const createBookmark = useCreateBookmark();
+
   const { uploadAsset } = useUploadAsset(settings, {
     onSuccess: () => {
       if (uploadToastIdRef.current !== null) {
@@ -84,10 +89,50 @@ function useNewBookmarkActions(openNewBookmarkModal: () => void) {
           sonnerToast.error("Failed to open photo library");
         }
       }
+    } else if (nativeEvent.event === "clipboard") {
+      if (createBookmark.isPending) return;
+
+      const toastId = sonnerToast.loading("Reading clipboard...");
+      try {
+        const contents = (await Clipboard.getStringAsync()).trim();
+        if (!contents) {
+          sonnerToast.error("Clipboard is empty", { id: toastId });
+          return;
+        }
+
+        sonnerToast.loading("Processing...", { id: toastId });
+        const isUrl = /^[a-z]+:\/\//i.test(contents);
+
+        const resp = await (isUrl
+          ? createBookmark.mutateAsync({
+              type: BookmarkTypes.LINK,
+              url: new URL(contents).toString(),
+              source: "mobile",
+            })
+          : createBookmark.mutateAsync({
+              type: BookmarkTypes.TEXT,
+              text: contents,
+              source: "mobile",
+            }));
+        sonnerToast.success(resp.alreadyExists ? "Already exists" : "Saved!", {
+          id: toastId,
+        });
+      } catch (e) {
+        sonnerToast.error(
+          e instanceof Error ? e.message : "Failed to save from clipboard",
+          { id: toastId },
+        );
+      }
     }
   };
 
   const actions = [
+    {
+      id: "clipboard",
+      title: "Clipboard",
+      image: Platform.select({ ios: "clipboard" }),
+      imageColor: Platform.select({ ios: menuIconColor }),
+    },
     {
       id: "new",
       title: "New Bookmark",


### PR DESCRIPTION
## Description



<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds a convenient button to auto-add URLS from the clipboard through _**expo-clipboard**_.
Makes it a lot faster, easier, and intuitive than older workflow. Fixes #1882 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Tested in Simulator on Ipad Mini, Iphone 16 Pro with personal Karakeep instance I self-host
- Items visible on regular web UI of my self-hosted instance.
- To reproduce, copy a link then click "+" and then new option "Clipboard"
- Passed linter, used formatter

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="173" height="115" alt="image" src="https://github.com/user-attachments/assets/bebcb277-f89c-446e-91eb-3b797ee91519" />

https://github.com/user-attachments/assets/711ea64e-b892-4850-a458-b5a4f8a31b66


</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I found the code location and added the button. AI was used to implement the logic, which i rewrote for clarity. Then tested on simulator.
