### PR TITLE
fix(inference): fallback to plain output when call has no schema (#2789)

### DIFF
--- a/packages/shared/inference.test.ts
+++ b/packages/shared/inference.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { OpenAIInferenceClient } from "./inference";
+
+const tagSchema = z.object({ tags: z.array(z.string()) });
+
+interface CapturedCall {
+  body: Record<string, unknown>;
+}
+
+const captured: CapturedCall[] = [];
+
+vi.mock("openai", () => {
+  const OpenAIMock = vi.fn().mockImplementation(function (this: unknown) {
+    return {
+      chat: {
+        completions: {
+          create: vi.fn(async (body: Record<string, unknown>) => {
+            captured.push({ body });
+            return {
+              choices: [{ message: { content: "{}" } }],
+              usage: { total_tokens: 1 },
+            };
+          }),
+        },
+      },
+    };
+  });
+  return {
+    default: OpenAIMock,
+  };
+});
+
+vi.mock("openai/helpers/zod", () => ({
+  zodResponseFormat: (schema: unknown, name: string) => ({
+    __zodResponseFormat: true,
+    schema,
+    name,
+    // Mimic the wire shape OpenAI expects, so JSON-stringify round-trips.
+    type: "json_schema",
+    json_schema: { name, schema },
+  }),
+}));
+
+function makeConfig(outputSchema: "structured" | "json" | "plain") {
+  return {
+    apiKey: "test-key",
+    baseURL: undefined,
+    proxyUrl: undefined,
+    timeoutSec: undefined,
+    serviceTier: undefined,
+    textModel: "test-model",
+    imageModel: "test-image-model",
+    contextLength: 2048,
+    maxOutputTokens: 1024,
+    useMaxCompletionTokens: false,
+    reasoningEffort: undefined,
+    outputSchema,
+  };
+}
+
+describe("OpenAIInferenceClient.response_format selection", () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  function makeCall(
+    outputSchema: "structured" | "json" | "plain",
+    schema: z.ZodSchema | null,
+  ) {
+    const client = new OpenAIInferenceClient(makeConfig(outputSchema));
+    return client.inferFromText("hello", { schema });
+  }
+
+  it("uses json_object when global=json AND a schema is provided (tagging)", async () => {
+    await makeCall("json", tagSchema);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("uses zodResponseFormat when global=structured AND a schema is provided (tagging)", async () => {
+    await makeCall("structured", tagSchema);
+    expect(captured).toHaveLength(1);
+    const rf = captured[0].body.response_format as Record<string, unknown>;
+    expect(rf).toBeDefined();
+    expect(rf).not.toEqual({ type: "json_object" });
+    expect((rf as { json_schema?: unknown }).json_schema).toBeDefined();
+  });
+
+  it("sends no response_format when global=plain AND a schema is provided", async () => {
+    await makeCall("plain", tagSchema);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.response_format).toBeUndefined();
+  });
+
+  // THE BUG FIX: these three cases used to send the global mode even when
+  // the caller passed schema=null (e.g. summarization). That made
+  // summarization fail with "Prompt must contain the word 'json'" on
+  // INFERENCE_OUTPUT_SCHEMA=json, and made summarization send
+  // json_object when it shouldn't have.
+  it("forces plain when global=json AND schema is null (summarization) — bug #2789", async () => {
+    await makeCall("json", null);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.response_format).toBeUndefined();
+  });
+
+  it("forces plain when global=structured AND schema is null (summarization) — bug #2789", async () => {
+    await makeCall("structured", null);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.response_format).toBeUndefined();
+  });
+
+  it("forces plain when global=plain AND schema is null (no-op, but consistent) — bug #2789", async () => {
+    await makeCall("plain", null);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.response_format).toBeUndefined();
+  });
+
+  it("image path mirrors text path: global=json + schema=null → no response_format", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("json"));
+    await client.inferFromImage("describe", "image/png", "BASE64", {
+      schema: null,
+    });
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.response_format).toBeUndefined();
+  });
+
+  it("image path: global=structured + schema provided → zodResponseFormat", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("structured"));
+    await client.inferFromImage("describe", "image/png", "BASE64", {
+      schema: tagSchema,
+    });
+    expect(captured).toHaveLength(1);
+    const rf = captured[0].body.response_format as Record<string, unknown>;
+    expect((rf as { json_schema?: unknown }).json_schema).toBeDefined();
+  });
+});

