### PR TITLE
fix(assets): allow video asset playback

### DIFF
--- a/apps/workers/workers/videoWorker.ts
+++ b/apps/workers/workers/videoWorker.ts
@@ -199,11 +199,13 @@ async function runWorker(job: DequeuedJob<ZVideoRequest>) {
       fileSize,
     );
 
+    const contentType = getVideoContentType(assetPath);
+
     await saveAssetFromFile({
       userId,
       assetId: videoAssetId,
       assetPath,
-      metadata: { contentType: ASSET_TYPES.VIDEO_MP4 },
+      metadata: { contentType },
       quotaApproved,
     });
 
@@ -215,7 +217,7 @@ async function runWorker(job: DequeuedJob<ZVideoRequest>) {
           bookmarkId,
           userId,
           assetType: AssetTypes.LINK_VIDEO,
-          contentType: ASSET_TYPES.VIDEO_MP4,
+          contentType,
           size: fileSize,
         },
         txn,
@@ -267,6 +269,17 @@ async function deleteLeftOverAssetFile(
     logger.error(
       `[VideoCrawler][${jobId}] Failed deleting leftover video asset "${assetFile}".`,
     );
+  }
+}
+
+function getVideoContentType(assetPath: string): ASSET_TYPES {
+  switch (path.extname(assetPath).toLowerCase()) {
+    case ".webm":
+      return ASSET_TYPES.VIDEO_WEBM;
+    case ".mkv":
+      return ASSET_TYPES.VIDEO_MKV;
+    default:
+      return ASSET_TYPES.VIDEO_MP4;
   }
 }
 

--- a/packages/api/utils/assets.ts
+++ b/packages/api/utils/assets.ts
@@ -5,6 +5,7 @@ import {
   createAssetReadStream,
   getAssetSize,
   readAssetMetadata,
+  VIDEO_ASSET_TYPES,
 } from "@karakeep/shared/assetdb";
 
 import { toWebReadableStream } from "./upload";
@@ -26,22 +27,24 @@ export async function serveAsset(c: Context, assetId: string, userId: string) {
   c.header("Content-type", metadata.contentType);
   c.header("X-Content-Type-Options", "nosniff");
   c.header("Cache-Control", "private, max-age=31536000, immutable");
-  c.header(
-    "Content-Security-Policy",
-    [
-      "sandbox",
-      "default-src 'none'",
-      "base-uri 'none'",
-      "form-action 'none'",
-      "img-src https: data: blob:",
-      "style-src 'unsafe-inline' https: data:",
-      "font-src https: data:",
-      "connect-src 'none'",
-      "media-src https: data: blob:",
-      "object-src 'none'",
-      "frame-src 'none'",
-    ].join("; "),
-  );
+  const contentSecurityPolicy = [
+    "default-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+    "img-src https: data: blob:",
+    "style-src 'unsafe-inline' https: data:",
+    "font-src https: data:",
+    "connect-src 'none'",
+    "media-src https: data: blob:",
+    "object-src 'none'",
+    "frame-src 'none'",
+  ];
+
+  if (!VIDEO_ASSET_TYPES.has(metadata.contentType)) {
+    contentSecurityPolicy.unshift("sandbox");
+  }
+
+  c.header("Content-Security-Policy", contentSecurityPolicy.join("; "));
 
   const range = c.req.header("Range");
   if (range) {

--- a/packages/e2e_tests/tests/api/assets.test.ts
+++ b/packages/e2e_tests/tests/api/assets.test.ts
@@ -3,7 +3,7 @@ import { assert, beforeEach, describe, expect, inject, it } from "vitest";
 import { createKarakeepClient } from "@karakeep/sdk";
 
 import { createTestUser, uploadTestAsset } from "../../utils/api";
-import { createTestPdfFile } from "../../utils/assets";
+import { createTestPdfFile, createTestVideoFile } from "../../utils/assets";
 
 describe("Assets API", () => {
   const port = inject("karakeepPort");
@@ -47,6 +47,32 @@ describe("Assets API", () => {
     );
 
     expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Security-Policy")).toContain("sandbox");
+  });
+
+  it("should serve video assets without sandboxing browser playback", async () => {
+    const uploadResponse = await uploadTestAsset(
+      apiKey,
+      port,
+      createTestVideoFile(),
+    );
+    expect(uploadResponse.assetId).toBeDefined();
+    expect(uploadResponse.contentType).toBe("video/mp4");
+
+    const resp = await fetch(
+      `http://localhost:${port}/api/v1/assets/${uploadResponse.assetId}`,
+      {
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+        },
+      },
+    );
+
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toContain("video/mp4");
+    expect(resp.headers.get("Content-Security-Policy")).not.toContain(
+      "sandbox",
+    );
   });
 
   it("should require assets:readwrite to upload an asset", async () => {

--- a/packages/e2e_tests/utils/assets.ts
+++ b/packages/e2e_tests/utils/assets.ts
@@ -9,3 +9,9 @@ export function createTestPdfFile(fileName = "test.pdf"): File {
     type: "application/pdf",
   });
 }
+
+export function createTestVideoFile(fileName = "test.mp4"): File {
+  return new File([new Uint8Array([0, 0, 0, 0])], fileName, {
+    type: "video/mp4",
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #2908

Video assets were served with a restrictive CSP that included `sandbox`. When the asset URL is opened directly, Chrome's built-in media document can hit that sandbox and render a black page instead of showing video controls.

This PR:
- keeps the existing sandboxed CSP for non-video assets
- omits only the `sandbox` directive for known video MIME types so browser playback can work
- stores yt-dlp downloads with a video MIME type matching the downloaded extension (`.webm`, `.mkv`, default `.mp4`) instead of always recording `video/mp4`
- adds API coverage that PDF assets keep sandboxing while video assets are served without it

## Test Plan
- `corepack pnpm --filter @karakeep/workers typecheck`
- `corepack pnpm --filter @karakeep/workers lint`
- `corepack pnpm --filter @karakeep/workers format`
- `corepack pnpm --filter @karakeep/api typecheck`
- `corepack pnpm --filter @karakeep/api lint`
- `corepack pnpm --filter @karakeep/api format`
- `corepack pnpm --filter @karakeep/e2e_tests typecheck`
- `corepack pnpm --filter @karakeep/e2e_tests lint`
- `corepack pnpm --filter @karakeep/e2e_tests format`

Attempted targeted e2e test:
- `corepack pnpm --filter @karakeep/e2e_tests test -- tests/api/assets.test.ts` — blocked locally because this environment does not have `docker` installed (`/bin/sh: 1: docker: not found`).
