### PR TITLE
fix: respect PORT in Docker healthchecks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,7 +178,7 @@ RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/init-db-migration \
     /etc/s6-overlay/s6-rc.d/user/contents.d/svc-web \
     /etc/s6-overlay/s6-rc.d/user/contents.d/svc-workers
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider "http://127.0.0.1:${PORT:-3000}/api/health" || exit 1
 
 ################# The web container ##############
 
@@ -188,7 +188,7 @@ RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/init-db-migration \
     /etc/s6-overlay/s6-rc.d/user/contents.d/svc-web
 ENV USING_LEGACY_SEPARATE_CONTAINERS=true
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider "http://127.0.0.1:${PORT:-3000}/api/health" || exit 1
 
 ################# The workers container ##############
 


### PR DESCRIPTION
## Summary
Fixes #2940

Update the Docker image healthchecks to use the configured `PORT` environment variable, while retaining `3000` as the default when `PORT` is unset.

## Changes
- Use `${PORT:-3000}` in the AIO image healthcheck URL
- Use `${PORT:-3000}` in the legacy web image healthcheck URL

## Test Plan
- Verified both Dockerfile `HEALTHCHECK` lines now reference `http://127.0.0.1:${PORT:-3000}/api/health`
- Smoke-tested shell expansion: unset `PORT` resolves to `:3000`; `PORT=80` resolves to `:80`
- Docker image build was not run locally because Docker/Podman is unavailable in this cron environment