### PR TITLE
feat(deploy): add Render Blueprint for Karakeep stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
     <a href="https://hosted.weblate.org/engage/hoarder/">
         <img src="https://hosted.weblate.org/widget/hoarder/hoarder/svg-badge.svg" alt="Translation status" />
     </a>
+    <a href="https://render.com/deploy?repo=https://github.com/karakeep-app/karakeep">
+        <img alt="Deploy to Render" src="https://render.com/images/deploy-to-render-button.svg" height="20" />
+    </a>
 </div>
 
 # <img height="50px" src="./screenshots/logo.png" />

--- a/docker/Dockerfile.render-chrome
+++ b/docker/Dockerfile.render-chrome
@@ -1,0 +1,19 @@
+# Headless Chrome sidecar for Karakeep on Render.
+# Mirrors docker/docker-compose.yml chrome service flags.
+#
+# Render image runtime dockerCommand is passed as a single argv and fails
+# (exit 128). Use runtime: docker with an explicit ENTRYPOINT/CMD instead.
+FROM gcr.io/zenika-hub/alpine-chrome
+
+USER chrome
+
+ENTRYPOINT ["chromium-browser"]
+CMD [
+  "--headless",
+  "--no-sandbox",
+  "--disable-gpu",
+  "--disable-dev-shm-usage",
+  "--remote-debugging-address=0.0.0.0",
+  "--remote-debugging-port=9222",
+  "--hide-scrollbars"
+]

--- a/docker/Dockerfile.render-chrome
+++ b/docker/Dockerfile.render-chrome
@@ -8,12 +8,4 @@ FROM gcr.io/zenika-hub/alpine-chrome
 USER chrome
 
 ENTRYPOINT ["chromium-browser"]
-CMD [
-  "--headless",
-  "--no-sandbox",
-  "--disable-gpu",
-  "--disable-dev-shm-usage",
-  "--remote-debugging-address=0.0.0.0",
-  "--remote-debugging-port=9222",
-  "--hide-scrollbars"
-]
+CMD ["--headless", "--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222", "--hide-scrollbars"]

--- a/docker/Dockerfile.render-chrome
+++ b/docker/Dockerfile.render-chrome
@@ -3,7 +3,7 @@
 #
 # Render image runtime dockerCommand is passed as a single argv and fails
 # (exit 128). Use runtime: docker with an explicit ENTRYPOINT/CMD instead.
-FROM gcr.io/zenika-hub/alpine-chrome
+FROM gcr.io/zenika-hub/alpine-chrome:124
 
 USER chrome
 

--- a/docker/Dockerfile.render-karakeep
+++ b/docker/Dockerfile.render-karakeep
@@ -1,6 +1,6 @@
 # Render wrapper for the official Karakeep AIO image.
 # Adds render-entrypoint.sh so BROWSER_WEB_URL can be built from fromService host.
-FROM ghcr.io/karakeep-app/karakeep
+FROM ghcr.io/karakeep-app/karakeep:release
 
 COPY docker/render-entrypoint.sh /render-entrypoint.sh
 RUN chmod +x /render-entrypoint.sh

--- a/docker/Dockerfile.render-karakeep
+++ b/docker/Dockerfile.render-karakeep
@@ -1,0 +1,8 @@
+# Render wrapper for the official Karakeep AIO image.
+# Adds render-entrypoint.sh so BROWSER_WEB_URL can be built from fromService host.
+FROM ghcr.io/karakeep-app/karakeep
+
+COPY docker/render-entrypoint.sh /render-entrypoint.sh
+RUN chmod +x /render-entrypoint.sh
+
+ENTRYPOINT ["/render-entrypoint.sh"]

--- a/docker/render-entrypoint.sh
+++ b/docker/render-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Render private DNS uses the pserv slug (e.g. chrome-c8jj), not the Blueprint
+# service name (chrome). Build BROWSER_WEB_URL from fromService host when set.
+if [ -z "${BROWSER_WEB_URL:-}" ] && [ -n "${BROWSER_WEB_HOST:-}" ]; then
+  export BROWSER_WEB_URL="http://${BROWSER_WEB_HOST}:${BROWSER_WEB_PORT:-9222}"
+fi
+
+exec /init "$@"

