### PR TITLE
[codex] Document browser extension dev port

### DIFF
--- a/apps/browser-extension/vite.config.ts
+++ b/apps/browser-extension/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     }),
   ],
   server: {
+    port: 5174,
     cors: {
       origin: [/chrome-extension:\/\//],
     },

--- a/apps/browser-extension/vite.config.ts
+++ b/apps/browser-extension/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   ],
   server: {
     port: 5174,
+    strictPort: true,
     cors: {
       origin: [/chrome-extension:\/\//],
     },

--- a/docs/docs/08-development/01-setup.md
+++ b/docs/docs/08-development/01-setup.md
@@ -178,10 +178,10 @@ Note: Changing the code will hot reload the app. However, installing new package
 
 - `cd apps/browser-extension`
 - `pnpm dev`
-- This will generate a `dist` package
-- Go to extension settings in chrome and enable developer mode.
-- Press `Load unpacked` and point it to the `dist` directory.
-- The plugin will pop up in the plugin list.
+- This will start the extension dev server on `http://localhost:5174` and generate a `dist` package.
+- Go to `chrome://extensions` in Chrome or Brave and enable developer mode.
+- Press `Load unpacked` and point it to the `apps/browser-extension/dist` directory.
+- The extension will pop up in the extension list.
 
 In dev mode, opening and closing the plugin menu should reload the code.
 


### PR DESCRIPTION
## Summary
- pin the browser extension Vite dev server to port 5174
- update the development docs with the 5174 dev server URL and clearer Chrome/Brave Load unpacked steps

Fixes #1290

## Verification
- env PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --filter @karakeep/browser-extension typecheck
- env PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --filter @karakeep/browser-extension lint
- env PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --filter @karakeep/browser-extension format
- git diff --check
- env PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --filter @karakeep/browser-extension dev --host 127.0.0.1, then confirmed http://127.0.0.1:5174 returned HTTP 200