### PR TITLE
fix(inference): only set JSON response_format for schema requests

### DIFF
--- a/packages/shared/inference.test.ts
+++ b/packages/shared/inference.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { OpenAIInferenceClient } from "./inference";
+import type { OpenAIInferenceConfig } from "./inference";
+
+const capturedBodies: Record<string, unknown>[] = [];
+const tagSchema = z.object({ tags: z.array(z.string()) });
+
+vi.mock("openai", () => {
+  const OpenAIMock = vi.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: vi.fn(async (body: Record<string, unknown>) => {
+          capturedBodies.push(body);
+          return {
+            choices: [{ message: { content: "{}" } }],
+            usage: { total_tokens: 1 },
+          };
+        }),
+      },
+    },
+  }));
+
+  return { default: OpenAIMock };
+});
+
+vi.mock("openai/helpers/zod", () => ({
+  zodResponseFormat: (schema: unknown, name: string) => ({
+    type: "json_schema",
+    json_schema: { name, schema },
+  }),
+}));
+
+function makeConfig(
+  outputSchema: OpenAIInferenceConfig["outputSchema"],
+): OpenAIInferenceConfig {
+  return {
+    apiKey: "test-key",
+    textModel: "test-text-model",
+    imageModel: "test-image-model",
+    contextLength: 2048,
+    maxOutputTokens: 1024,
+    useMaxCompletionTokens: false,
+    outputSchema,
+  };
+}
+
+describe("OpenAIInferenceClient response_format", () => {
+  beforeEach(() => {
+    capturedBodies.length = 0;
+  });
+
+  it("omits response_format for schema-less text inference in json mode", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("json"));
+
+    await client.inferFromText("summarize this text", { schema: null });
+
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].response_format).toBeUndefined();
+  });
+
+  it("keeps json_object for schema-backed text inference in json mode", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("json"));
+
+    await client.inferFromText("infer tags as json", { schema: tagSchema });
+
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].response_format).toEqual({ type: "json_object" });
+  });
+
+  it("omits response_format for schema-less image inference in json mode", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("json"));
+
+    await client.inferFromImage("describe this image", "image/png", "BASE64", {
+      schema: null,
+    });
+
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].response_format).toBeUndefined();
+  });
+
+  it("keeps structured response_format for schema-backed text inference in structured mode", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("structured"));
+
+    await client.inferFromText("infer tags", { schema: tagSchema });
+
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].response_format).toMatchObject({
+      type: "json_schema",
+      json_schema: { name: "schema" },
+    });
+  });
+});

--- a/packages/shared/inference.ts
+++ b/packages/shared/inference.ts
@@ -136,6 +136,24 @@ const mapInferenceOutputSchema = <
   return opts[type];
 };
 
+const mapOpenAIResponseFormat = (
+  schema: z.ZodSchema | null,
+  outputSchema: typeof serverConfig.inference.outputSchema,
+) => {
+  if (schema === null) {
+    return undefined;
+  }
+
+  return mapInferenceOutputSchema(
+    {
+      structured: zodResponseFormat(schema, "schema"),
+      json: { type: "json_object" as const },
+      plain: undefined,
+    },
+    outputSchema,
+  );
+};
+
 export interface OpenAIInferenceConfig {
   apiKey: string;
   baseURL?: string;
@@ -221,14 +239,8 @@ export class OpenAIInferenceClient implements InferenceClient {
         ...(this.config.useMaxCompletionTokens
           ? { max_completion_tokens: this.config.maxOutputTokens }
           : { max_tokens: this.config.maxOutputTokens }),
-        response_format: mapInferenceOutputSchema(
-          {
-            structured: optsWithDefaults.schema
-              ? zodResponseFormat(optsWithDefaults.schema, "schema")
-              : undefined,
-            json: { type: "json_object" },
-            plain: undefined,
-          },
+        response_format: mapOpenAIResponseFormat(
+          optsWithDefaults.schema,
           this.config.outputSchema,
         ),
         reasoning_effort: this.config.reasoningEffort,
@@ -264,14 +276,8 @@ export class OpenAIInferenceClient implements InferenceClient {
         ...(this.config.useMaxCompletionTokens
           ? { max_completion_tokens: this.config.maxOutputTokens }
           : { max_tokens: this.config.maxOutputTokens }),
-        response_format: mapInferenceOutputSchema(
-          {
-            structured: optsWithDefaults.schema
-              ? zodResponseFormat(optsWithDefaults.schema, "schema")
-              : undefined,
-            json: { type: "json_object" },
-            plain: undefined,
-          },
+        response_format: mapOpenAIResponseFormat(
+          optsWithDefaults.schema,
           this.config.outputSchema,
         ),
         messages: [


### PR DESCRIPTION
## Description

When `INFERENCE_OUTPUT_SCHEMA=json` is enabled, schema-less summary requests still send `response_format: { type: "json_object" }` to OpenAI-compatible providers.

This breaks providers such as DeepSeek, which reject JSON mode unless the prompt explicitly asks for JSON:

```text
400 Prompt must contain the word 'json' in some form to use 'response_format' of type 'json_object'.
```

This change only sends OpenAI `response_format` for requests that provide a schema. Schema-backed tagging keeps using JSON mode, while schema-less summaries use normal text generation.

Fixes #2789.
Related: #2077.

## How Has This Been Tested?

- [x] `pnpm --filter @karakeep/shared test -- inference.test.ts --run`
- [x] `pnpm --filter @karakeep/shared typecheck`
- [x] `pnpm --filter @karakeep/shared lint`
- [x] `pnpm --filter @karakeep/shared format`
- [x] Reproduced the DeepSeek failure locally with `INFERENCE_OUTPUT_SCHEMA=json`.
- [x] Verified summaries succeed after the patch with the same config.
- [x] Verified JSON-mode tagging still works.

Before the fix, schema-less summary generation failed with DeepSeek:

```text
error: [inference][111] inference job failed: Error: 400 Prompt must contain the word 'json' in some form to use 'response_format' of type 'json_object'.
```

After the fix, summary generation succeeds with the same `INFERENCE_OUTPUT_SCHEMA=json` config:

```text
info: [inference][113] Generated summary for bookmark using 858 tokens.
info: [inference][113] Completed successfully
```

Tagging still uses the JSON/schema path successfully:

```text
info: [inference][115] Inferring tag for bookmark used 986 tokens and inferred tags successfully.
info: [inference][115] Completed successfully
```


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used to help draft parts of the implementation/tests and PR text. The final patch was manually reviewed, edited, and validated before submission.
