### PR TITLE
feat(workers): implement Reddit OAuth client credentials flow to bypa…

### DIFF
--- a/apps/workers/metascraper-plugins/metascraper-reddit.ts
+++ b/apps/workers/metascraper-plugins/metascraper-reddit.ts
@@ -4,6 +4,7 @@ import { decode as decodeHtmlEntities } from "html-entities";
 import { fetchWithProxy } from "network";
 import { z } from "zod";
 
+import serverConfig from "@karakeep/shared/config";
 import logger from "@karakeep/shared/logger";
 
 /**
@@ -105,11 +106,60 @@ const decodeRedditUrl = (url?: string): string | undefined => {
   return decoded || undefined;
 };
 
-const buildJsonUrl = (url: string): string => {
+let redditAccessToken: string | null = null;
+let redditAccessTokenExpiresAt: number = 0;
+
+const getRedditAccessToken = async (): Promise<string | null> => {
+  const { clientId, clientSecret } = serverConfig.reddit;
+  if (!clientId || !clientSecret) {
+    return null;
+  }
+
+  const now = Date.now();
+  if (redditAccessToken && redditAccessTokenExpiresAt > now) {
+    return redditAccessToken;
+  }
+
+  try {
+    const response = await fetchWithProxy("https://www.reddit.com/api/v1/access_token", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        "User-Agent": "KarakeepBot/1.0",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: "grant_type=client_credentials",
+    });
+
+    if (!response.ok) {
+      logger.warn(`[MetascraperReddit] Failed to obtain access token: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { access_token: string; expires_in: number };
+    if (!data.access_token) {
+      return null;
+    }
+
+    redditAccessToken = data.access_token;
+    // Expire 5 minutes before the actual expiration to be safe
+    redditAccessTokenExpiresAt = now + (data.expires_in - 300) * 1000;
+    return redditAccessToken;
+  } catch (error) {
+    logger.warn("[MetascraperReddit] Error obtaining access token", error);
+    return null;
+  }
+};
+
+const buildJsonUrl = (url: string, useOauth: boolean): string => {
   const urlObj = new URL(url);
 
   if (!urlObj.pathname.endsWith(".json")) {
     urlObj.pathname = urlObj.pathname.replace(/\/?$/, ".json");
+  }
+
+  if (useOauth) {
+    urlObj.hostname = "oauth.reddit.com";
   }
 
   return urlObj.toString();
@@ -221,9 +271,12 @@ const fetchRedditPostData = async (url: string): Promise<RedditFetchResult> => {
   }
 
   const promise = (async () => {
+    const accessToken = await getRedditAccessToken();
+    const useOauth = !!accessToken;
+
     let jsonUrl: string;
     try {
-      jsonUrl = buildJsonUrl(url);
+      jsonUrl = buildJsonUrl(url, useOauth);
     } catch (error) {
       logger.warn(
         "[MetascraperReddit] Failed to construct Reddit JSON URL",
@@ -234,9 +287,13 @@ const fetchRedditPostData = async (url: string): Promise<RedditFetchResult> => {
 
     let response;
     try {
-      response = await fetchWithProxy(jsonUrl, {
-        headers: { accept: "application/json" },
-      });
+      const headers: Record<string, string> = { accept: "application/json" };
+      if (accessToken) {
+        headers["Authorization"] = `Bearer ${accessToken}`;
+        headers["User-Agent"] = "KarakeepBot/1.0";
+      }
+      
+      response = await fetchWithProxy(jsonUrl, { headers });
     } catch (error) {
       logger.warn(
         `[MetascraperReddit] Failed to fetch Reddit JSON for ${jsonUrl}`,

--- a/apps/workers/metascraper-plugins/metascraper-reddit.ts
+++ b/apps/workers/metascraper-plugins/metascraper-reddit.ts
@@ -108,6 +108,7 @@ const decodeRedditUrl = (url?: string): string | undefined => {
 
 let redditAccessToken: string | null = null;
 let redditAccessTokenExpiresAt: number = 0;
+let redditAccessTokenPromise: Promise<string | null> | null = null;
 
 const getRedditAccessToken = async (): Promise<string | null> => {
   const { clientId, clientSecret } = serverConfig.reddit;
@@ -120,35 +121,45 @@ const getRedditAccessToken = async (): Promise<string | null> => {
     return redditAccessToken;
   }
 
-  try {
-    const response = await fetchWithProxy("https://www.reddit.com/api/v1/access_token", {
-      method: "POST",
-      headers: {
-        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-        "User-Agent": "KarakeepBot/1.0",
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: "grant_type=client_credentials",
-    });
-
-    if (!response.ok) {
-      logger.warn(`[MetascraperReddit] Failed to obtain access token: ${response.status}`);
-      return null;
-    }
-
-    const data = (await response.json()) as { access_token: string; expires_in: number };
-    if (!data.access_token) {
-      return null;
-    }
-
-    redditAccessToken = data.access_token;
-    // Expire 5 minutes before the actual expiration to be safe
-    redditAccessTokenExpiresAt = now + (data.expires_in - 300) * 1000;
-    return redditAccessToken;
-  } catch (error) {
-    logger.warn("[MetascraperReddit] Error obtaining access token", error);
-    return null;
+  if (redditAccessTokenPromise) {
+    return redditAccessTokenPromise;
   }
+
+  redditAccessTokenPromise = (async () => {
+    try {
+      const response = await fetchWithProxy("https://www.reddit.com/api/v1/access_token", {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+          "User-Agent": "KarakeepBot/1.0",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: "grant_type=client_credentials",
+      });
+
+      if (!response.ok) {
+        logger.warn(`[MetascraperReddit] Failed to obtain access token: ${response.status}`);
+        return null;
+      }
+
+      const data = (await response.json()) as { access_token: string; expires_in: number };
+      if (!data.access_token) {
+        return null;
+      }
+
+      redditAccessToken = data.access_token;
+      // Expire 5 minutes before the actual expiration to be safe
+      redditAccessTokenExpiresAt = now + Math.max(0, data.expires_in - 300) * 1000;
+      return redditAccessToken;
+    } catch (error) {
+      logger.warn("[MetascraperReddit] Error obtaining access token", error);
+      return null;
+    } finally {
+      redditAccessTokenPromise = null;
+    }
+  })();
+
+  return redditAccessTokenPromise;
 };
 
 const buildJsonUrl = (url: string, useOauth: boolean): string => {

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -198,6 +198,10 @@ const allEnv = z.object({
   PAID_QUOTA_ASSET_SIZE_BYTES: z.coerce.number().optional(),
   PAID_BROWSER_CRAWLING_ENABLED: optionalStringBool(),
 
+  // Reddit configuration
+  REDDIT_CLIENT_ID: z.string().optional(),
+  REDDIT_CLIENT_SECRET: z.string().optional(),
+
   // Proxy configuration
   CRAWLER_HTTP_PROXY: z
     .string()
@@ -469,6 +473,10 @@ const serverConfigSchema = allEnv.transform((val, ctx) => {
         assetSizeBytes: val.PAID_QUOTA_ASSET_SIZE_BYTES ?? null,
         browserCrawlingEnabled: val.PAID_BROWSER_CRAWLING_ENABLED ?? null,
       },
+    },
+    reddit: {
+      clientId: val.REDDIT_CLIENT_ID,
+      clientSecret: val.REDDIT_CLIENT_SECRET,
     },
     database: {
       walMode: val.DB_WAL_MODE,


### PR DESCRIPTION
## Description

Fixes #2885

Reddit has recently updated their crawler policies, causing our unauthenticated `.json` requests to frequently get blocked. 

To resolve this, this PR implements the official Reddit OAuth Client Credentials flow for the `metascraper-reddit` plugin. 

Specifically:
- Added optional `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` environment variables to `serverConfig`.
- The scraper now fetches an access token and uses an in-memory cache (with a 5-minute safety buffer before expiration) to avoid rate limits on the authentication endpoint.
- If the credentials are provided, requests are routed through `oauth.reddit.com` using the `Bearer` token and a custom `User-Agent`.
- If credentials are not configured, it gracefully falls back to the previous unauthenticated `.json` polling, ensuring the change is fully backward-compatible.

## How Has This Been Tested?

- [x] Verified that if `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` are not present, it correctly falls back to unauthenticated `.json` requests.
- [x] Verified that when credentials are provided, the system correctly fetches a token, routes the request to `oauth.reddit.com`, and successfully fetches the Reddit metadata without being blocked.
- [x] Verified that the token cache correctly caches the token and reuses it until expiration.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I collaborated with an AI coding assistant to help design the caching logic and integrate the standard OAuth Client Credentials flow.