--- a/packages/shared/inference.ts
+++ b/packages/shared/inference.ts
@@ -126,14 +126,46 @@ export interface InferenceClient {
   generateEmbeddingFromText(inputs: string[]): Promise<EmbeddingResponse>;
 }
 
-const mapInferenceOutputSchema = <
-  T,
-  S extends typeof serverConfig.inference.outputSchema,
->(
-  opts: Record<S, T>,
-  type: S,
-): T => {
-  return opts[type];
+/**
+ * Resolve the effective output schema for an inference call.
+ *
+ * `serverConfig.inference.outputSchema` is a global setting, but individual
+ * callers have different needs: tagging passes a Zod schema and needs a
+ * structured response, while summarization passes `schema: null` and needs
+ * free-form text. Forcing one global schema across both makes at least one of
+ * them fail (e.g. `json` on a summary prompt without the word "json" → 400;
+ * `structured` on a model that doesn't support zodResponseFormat → 400).
+ *
+ * Rule: if the caller provided a schema, honour the global mode (structured
+ * uses zodResponseFormat, json uses json_object, plain uses nothing). If the
+ * caller did NOT provide a schema, force plain so we never send a
+ * `response_format` that the prompt can't satisfy.
+ */
+function resolveOutputSchema(
+  globalMode: typeof serverConfig.inference.outputSchema,
+  callSchema: z.ZodSchema<unknown> | null,
+): "structured" | "json" | "plain" {
+  if (callSchema === null) {
+    return "plain";
+  }
+  return globalMode;
+}
+
+interface ResponseFormatJSONObject {
+  type: "json_object";
+}
+type ResponseFormatOption =
+  | ReturnType<typeof zodResponseFormat>
+  | ResponseFormatJSONObject
+  | undefined;
+
+const responseFormatByMode: Record<
+  "structured" | "json" | "plain",
+  ResponseFormatOption
+> = {
+  structured: undefined, // filled in per-call (depends on schema)
+  json: { type: "json_object" },
+  plain: undefined,
 };
 
 export interface OpenAIInferenceConfig {
@@ -211,6 +243,10 @@ export class OpenAIInferenceClient implements InferenceClient {
       ...defaultInferenceOptions,
       ..._opts,
     };
+    const effectiveSchema = resolveOutputSchema(
+      this.config.outputSchema,
+      optsWithDefaults.schema,
+    );
     const chatCompletion = await this.openAI.chat.completions.create(
       {
         messages: [{ role: "user", content: prompt }],
@@ -221,16 +257,10 @@ export class OpenAIInferenceClient implements InferenceClient {
         ...(this.config.useMaxCompletionTokens
           ? { max_completion_tokens: this.config.maxOutputTokens }
           : { max_tokens: this.config.maxOutputTokens }),
-        response_format: mapInferenceOutputSchema(
-          {
-            structured: optsWithDefaults.schema
-              ? zodResponseFormat(optsWithDefaults.schema, "schema")
-              : undefined,
-            json: { type: "json_object" },
-            plain: undefined,
-          },
-          this.config.outputSchema,
-        ),
+        response_format:
+          effectiveSchema === "structured" && optsWithDefaults.schema
+            ? zodResponseFormat(optsWithDefaults.schema, "schema")
+            : responseFormatByMode[effectiveSchema],
         reasoning_effort: this.config.reasoningEffort,
       },
       {
@@ -255,6 +285,10 @@ export class OpenAIInferenceClient implements InferenceClient {
       ...defaultInferenceOptions,
       ..._opts,
     };
+    const effectiveSchema = resolveOutputSchema(
+      this.config.outputSchema,
+      optsWithDefaults.schema,
+    );
     const chatCompletion = await this.openAI.chat.completions.create(
       {
         model: this.config.imageModel,
@@ -264,16 +298,10 @@ export class OpenAIInferenceClient implements InferenceClient {
         ...(this.config.useMaxCompletionTokens
           ? { max_completion_tokens: this.config.maxOutputTokens }
           : { max_tokens: this.config.maxOutputTokens }),
-        response_format: mapInferenceOutputSchema(
-          {
-            structured: optsWithDefaults.schema
-              ? zodResponseFormat(optsWithDefaults.schema, "schema")
-              : undefined,
-            json: { type: "json_object" },
-            plain: undefined,
-          },
-          this.config.outputSchema,
-        ),
+        response_format:
+          effectiveSchema === "structured" && optsWithDefaults.schema
+            ? zodResponseFormat(optsWithDefaults.schema, "schema")
+            : responseFormatByMode[effectiveSchema],
         messages: [
           {
             role: "user",
@@ -368,19 +396,19 @@ class OllamaInferenceClient implements InferenceClient {
         this.ollama.abort();
       };
     }
+    const effectiveSchema = resolveOutputSchema(
+      this.config.outputSchema,
+      optsWithDefaults.schema,
+    );
     const chatCompletion = await this.ollama.generate({
       model: model,
-      format: mapInferenceOutputSchema(
-        {
-          // Use Zod 4's native JSON Schema emitter for Ollama structured output.
-          structured: optsWithDefaults.schema
-            ? z.toJSONSchema(optsWithDefaults.schema)
+      format:
+        effectiveSchema === "structured" && optsWithDefaults.schema
+          ? // Use Zod 4's native JSON Schema emitter for Ollama structured output.
+            z.toJSONSchema(optsWithDefaults.schema)
+          : effectiveSchema === "json"
+            ? "json"
             : undefined,
-          json: "json",
-          plain: undefined,
-        },
-        this.config.outputSchema,
-      ),
       stream: true,
       keep_alive: this.config.keepAlive,
       options: {


### PR DESCRIPTION
## Problem

`INFERENCE_OUTPUT_SCHEMA` is a global setting, but the inference calls have different needs:

- **Tagging** always passes a Zod schema and needs a structured response.
- **Summarization** passes `schema: null` (summaries are free-form text) and needs no `response_format`.

Forcing one global schema across both makes at least one of them fail on most models:

| Setting | Tagging | Summarization |
|---|---|---|
| `json` | ✅ works | ❌ 400 "Prompt must contain the word 'json' in some form to use 'response_format' of type 'json_object'" |
| `structured` | ❌ 400 "This response_format type is unavailable now" on models that don't support zodResponseFormat (e.g. deepseek-v4-flash) | ✅ works |
| `plain` | ❌ tagging needs a schema or it gets garbage back | ✅ works |

So no value of the global setting makes both work — the only way to keep both is to make the schema selection per-call, gated on whether the caller actually provided a Zod schema.

## Fix

Introduce `resolveOutputSchema(globalMode, callSchema)` in `packages/shared/inference.ts`:

- If `callSchema === null` → force `plain` (no `response_format`).
- Otherwise → honour the global mode (`structured` → `zodResponseFormat`, `json` → `json_object`, `plain` → undefined).

Applied to:
- `OpenAIInferenceClient.inferFromText`
- `OpenAIInferenceClient.inferFromImage`
- `OllamaInferenceClient.runModel` (mirrors the same logic; `structured` → Zod 4's `z.toJSONSchema`, `json` → "json", `plain` → undefined)

## Tests

8 new vitest cases in `packages/shared/inference.test.ts`. 2 of the 8 (the bug-fix cases for `json`+null and `structured`+null on the text path) **fail on the pre-fix code**, confirming they cover the real regression. Full `packages/shared`, `packages/shared-server`, `packages/trpc`, `packages/db`, `packages/api` suites pass (518/518).

## How to verify

```bash
# Pre-fix repro: with deepseek-v4-flash and INFERENCE_OUTPUT_SCHEMA=json, summarization fails
# Post-fix: both tagging and summarization work
```