### PR TITLE
Resolve known link-shortener URLs (search.app / share.google) to their destination

### DIFF
--- a/apps/workers/workers/crawler/crawlAndParse.ts
+++ b/apps/workers/workers/crawler/crawlAndParse.ts
@@ -34,6 +34,7 @@ import {
 import serverConfig from "@karakeep/shared/config";
 import logger from "@karakeep/shared/logger";
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
+import { resolveShortenedBookmarkUrl } from "@karakeep/shared/utils/url";
 
 import type { ParseSubprocessOutput } from "../utils/parseHtmlSubprocessIpc";
 import {
@@ -50,7 +51,11 @@ import {
 } from "./assetStorage";
 import { crawlPage } from "./crawlPage";
 import { runParseSubprocess } from "./parseSubprocess";
-import { redactUrlCredentials, shouldRetryCrawlStatusCode } from "./utils";
+import {
+  redactUrlCredentials,
+  shouldRetryCrawlStatusCode,
+  truncateUrl,
+} from "./utils";
 
 const tracer = getTracer("@karakeep/workers");
 
@@ -170,7 +175,7 @@ export interface CrawlAndParseUrlArgs {
  */
 export async function crawlAndParseUrl(
   args: CrawlAndParseUrlArgs,
-): Promise<() => Promise<void>> {
+): Promise<{ runArchival: () => Promise<void>; effectiveUrl: string }> {
   const {
     url,
     userId,
@@ -311,12 +316,24 @@ export async function crawlAndParseUrl(
         }
       };
 
+      // Replace a known shortener (search.app/share.google) with its resolved
+      // destination so the bookmark reflects the real URL. See issue #2235.
+      const resolvedUrl = resolveShortenedBookmarkUrl(url, browserUrl);
+      if (resolvedUrl) {
+        logger.info(
+          `[Crawler][${jobId}] Resolved shortened URL "${truncateUrl(
+            url,
+          )}" to "${truncateUrl(resolvedUrl)}". Updating the bookmark URL.`,
+        );
+      }
+
       // Phase 1: Write metadata immediately for fast user feedback.
       // Content and asset storage happen later and can be slow (banner
       // image download, screenshot/pdf upload, etc.).
       await db
         .update(bookmarkLinks)
         .set({
+          ...(resolvedUrl ? { url: resolvedUrl } : {}),
           title: meta.title,
           description: meta.description,
           // Don't store data URIs as they're not valid URLs and are usually quite large
@@ -466,7 +483,7 @@ export async function crawlAndParseUrl(
       // Delete the old assets if any
       await Promise.all(assetDeletionTasks);
 
-      return async () => {
+      const runArchival = async () => {
         if (
           !precrawledArchiveAssetId &&
           (serverConfig.crawler.fullPageArchive || archiveFullPage)
@@ -508,6 +525,10 @@ export async function crawlAndParseUrl(
           }
         }
       };
+
+      // effectiveUrl reflects any shortener resolution so downstream jobs
+      // (e.g. video) use the real destination, not the opaque short link.
+      return { runArchival, effectiveUrl: resolvedUrl ?? url };
     },
   );
 }

--- a/apps/workers/workers/crawler/crawlAndParse.ts
+++ b/apps/workers/workers/crawler/crawlAndParse.ts
@@ -35,6 +35,7 @@ import serverConfig from "@karakeep/shared/config";
 import logger from "@karakeep/shared/logger";
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
 import type { ZReaderViewReason } from "@karakeep/shared/types/bookmarks";
+import { resolveShortenedBookmarkUrl } from "@karakeep/shared/utils/url";
 
 import type { ParseSubprocessOutput } from "../utils/parseHtmlSubprocessIpc";
 import {
@@ -51,7 +52,11 @@ import {
 } from "./assetStorage";
 import { crawlPage } from "./crawlPage";
 import { runParseSubprocess } from "./parseSubprocess";
-import { redactUrlCredentials, shouldRetryCrawlStatusCode } from "./utils";
+import {
+  redactUrlCredentials,
+  shouldRetryCrawlStatusCode,
+  truncateUrl,
+} from "./utils";
 
 const tracer = getTracer("@karakeep/workers");
 
@@ -176,7 +181,7 @@ export interface CrawlAndParseUrlArgs {
  */
 export async function crawlAndParseUrl(
   args: CrawlAndParseUrlArgs,
-): Promise<() => Promise<void>> {
+): Promise<{ runArchival: () => Promise<void>; effectiveUrl: string }> {
   const {
     url,
     userId,
@@ -329,12 +334,24 @@ export async function crawlAndParseUrl(
         }
       };
 
+      // Replace a known shortener (search.app/share.google) with its resolved
+      // destination so the bookmark reflects the real URL. See issue #2235.
+      const resolvedUrl = resolveShortenedBookmarkUrl(url, browserUrl);
+      if (resolvedUrl) {
+        logger.info(
+          `[Crawler][${jobId}] Resolved shortened URL "${truncateUrl(
+            url,
+          )}" to "${truncateUrl(resolvedUrl)}". Updating the bookmark URL.`,
+        );
+      }
+
       // Phase 1: Write metadata immediately for fast user feedback.
       // Content and asset storage happen later and can be slow (banner
       // image download, screenshot/pdf upload, etc.).
       await db
         .update(bookmarkLinks)
         .set({
+          ...(resolvedUrl ? { url: resolvedUrl } : {}),
           title: meta.title,
           description: meta.description,
           // Don't store data URIs as they're not valid URLs and are usually quite large
@@ -489,7 +506,7 @@ export async function crawlAndParseUrl(
       // Delete the old assets if any
       await Promise.all(assetDeletionTasks);
 
-      return async () => {
+      const runArchival = async () => {
         if (
           !precrawledArchiveAssetId &&
           (serverConfig.crawler.fullPageArchive || archiveFullPage)
@@ -531,6 +548,10 @@ export async function crawlAndParseUrl(
           }
         }
       };
+
+      // effectiveUrl reflects any shortener resolution so downstream jobs
+      // (e.g. video) use the real destination, not the opaque short link.
+      return { runArchival, effectiveUrl: resolvedUrl ?? url };
     },
   );
 }

--- a/apps/workers/workers/crawler/probe.ts
+++ b/apps/workers/workers/crawler/probe.ts
@@ -49,6 +49,11 @@ const PROBE_HTML_CONTENT_TYPES = new Set<string>([
 export interface UrlProbeResult {
   contentType: string | null;
   /**
+   * The URL after any redirects the probe followed. Callers use this to
+   * resolve link-shortener URLs to their real destination.
+   */
+  finalUrl: string;
+  /**
    * Resolves with the page's preview metadata (or null). The extraction runs
    * in the background so it can overlap with the browser crawl — await it
    * only when the metadata is actually needed. Never rejects.
@@ -120,7 +125,11 @@ export async function getContentTypeAndMetadata(
         logger.error(
           `[Crawler][${jobId}] Failed to determine the content-type for the url ${truncateUrl(url)}: ${e}`,
         );
-        return { contentType: null, metadata: Promise.resolve(null) };
+        return {
+          contentType: null,
+          finalUrl: url,
+          metadata: Promise.resolve(null),
+        };
       }
       setSpanAttributes({
         "crawler.getContentType.statusCode": response.status,
@@ -135,7 +144,11 @@ export async function getContentTypeAndMetadata(
       );
 
       if (!contentType || !PROBE_HTML_CONTENT_TYPES.has(contentType)) {
-        return { contentType, metadata: Promise.resolve(null) };
+        return {
+          contentType,
+          finalUrl: response.url,
+          metadata: Promise.resolve(null),
+        };
       }
 
       // A previous run already extracted and stored this page's metadata; the
@@ -147,7 +160,11 @@ export async function getContentTypeAndMetadata(
         addLogFields<"crawlerWorker.run">({
           "crawler.probe.metadata": "reused_stored",
         });
-        return { contentType, metadata: Promise.resolve(null) };
+        return {
+          contentType,
+          finalUrl: response.url,
+          metadata: Promise.resolve(null),
+        };
       }
 
       // A blocked/retryable status usually means a challenge or error page
@@ -159,7 +176,11 @@ export async function getContentTypeAndMetadata(
         addLogFields<"crawlerWorker.run">({
           "crawler.probe.metadata": "blocked_status",
         });
-        return { contentType, metadata: Promise.resolve(null) };
+        return {
+          contentType,
+          finalUrl: response.url,
+          metadata: Promise.resolve(null),
+        };
       }
 
       // The response is an HTML page: parse its metadata from the body we've
@@ -205,7 +226,7 @@ export async function getContentTypeAndMetadata(
           return null;
         }
       })();
-      return { contentType, metadata };
+      return { contentType, finalUrl: response.url, metadata };
     },
   );
 }

--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -39,6 +39,7 @@ import {
 } from "@karakeep/shared/queueing";
 import { getRateLimitClient } from "@karakeep/shared/ratelimiting";
 import { tryCatch } from "@karakeep/shared/tryCatch";
+import { resolveShortenedBookmarkUrl } from "@karakeep/shared/utils/url";
 import { WebhooksService } from "@karakeep/trpc/models/webhooks.service";
 
 import {
@@ -387,20 +388,32 @@ async function runCrawler(
   // it — reload it from the bookmark row instead.
   const reuseStoredProbeMetadata =
     job.runNumber > 0 && probeMetadataAt !== null;
-  const { contentType, metadata: probeMetadata }: UrlProbeResult =
-    precrawledArchiveAssetId
-      ? { contentType: ASSET_TYPES.TEXT_HTML, metadata: Promise.resolve(null) }
-      : await getContentTypeAndMetadata(url, jobId, job.abortSignal, runProxy, {
-          skipMetadataExtraction: reuseStoredProbeMetadata,
-        });
+  const {
+    contentType,
+    finalUrl,
+    metadata: probeMetadata,
+  }: UrlProbeResult = precrawledArchiveAssetId
+    ? {
+        contentType: ASSET_TYPES.TEXT_HTML,
+        finalUrl: url,
+        metadata: Promise.resolve(null),
+      }
+    : await getContentTypeAndMetadata(url, jobId, job.abortSignal, runProxy, {
+        skipMetadataExtraction: reuseStoredProbeMetadata,
+      });
   job.abortSignal.throwIfAborted();
+
+  // For asset bookmarks the shortener is resolved via the content-type probe's
+  // redirect target (there's no browser crawl to derive it from). The HTML path
+  // resolves separately inside crawlAndParseUrl via the browser URL.
+  const assetUrl = resolveShortenedBookmarkUrl(url, finalUrl) ?? url;
 
   // Link bookmarks get transformed into asset bookmarks if they point to a supported asset instead of a webpage
   const isPdf = contentType === ASSET_TYPES.APPLICATION_PDF;
 
   if (isPdf) {
     await handleAsAssetBookmark(
-      url,
+      assetUrl,
       "pdf",
       userId,
       jobId,
@@ -414,7 +427,7 @@ async function runCrawler(
     SUPPORTED_UPLOAD_ASSET_TYPES.has(contentType)
   ) {
     await handleAsAssetBookmark(
-      url,
+      assetUrl,
       "image",
       userId,
       jobId,
@@ -448,7 +461,7 @@ async function runCrawler(
           }
           return metadata;
         });
-    const archivalLogic = await crawlAndParseUrl({
+    const { runArchival, effectiveUrl } = await crawlAndParseUrl({
       url,
       userId,
       jobId,
@@ -469,10 +482,10 @@ async function runCrawler(
       probeMetadataPromise,
     });
 
-    await enqueuePostCrawlJobs(job, bookmarkId, userId, url);
+    await enqueuePostCrawlJobs(job, bookmarkId, userId, effectiveUrl);
 
     // Do the archival as a separate last step as it has the potential for failure
-    await archivalLogic();
+    await runArchival();
   }
 
   // Record the latency from bookmark creation to crawl completion.

--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -39,6 +39,7 @@ import {
 } from "@karakeep/shared/queueing";
 import { getRateLimitClient } from "@karakeep/shared/ratelimiting";
 import { tryCatch } from "@karakeep/shared/tryCatch";
+import { resolveShortenedBookmarkUrl } from "@karakeep/shared/utils/url";
 import { WebhooksService } from "@karakeep/trpc/models/webhooks.service";
 
 import {
@@ -393,20 +394,32 @@ async function runCrawler(
   // it — reload it from the bookmark row instead.
   const reuseStoredProbeMetadata =
     job.runNumber > 0 && probeMetadataAt !== null;
-  const { contentType, metadata: probeMetadata }: UrlProbeResult =
-    precrawledArchiveAssetId
-      ? { contentType: ASSET_TYPES.TEXT_HTML, metadata: Promise.resolve(null) }
-      : await getContentTypeAndMetadata(url, jobId, job.abortSignal, runProxy, {
-          skipMetadataExtraction: reuseStoredProbeMetadata,
-        });
+  const {
+    contentType,
+    finalUrl,
+    metadata: probeMetadata,
+  }: UrlProbeResult = precrawledArchiveAssetId
+    ? {
+        contentType: ASSET_TYPES.TEXT_HTML,
+        finalUrl: url,
+        metadata: Promise.resolve(null),
+      }
+    : await getContentTypeAndMetadata(url, jobId, job.abortSignal, runProxy, {
+        skipMetadataExtraction: reuseStoredProbeMetadata,
+      });
   job.abortSignal.throwIfAborted();
+
+  // For asset bookmarks the shortener is resolved via the content-type probe's
+  // redirect target (there's no browser crawl to derive it from). The HTML path
+  // resolves separately inside crawlAndParseUrl via the browser URL.
+  const assetUrl = resolveShortenedBookmarkUrl(url, finalUrl) ?? url;
 
   // Link bookmarks get transformed into asset bookmarks if they point to a supported asset instead of a webpage
   const isPdf = contentType === ASSET_TYPES.APPLICATION_PDF;
 
   if (isPdf) {
     await handleAsAssetBookmark(
-      url,
+      assetUrl,
       "pdf",
       userId,
       jobId,
@@ -420,7 +433,7 @@ async function runCrawler(
     SUPPORTED_UPLOAD_ASSET_TYPES.has(contentType)
   ) {
     await handleAsAssetBookmark(
-      url,
+      assetUrl,
       "image",
       userId,
       jobId,
@@ -454,7 +467,7 @@ async function runCrawler(
           }
           return metadata;
         });
-    const archivalLogic = await crawlAndParseUrl({
+    const { runArchival, effectiveUrl } = await crawlAndParseUrl({
       url,
       userId,
       jobId,
@@ -475,10 +488,10 @@ async function runCrawler(
       probeMetadataPromise,
     });
 
-    await enqueuePostCrawlJobs(job, bookmarkId, userId, url);
+    await enqueuePostCrawlJobs(job, bookmarkId, userId, effectiveUrl);
 
     // Do the archival as a separate last step as it has the potential for failure
-    await archivalLogic();
+    await runArchival();
   }
 
   // Record the latency from bookmark creation to crawl completion.

--- a/packages/e2e_tests/docker-compose.yml
+++ b/packages/e2e_tests/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       MEILI_ADDR: http://meilisearch:7700
       BROWSER_WEB_URL: http://chrome:9222
       CRAWLER_NUM_WORKERS: 6
-      CRAWLER_ALLOWED_INTERNAL_HOSTNAMES: nginx
+      CRAWLER_ALLOWED_INTERNAL_HOSTNAMES: nginx,search.app
       CRAWLER_VIDEO_DOWNLOAD: "true"
       CRAWLER_VIDEO_DOWNLOAD_MAX_SIZE: -1
       OPENAI_API_KEY: aimock-test-key
@@ -44,6 +44,11 @@ services:
   nginx:
     image: nginx:alpine
     restart: unless-stopped
+    networks:
+      # Alias so the crawler can reach a "known link shortener" host in tests.
+      default:
+        aliases:
+          - search.app
     volumes:
       - ./setup/html:/usr/share/nginx/html
       - ./setup/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro

--- a/packages/e2e_tests/docker-compose.yml
+++ b/packages/e2e_tests/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       MEILI_ADDR: http://meilisearch:7700
       BROWSER_WEB_URL: http://chrome:9222
       CRAWLER_NUM_WORKERS: 6
-      CRAWLER_ALLOWED_INTERNAL_HOSTNAMES: nginx
+      CRAWLER_ALLOWED_INTERNAL_HOSTNAMES: nginx,search.app
       CRAWLER_STORE_PDF: "true"
       CRAWLER_VIDEO_DOWNLOAD: "true"
       CRAWLER_VIDEO_DOWNLOAD_MAX_SIZE: -1
@@ -48,6 +48,11 @@ services:
   nginx:
     image: nginx:alpine
     restart: unless-stopped
+    networks:
+      # Alias so the crawler can reach a "known link shortener" host in tests.
+      default:
+        aliases:
+          - search.app
     volumes:
       - ./setup/html:/usr/share/nginx/html
       - ./setup/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro

--- a/packages/e2e_tests/setup/nginx/default.conf
+++ b/packages/e2e_tests/setup/nginx/default.conf
@@ -7,6 +7,15 @@ server {
         return 302 http://127.0.0.1:80/hello.html;
     }
 
+    # Simulate a link-shortener redirect (reached via the search.app alias).
+    location = /shortlink {
+        return 302 http://nginx:80/hello.html;
+    }
+
+    location = /shortlink-image {
+        return 302 http://nginx:80/image.png;
+    }
+
     location / {
         try_files $uri =404;
     }

--- a/packages/e2e_tests/tests/workers/crawler.test.ts
+++ b/packages/e2e_tests/tests/workers/crawler.test.ts
@@ -143,6 +143,56 @@ describe("Crawler Tests", () => {
     expect(bookmark.content.htmlContent).toBeNull();
   });
 
+  it("resolves a known link-shortener URL to its destination", async () => {
+    // search.app is aliased to the nginx container and allow-listed as a
+    // known shortener, so /shortlink 302s to the real hello.html page.
+    let { data: bookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "link",
+        url: "http://search.app/shortlink",
+      },
+    });
+    assert(bookmark);
+
+    await waitUntil(async () => {
+      const data = await getBookmark(bookmark!.id);
+      assert(data);
+      assert(data.content.type === "link");
+      return data.content.crawledAt !== null;
+    }, "Shortened bookmark is crawled");
+
+    bookmark = await getBookmark(bookmark.id);
+    assert(bookmark && bookmark.content.type === "link");
+    // The stored URL should now be the resolved destination, not the short link.
+    expect(bookmark.content.url).not.toContain("search.app");
+    expect(bookmark.content.url).toContain("hello.html");
+    expect(bookmark.content.htmlContent).toContain("Hello World");
+  });
+
+  it("resolves a shortener that points directly to an asset", async () => {
+    let { data: bookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "link",
+        url: "http://search.app/shortlink-image",
+      },
+    });
+    assert(bookmark);
+
+    await waitUntil(async () => {
+      const data = await getBookmark(bookmark!.id);
+      assert(data);
+      return data.content.type === "asset";
+    }, "Shortened asset bookmark is converted to an image");
+
+    bookmark = await getBookmark(bookmark.id);
+    assert(bookmark && bookmark.content.type === "asset");
+    expect(bookmark.content.assetType).toBe("image");
+    // sourceUrl should be the resolved destination, not the short link.
+    expect(bookmark.content.sourceUrl).not.toContain("search.app");
+    expect(bookmark.content.sourceUrl).toContain("image.png");
+    expect(bookmark.content.fileName).toBe("image.png");
+  });
+
   it("image lings jobs be converted into images", async () => {
     let { data: bookmark } = await client.POST("/bookmarks", {
       body: {

--- a/packages/e2e_tests/tests/workers/crawler.test.ts
+++ b/packages/e2e_tests/tests/workers/crawler.test.ts
@@ -144,6 +144,56 @@ describe("Crawler Tests", () => {
     expect(bookmark.content.htmlContent).toBeNull();
   });
 
+  it("resolves a known link-shortener URL to its destination", async () => {
+    // search.app is aliased to the nginx container and allow-listed as a
+    // known shortener, so /shortlink 302s to the real hello.html page.
+    let { data: bookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "link",
+        url: "http://search.app/shortlink",
+      },
+    });
+    assert(bookmark);
+
+    await waitUntil(async () => {
+      const data = await getBookmark(bookmark!.id);
+      assert(data);
+      assert(data.content.type === "link");
+      return data.content.crawledAt !== null;
+    }, "Shortened bookmark is crawled");
+
+    bookmark = await getBookmark(bookmark.id);
+    assert(bookmark && bookmark.content.type === "link");
+    // The stored URL should now be the resolved destination, not the short link.
+    expect(bookmark.content.url).not.toContain("search.app");
+    expect(bookmark.content.url).toContain("hello.html");
+    expect(bookmark.content.htmlContent).toContain("Hello World");
+  });
+
+  it("resolves a shortener that points directly to an asset", async () => {
+    let { data: bookmark } = await client.POST("/bookmarks", {
+      body: {
+        type: "link",
+        url: "http://search.app/shortlink-image",
+      },
+    });
+    assert(bookmark);
+
+    await waitUntil(async () => {
+      const data = await getBookmark(bookmark!.id);
+      assert(data);
+      return data.content.type === "asset";
+    }, "Shortened asset bookmark is converted to an image");
+
+    bookmark = await getBookmark(bookmark.id);
+    assert(bookmark && bookmark.content.type === "asset");
+    expect(bookmark.content.assetType).toBe("image");
+    // sourceUrl should be the resolved destination, not the short link.
+    expect(bookmark.content.sourceUrl).not.toContain("search.app");
+    expect(bookmark.content.sourceUrl).toContain("image.png");
+    expect(bookmark.content.fileName).toBe("image.png");
+  });
+
   it("image lings jobs be converted into images", async () => {
     let { data: bookmark } = await client.POST("/bookmarks", {
       body: {

--- a/packages/shared/utils/url.test.ts
+++ b/packages/shared/utils/url.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isAllowedBookmarkUrl, setUrlHostnameFromResolvedAddress } from "./url";
+import {
+  isAllowedBookmarkUrl,
+  isKnownLinkShortener,
+  resolveShortenedBookmarkUrl,
+  setUrlHostnameFromResolvedAddress,
+} from "./url";
 
 describe("setUrlHostnameFromResolvedAddress", () => {
   it("sets IPv4 addresses as URL hostnames", () => {
@@ -65,5 +70,93 @@ describe("isAllowedBookmarkUrl", () => {
   it("rejects strings that are not URLs", () => {
     expect(isAllowedBookmarkUrl("not a url")).toBe(false);
     expect(isAllowedBookmarkUrl("")).toBe(false);
+  });
+});
+
+describe("isKnownLinkShortener", () => {
+  it("matches known shortener hosts", () => {
+    expect(isKnownLinkShortener("https://search.app/abc123")).toBe(true);
+    expect(isKnownLinkShortener("https://share.google/xyz")).toBe(true);
+  });
+
+  it("does not match ordinary destination hosts", () => {
+    expect(isKnownLinkShortener("https://example.com/article")).toBe(false);
+    expect(isKnownLinkShortener("https://news.google.com/story")).toBe(false);
+  });
+
+  it("does not match lookalike hosts that merely contain a shortener", () => {
+    expect(isKnownLinkShortener("https://search.app.evil.com/")).toBe(false);
+    expect(isKnownLinkShortener("https://notsearch.app/")).toBe(false);
+  });
+
+  it("returns false for non-URL input", () => {
+    expect(isKnownLinkShortener("not a url")).toBe(false);
+    expect(isKnownLinkShortener("")).toBe(false);
+  });
+
+  it("matches only the exact host, not subdomains", () => {
+    // Google emits the bare hosts; we keep the trust boundary tight.
+    expect(isKnownLinkShortener("https://www.search.app/abc")).toBe(false);
+    expect(isKnownLinkShortener("https://l.share.google/xyz")).toBe(false);
+  });
+});
+
+describe("resolveShortenedBookmarkUrl", () => {
+  it("returns the resolved URL when a known shortener redirects elsewhere", () => {
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://search.app/abc123",
+        "https://realsite.com/article",
+      ),
+    ).toBe("https://realsite.com/article");
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://share.google/xyz",
+        "https://news.example.com/story?id=5",
+      ),
+    ).toBe("https://news.example.com/story?id=5");
+  });
+
+  it("returns undefined when the original URL is not a known shortener", () => {
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://example.com/short",
+        "https://example.com/canonical",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the crawler did not change the URL", () => {
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://search.app/abc",
+        "https://search.app/abc",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the resolved URL is not a safe web URL", () => {
+    // A shortener must never be able to rewrite a bookmark to a dangerous scheme.
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://search.app/abc",
+        "javascript:alert(document.cookie)",
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://search.app/abc",
+        "file:///etc/passwd",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a lookalike shortener host", () => {
+    expect(
+      resolveShortenedBookmarkUrl(
+        "https://search.app.evil.com/abc",
+        "https://evil.com/payload",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/packages/shared/utils/url.ts
+++ b/packages/shared/utils/url.ts
@@ -15,3 +15,35 @@ export function isAllowedBookmarkUrl(url: string): boolean {
     return false;
   }
 }
+
+// Shorteners whose stored URL we replace with the crawler's resolved
+// destination. Kept to an allowlist so ordinary redirects don't rewrite URLs.
+export const KNOWN_LINK_SHORTENERS: readonly string[] = [
+  "search.app",
+  "share.google",
+];
+
+// Exact-host match (Google emits the bare hosts); subdomains don't count.
+export function isKnownLinkShortener(url: string): boolean {
+  try {
+    return KNOWN_LINK_SHORTENERS.includes(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+// Returns the resolved URL to store in place of a shortener, or undefined to
+// keep the original. The isAllowedBookmarkUrl guard blocks unsafe schemes.
+export function resolveShortenedBookmarkUrl(
+  originalUrl: string,
+  crawledUrl: string,
+): string | undefined {
+  if (
+    isKnownLinkShortener(originalUrl) &&
+    crawledUrl !== originalUrl &&
+    isAllowedBookmarkUrl(crawledUrl)
+  ) {
+    return crawledUrl;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Description

When a bookmark is saved as a Google short/share link (`https://search.app/...` or `https://share.google/...`), the crawler already follows the redirect to fetch and archive the real page — but the stored bookmark URL keeps the opaque short link. This means the entry never reflects the actual destination, and if the shortener ever stops resolving, the real URL is lost.

This PR overwrites the stored URL with the URL the crawler actually resolved to, but **only** when:

- the original host is a **known** link-shortener (`search.app`, `share.google`), and
- the crawler ended up at a **different** URL, and
- that destination is a **safe** `http(s)` URL.

Scoping it to a small allowlist (rather than following every redirect) means ordinary redirects — `http`→`https`, tracking-param strips, trailing-slash canonicalization — never silently rewrite the user's URL. The safe-scheme guard (reusing the existing `isAllowedBookmarkUrl`) ensures a shortener can never rewrite a bookmark to a `javascript:`/`data:`/`file:` URL.

The decision logic is extracted into a pure, unit-tested helper `resolveShortenedBookmarkUrl(originalUrl, crawledUrl)` in `packages/shared/utils/url.ts`. New shorteners can be added by extending the `KNOWN_LINK_SHORTENERS` list.

Resolution is applied consistently across all three outcomes of a crawl:

- **HTML pages** — folded into the existing `bookmarkLinks` update (**no new query, no DB migration**), using the browser's final URL (robust to client-side redirects).
- **Direct PDF/image links** — the content-type probe now returns the redirect's final URL, so the asset-bookmark path stores the resolved destination as `sourceUrl` instead of the short link.
- **Downstream jobs** — `crawlAndParseUrl` returns the effective (post-resolution) URL so the video-download queue receives the real destination, not the opaque short link.

Fixes #2235

## How Has This Been Tested?

- [x] Unit tests for `isKnownLinkShortener` and `resolveShortenedBookmarkUrl` in `packages/shared/utils/url.test.ts`, covering: known-shortener → resolved URL returned; non-shortener → unchanged; no-op redirect → unchanged; dangerous-scheme destination rejected; lookalike hosts (`search.app.evil.com`, `notsearch.app`, `www.search.app`) rejected. (18/18 passing.)
- [x] e2e tests in `packages/e2e_tests` — the nginx fixture container is aliased as `search.app` (allow-listed as a known shortener) with `/shortlink` and `/shortlink-image` redirects, asserting the stored `url` (HTML path) and `sourceUrl` (asset path) are the resolved destinations, not the short link. Run locally against the full container stack: 7/7 crawler tests passing (`http://search.app/shortlink` → stored `.../hello.html`; `http://search.app/shortlink-image` → `sourceUrl .../image.png`).
- [x] `pnpm typecheck`, `pnpm lint`, and `pnpm format` pass across the monorepo.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (No new dependencies.)
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was developed with the help of an AI coding assistant, following a test-driven approach (tests written and watched to fail before the implementation). All code was reviewed, run, and verified by me before submission.