--- a/docs/docs/02-installation/11-render.md
+++ b/docs/docs/02-installation/11-render.md
@@ -1,0 +1,31 @@
+# Render
+
+Deploy Karakeep on [Render](https://render.com/) with the Blueprint in this repo (`render.yaml`). It mirrors the official Docker Compose stack: web app, Meilisearch, and headless Chrome on Render's private network.
+
+<p>
+  <a href="https://render.com/deploy?repo=https://github.com/karakeep-app/karakeep">
+    <img alt="Deploy to Render" src="https://render.com/images/deploy-to-render-button.svg" height="20" />
+  </a>
+</p>
+
+### Requirements
+
+- A [Render](https://render.com/) account
+- A GitHub account (Render forks the repo when you deploy from the button)
+
+### 1. Deploy the Blueprint
+
+Click **Deploy to Render** above, or open the [Blueprint deploy link](https://render.com/deploy?repo=https://github.com/karakeep-app/karakeep) and apply `render.yaml`.
+
+Render creates three services:
+
+- **karakeep** (web): official image, persistent disk for bookmarks and assets
+- **meilisearch** (private service): full-text search
+- **chrome** (private service): crawling and screenshots
+
+### 2. Finish setup
+
+1. Open the **karakeep** web service URL and create your account.
+2. Optional: set `OPENAI_API_KEY` on the **karakeep** service in the Render Dashboard for AI tagging and summarization.
+
+`NEXTAUTH_SECRET`, `MEILI_MASTER_KEY`, and `NEXTAUTH_URL` are wired by the Blueprint. Plan and image tag choices are made at deploy time in the Dashboard.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+#
+# Karakeep on Render — official GHCR image + Meilisearch + headless Chrome
+# Mirrors docker/docker-compose.yml: web (AIO image with workers), meilisearch, chrome.
+# Repo: https://github.com/ojusave/karakeep
+# Upstream: https://github.com/karakeep-app/karakeep
+#
+# After deploy: open the karakeep web URL, create your account, then add OPENAI_API_KEY
+# in the Dashboard if you want AI tagging (optional but recommended).
+
+previews:
+  generation: off
+
+envVarGroups:
+  - name: karakeep-shared
+    envVars:
+      # Same key on karakeep + meilisearch (search disabled if missing or mismatched).
+      - key: MEILI_MASTER_KEY
+        generateValue: true
+
+projects:
+  - name: karakeep
+    environments:
+      - name: production
+        services:
+          - type: web
+            name: karakeep
+            runtime: image
+            plan: standard
+            region: oregon
+            image:
+              url: ghcr.io/karakeep-app/karakeep:release
+            healthCheckPath: /api/health
+            disk:
+              name: karakeep-data
+              mountPath: /data
+              sizeGB: 5
+            envVars:
+              - fromGroup: karakeep-shared
+              - key: DATA_DIR
+                value: /data
+              - key: MEILI_ADDR
+                value: http://meilisearch:7700
+              - key: BROWSER_WEB_URL
+                value: http://chrome:9222
+              - key: DB_WAL_MODE
+                value: "true"
+              - key: NEXTAUTH_SECRET
+                generateValue: true
+              - key: NEXTAUTH_URL
+                fromService:
+                  name: karakeep
+                  type: web
+                  envVarKey: RENDER_EXTERNAL_URL
+              # Optional: enable AI tagging and summarization after deploy.
+              - key: OPENAI_API_KEY
+                sync: false
+
+          - type: pserv
+            name: meilisearch
+            runtime: image
+            plan: starter
+            region: oregon
+            image:
+              url: getmeili/meilisearch:v1.41.0
+            disk:
+              name: meilisearch-data
+              mountPath: /meili_data
+              sizeGB: 1
+            envVars:
+              - fromGroup: karakeep-shared
+              - key: MEILI_NO_ANALYTICS
+                value: "true"
+
+          - type: pserv
+            name: chrome
+            runtime: image
+            plan: starter
+            region: oregon
+            image:
+              url: gcr.io/zenika-hub/alpine-chrome:124
+            dockerCommand: --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --hide-scrollbars

--- a/render.yaml
+++ b/render.yaml
@@ -26,10 +26,9 @@ projects:
           - type: web
             name: karakeep
             runtime: image
-            plan: standard
             region: oregon
             image:
-              url: ghcr.io/karakeep-app/karakeep:release
+              url: ghcr.io/karakeep-app/karakeep
             healthCheckPath: /api/health
             disk:
               name: karakeep-data
@@ -59,10 +58,9 @@ projects:
           - type: pserv
             name: meilisearch
             runtime: image
-            plan: starter
             region: oregon
             image:
-              url: getmeili/meilisearch:v1.41.0
+              url: getmeili/meilisearch
             disk:
               name: meilisearch-data
               mountPath: /meili_data
@@ -75,8 +73,7 @@ projects:
           - type: pserv
             name: chrome
             runtime: image
-            plan: starter
             region: oregon
             image:
-              url: gcr.io/zenika-hub/alpine-chrome:124
+              url: gcr.io/zenika-hub/alpine-chrome
             dockerCommand: --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --hide-scrollbars

--- a/render.yaml
+++ b/render.yaml
@@ -25,10 +25,10 @@ projects:
         services:
           - type: web
             name: karakeep
-            runtime: image
+            runtime: docker
             region: oregon
-            image:
-              url: ghcr.io/karakeep-app/karakeep
+            dockerfilePath: ./docker/Dockerfile.render-karakeep
+            dockerContext: .
             healthCheckPath: /api/health
             disk:
               name: karakeep-data
@@ -40,8 +40,14 @@ projects:
                 value: /data
               - key: MEILI_ADDR
                 value: http://meilisearch:7700
-              - key: BROWSER_WEB_URL
-                value: http://chrome:9222
+              # Render private DNS host (slug), wired via fromService in entrypoint.
+              - key: BROWSER_WEB_HOST
+                fromService:
+                  name: chrome
+                  type: pserv
+                  property: host
+              - key: BROWSER_WEB_PORT
+                value: "9222"
               - key: DB_WAL_MODE
                 value: "true"
               - key: NEXTAUTH_SECRET

--- a/render.yaml
+++ b/render.yaml
@@ -70,10 +70,11 @@ projects:
               - key: MEILI_NO_ANALYTICS
                 value: "true"
 
+          # dockerCommand on runtime:image is passed as one argv (exit 128).
+          # Build from docker/Dockerfile.render-chrome instead.
           - type: pserv
             name: chrome
-            runtime: image
+            runtime: docker
             region: oregon
-            image:
-              url: gcr.io/zenika-hub/alpine-chrome
-            dockerCommand: --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --hide-scrollbars
+            dockerfilePath: ./docker/Dockerfile.render-chrome
+            dockerContext: .

--- a/render.yaml
+++ b/render.yaml
@@ -64,7 +64,7 @@ projects:
             runtime: image
             region: oregon
             image:
-              url: getmeili/meilisearch
+              url: getmeili/meilisearch:v1.41.0
             disk:
               name: meilisearch-data
               mountPath: /meili_data

--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,6 @@
 #
 # Karakeep on Render — official GHCR image + Meilisearch + headless Chrome
 # Mirrors docker/docker-compose.yml: web (AIO image with workers), meilisearch, chrome.
-# Repo: https://github.com/ojusave/karakeep
-# Upstream: https://github.com/karakeep-app/karakeep
 #
 # After deploy: open the karakeep web URL, create your account, then add OPENAI_API_KEY
 # in the Dashboard if you want AI tagging (optional but recommended).


### PR DESCRIPTION
## Description

Adds a [Render Blueprint](https://render.com/docs/blueprint-spec) (`render.yaml`) so Karakeep can be deployed on Render with the same three-service layout as `docker/docker-compose.yml`:

- **karakeep** (web): official `ghcr.io/karakeep-app/karakeep` AIO image with a persistent disk for `DATA_DIR`
- **meilisearch** (private service): full-text search
- **chrome** (private service): headless browser for crawling, screenshots, and JS execution

### Why this is needed

Karakeep already documents Docker Compose as the primary self-host path. Render is a common managed host for Compose-style stacks, but the platform has a few constraints that need small wrappers:

1. **Private DNS hostnames**: Render private services use slug-based hostnames (e.g. `chrome-c8jj`), not the Blueprint service name. A thin entrypoint builds `BROWSER_WEB_URL` from `fromService` host wiring.
2. **Chrome startup**: `runtime: image` + `dockerCommand` passes the command as a single argv and fails (exit 128). A dedicated `Dockerfile.render-chrome` uses explicit `ENTRYPOINT`/`CMD` instead.
3. **Secrets and URLs**: Blueprint generates `NEXTAUTH_SECRET` and `MEILI_MASTER_KEY`, and wires `NEXTAUTH_URL` from `RENDER_EXTERNAL_URL`.

No application code changes. Only deployment artifacts under `docker/` and root `render.yaml`.

After deploy: open the web service URL, create an account, and optionally set `OPENAI_API_KEY` in the Dashboard for AI tagging.

## How Has This Been Tested?

- [x] Deployed the Blueprint from this branch on Render (web + meilisearch + chrome pservs)
- [x] Verified health check at `/api/health`
- [x] Verified bookmark crawling works with the chrome sidecar over Render private networking
- [x] Verified Meilisearch connectivity with shared `MEILI_MASTER_KEY`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A (infrastructure-only change)

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM assistance was used to draft the Blueprint, Docker wrappers, and this PR description. Deployment was tested manually on Render.