### PR TITLE
fix(mcp): coerce null htmlContent before turndown in get-bookmark-content

### DIFF
--- a/apps/mcp/src/bookmarks.ts
+++ b/apps/mcp/src/bookmarks.ts
@@ -247,7 +247,7 @@ mcpServer.tool(
     let content;
     if (res.data.content.type === "link") {
       const htmlContent = res.data.content.htmlContent;
-      content = turndownService.turndown(htmlContent);
+      content = turndownService.turndown(htmlContent ?? "");
     } else if (res.data.content.type === "text") {
       content = res.data.content.text;
     } else if (res.data.content.type === "asset") {


### PR DESCRIPTION
## Description

`apps/mcp/src/bookmarks.ts:250` passes `htmlContent` directly to `turndownService.turndown()` without null-checking. The SDK schema declares `htmlContent?: string | null`, so on link bookmarks where the crawl hasn't run (or failed), `turndown()` throws at runtime. One-line coerce to `""` matches the `?? ""` convention used everywhere else in the same file.

Refs #2914

## How Has This Been Tested?

- [x] Local `pnpm --filter @karakeep/mcp typecheck` passes
- [x] Manual reproduction: with the fix, `get-bookmark-content` on an uncrawled link bookmark returns an empty markdown body instead of crashing
- [x] Build still succeeds
- [x] **Regression test landed in the stacked PR #2917** — the vitest harness it needs already exists there (`apps/mcp/src/bookmarks.test.ts`). The regression test asserts that null `htmlContent` is coerced to `""` before being passed to `turndownService.turndown()`, covers a string-htmlContent happy path, and confirms text bookmarks bypass turndown entirely. If you'd prefer the test land here too, happy to bootstrap vitest in this branch as a follow-up commit — flagged separately because it would import the same lockfile cascade we disclose in #2917.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (N/A)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none)
- [x] I have written tests for new code (if applicable) — regression test in stacked PR #2917, see above

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (Anthropic, via Claude Code) authored the fix. I (Joe Stump) reviewed it on my fork before this submission. Closed PRs on my fork that landed this and related work: https://github.com/joestump/karakeep/pulls?q=is%3Apr+is%3Aclosed