### PR TITLE
fix(workers): honor RSS/Atom entry date as bookmark created date

### DIFF
--- a/apps/workers/workers/feedWorker.ts
+++ b/apps/workers/workers/feedWorker.ts
@@ -267,6 +267,10 @@ async function run(req: DequeuedJob<ZFeedRequestSchema>) {
         url: item.link!,
         title: item.title,
         source: "rss",
+        // Respect the entry's published date (when present) so imported
+        // bookmarks are dated when they were published, not when the feed was
+        // fetched. Falls back to the server default when the feed omits a date.
+        createdAt: item.publishedAt,
       }),
     ),
   );

--- a/apps/workers/workers/utils/feedParser.test.ts
+++ b/apps/workers/workers/utils/feedParser.test.ts
@@ -19,7 +19,55 @@ describe("parseFeedItems", () => {
       link: "https://www.twz.com/sea/test-article",
       title: "Test TWZ article",
       categories: ["Sea", "News & Features"],
+      // 2026-01-14 10:00:00 -0500 == 2026-01-14 15:00:00 UTC
+      publishedAt: new Date("2026-01-14T15:00:00.000Z"),
     });
+  });
+
+  test("extracts the published date from Atom feeds (e.g. Reddit)", async () => {
+    const items = await parseFeedItems(`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>reddit</title>
+        <entry>
+          <author><name>/u/username</name></author>
+          <id>post_id</id>
+          <link href="https://example.org/permalink"/>
+          <updated>2025-12-31T12:28:39+00:00</updated>
+          <published>2025-12-31T12:28:39+00:00</published>
+          <title>Post title</title>
+        </entry>
+      </feed>
+    `);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      guid: "post_id",
+      link: "https://example.org/permalink",
+      title: "Post title",
+      publishedAt: new Date("2025-12-31T12:28:39.000Z"),
+    });
+  });
+
+  test("leaves publishedAt undefined when the feed provides no date", async () => {
+    const items = await parseFeedItems(`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Test Feed</title>
+          <link>https://example.com</link>
+          <description>Test</description>
+          <item>
+            <guid isPermaLink="false">no-date</guid>
+            <link>https://example.com/no-date</link>
+            <title>No date</title>
+          </item>
+        </channel>
+      </rss>
+    `);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].publishedAt).toBeUndefined();
   });
 
   test("falls back to guid when feeds do not provide an item id", async () => {

--- a/apps/workers/workers/utils/feedParser.ts
+++ b/apps/workers/workers/utils/feedParser.ts
@@ -16,6 +16,17 @@ const optionalStringSchema = z.preprocess(
   z.string().optional(),
 );
 
+// rss-parser normalizes both the RSS `<pubDate>` and the Atom
+// `<updated>`/`<published>` elements into `isoDate`, so we prefer it and fall
+// back to the raw `pubDate` when the normalized value is missing.
+function parseFeedDate(value: string | undefined): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
 const feedItemSchema = z
   .object({
     id: optionalStringSchema,
@@ -23,10 +34,13 @@ const feedItemSchema = z
     guid: z.string().optional(),
     title: z.string().optional(),
     categories: z.array(categorySchema).optional(),
+    isoDate: optionalStringSchema,
+    pubDate: optionalStringSchema,
   })
   .transform((item) => ({
     ...item,
     guid: item.guid ?? item.id ?? item.link,
+    publishedAt: parseFeedDate(item.isoDate ?? item.pubDate),
   }));
 
 export type ParsedFeedItem = z.infer<typeof feedItemSchema>;


### PR DESCRIPTION
## Description

RSS/Atom feed entries carry a publication date (`<pubDate>` for RSS, `<updated>`/`<published>` for Atom), which rss-parser normalizes into `isoDate`. The feed worker ignored it and always created bookmarks with the fetch-time default, so entries imported from a feed were dated when the feed was polled instead of when they were published (e.g. a Reddit saved-posts feed shows "today" for every item).

This makes RSS ingestion consistent with file imports, which already honor their source date via `sourceAddedAt` -> `createdAt` in the import worker.

Changes:
- `feedParser`: parse the entry's published date (`isoDate`, falling back to raw `pubDate`) into a `publishedAt: Date | undefined`.
- `feedWorker`: pass it as `createdAt` when creating the bookmark; when the feed omits a date we send `undefined` and the server default is used.

Scope: this fixes the **date** half of the issue. The **author** part is a separate, crawler-side concern (link author is populated by the crawl and `createBookmark` has no author field for links), so it's intentionally left out of this PR.

Fixes #2334

## How Has This Been Tested?

- [x] Added `feedParser` unit tests (vitest): RSS `<pubDate>`, Atom `<updated>` (Reddit-style), and the no-date fallback (`publishedAt` undefined). Fail before the fix, pass after.
- [x] `pnpm --filter @karakeep/workers typecheck`, oxfmt `--check`, oxlint all clean.

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was written with substantial help from an AI coding assistant (Anthropic Claude), which located the bug, wrote the code and tests, and ran the checks. All changes were reviewed by me before submission, and I take responsibility for them.
