### PR TITLE
feat: add unused tags management to cleanups page

### DIFF
--- a/apps/web/app/dashboard/cleanups/page.tsx
+++ b/apps/web/app/dashboard/cleanups/page.tsx
@@ -1,4 +1,5 @@
 import { TagDuplicationDetection } from "@/components/dashboard/cleanups/TagDuplicationDetention";
+import { UnusedTagsSection } from "@/components/dashboard/cleanups/UnusedTagsSection";
 import { Separator } from "@/components/ui/separator";
 import { useTranslation } from "@/lib/i18n/server";
 import { Paintbrush, Tags } from "lucide-react";
@@ -20,6 +21,8 @@ export default async function Cleanups() {
       </span>
       <Separator />
       <TagDuplicationDetection />
+      <Separator />
+      <UnusedTagsSection />
     </div>
   );
 }

--- a/apps/web/components/dashboard/cleanups/UnusedTagsSection.tsx
+++ b/apps/web/components/dashboard/cleanups/UnusedTagsSection.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { ActionButton } from "@/components/ui/action-button";
+import ActionConfirmingDialog from "@/components/ui/action-confirming-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { toast } from "@/components/ui/sonner";
+import LoadingSpinner from "@/components/ui/spinner";
+import { useTranslation } from "@/lib/i18n/client";
+import { Trash2 } from "lucide-react";
+
+import {
+  useDeleteUnusedTags,
+  usePaginatedSearchTags,
+} from "@karakeep/shared-react/hooks/tags";
+
+export function UnusedTagsSection() {
+  const { t } = useTranslation();
+
+  const { data, isLoading, hasNextPage } = usePaginatedSearchTags({
+    attachedBy: "none",
+    limit: 50,
+  });
+
+  const count = data?.tags.length ?? 0;
+
+  const { mutate, isPending } = useDeleteUnusedTags({
+    onSuccess: () => {
+      toast({ description: `Deleted all unused tags` });
+    },
+    onError: () => {
+      toast({ description: "Something went wrong", variant: "destructive" });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <span>{t("tags.unused_tags")}</span>
+          <Badge variant="secondary">
+            {count}
+            {hasNextPage ? "+" : ""}
+          </Badge>
+        </CardTitle>
+        <CardDescription>{t("tags.unused_tags_info")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <ActionConfirmingDialog
+            title={t("tags.delete_all_unused_tags")}
+            description={`Are you sure you want to delete the ${count} unused tags?`}
+            actionButton={() => (
+              <ActionButton
+                variant="destructive"
+                loading={isPending}
+                onClick={() => mutate()}
+              >
+                <Trash2 className="mr-2 size-4" />
+                {t("tags.delete_all_unused_tags")}
+              </ActionButton>
+            )}
+          >
+            <Button variant="destructive" disabled={count === 0}>
+              <Trash2 className="mr-2 size-4" />
+              {t("tags.delete_all_unused_tags")}
+            </Button>
+          </ActionConfirmingDialog>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Adds unused tags management to the Cleanups page (fixes #1747).

- New `UnusedTagsSection` client component displays the count of unused tags and a delete-all action with confirmation dialog
- Reuses existing hooks (`usePaginatedSearchTags`, `useDeleteUnusedTags`) and i18n keys (`tags.unused_tags`, `tags.unused_tags_info`, `tags.delete_all_unused_tags`) — no new strings added
- `AllTagsView` is not modified

## Changes

- `apps/web/components/dashboard/cleanups/UnusedTagsSection.tsx` (new)
- `apps/web/app/dashboard/cleanups/page.tsx` (import + render `UnusedTagsSection`)

Fixes #1747