### PR TITLE
fix(crawler): preserve inline GIF data images

### DIFF
--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -84,16 +84,28 @@ const LAZY_SRC_ATTRS = [
   "data-url",
 ];
 
+function isPlaceholderDataImage(src: string): boolean {
+  // Tiny data-URI images are commonly used as lazy-load placeholders. Do not
+  // treat every data:image/gif as a placeholder: SingleFile and some sites
+  // inline real GIF assets as data URIs, and replacing those with a lazy
+  // attribute URL makes the saved reader content depend on the remote image.
+  const normalizedSrc = src.replace(/\s/g, "").toLowerCase();
+  return (
+    normalizedSrc.length <= 200 &&
+    (normalizedSrc.startsWith("data:image/gif") ||
+      normalizedSrc.startsWith("data:image/png"))
+  );
+}
+
 function normalizeLazyLoadImages(document: Document): void {
   const images = document.querySelectorAll("img");
   for (const img of images) {
-    // Only fill in src if it is absent or a known placeholder (blank / data:)
+    // Only fill in src if it is absent or a known tiny placeholder. Real
+    // inlined GIF/PNG data URIs must be preserved so archived content keeps
+    // the saved image rather than falling back to a remote lazy-load URL.
     const currentSrc = img.getAttribute("src") ?? "";
     const needsSrc =
-      !currentSrc ||
-      currentSrc === "#" ||
-      currentSrc.startsWith("data:image/gif") ||
-      currentSrc.startsWith("data:image/png");
+      !currentSrc || currentSrc === "#" || isPlaceholderDataImage(currentSrc);
 
     if (!needsSrc) {
       continue;

--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -89,9 +89,13 @@ function isPlaceholderDataImage(src: string): boolean {
   // treat every data:image/gif as a placeholder: SingleFile and some sites
   // inline real GIF assets as data URIs, and replacing those with a lazy
   // attribute URL makes the saved reader content depend on the remote image.
+  // 200 chars is a deliberately generous cutoff: a 1x1 transparent GIF/PNG
+  // placeholder is only ~60-100 chars, while a real inlined image is many KB,
+  // so anything under this limit is safely a placeholder rather than an asset.
+  const PLACEHOLDER_MAX_LENGTH = 200;
   const normalizedSrc = src.replace(/\s/g, "").toLowerCase();
   return (
-    normalizedSrc.length <= 200 &&
+    normalizedSrc.length <= PLACEHOLDER_MAX_LENGTH &&
     (normalizedSrc.startsWith("data:image/gif") ||
       normalizedSrc.startsWith("data:image/png"))
   );


### PR DESCRIPTION
## Summary
Fixes #2905.

Preserve real inline GIF/PNG data URIs when normalizing lazy-loaded article images before Readability. The crawler previously treated every `data:image/gif`/`data:image/png` `src` as a placeholder and could replace a SingleFile-saved inline GIF with a remote lazy-load URL, causing GIFs to be lost from saved reader content.

## Changes
- Only replace absent, `#`, or tiny data-URI placeholder images with lazy-load attributes.
- Keep larger inline data images intact so archived content retains saved GIF assets.

## Test Plan
- `corepack pnpm --filter @karakeep/workers format`
- `corepack pnpm --filter @karakeep/workers lint`
- `corepack pnpm --filter @karakeep/workers typecheck`
- Manual parser check: ran `corepack pnpm --filter @karakeep/workers exec tsx scripts/parseHtmlSubprocess.ts` with HTML containing a large inline `data:image/gif` plus `data-src`; verified the readable content kept the inline GIF `src`.
- Manual parser check: ran the same parser with a tiny transparent GIF placeholder plus `data-src`; verified the placeholder was replaced with the remote GIF URL.
