### PR TITLE
fix: track import progress per-job

### DIFF
--- a/apps/web/components/settings/ImportExport.tsx
+++ b/apps/web/components/settings/ImportExport.tsx
@@ -347,18 +347,18 @@ export function ImportExportRow() {
         </ImportCard>
         <ExportButton />
       </div>
-      {importProgress && (
-        <div className="flex flex-col gap-2">
-          <p className="shrink-0 text-sm">
-            Processed {importProgress.done} of {importProgress.total} bookmarks
-          </p>
-          <div className="w-full">
-            <Progress
-              value={(importProgress.done * 100) / importProgress.total}
-            />
+      {Object.entries(importProgress).map(([id, progress]) => {
+        return (
+          <div key={id} className="flex flex-col gap-2">
+            <p className="shrink-0 text-sm">
+              Processed {progress.done} of {progress.total} bookmarks
+            </p>
+            <div className="w-full">
+              <Progress value={(progress.done * 100) / progress.total} />
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/lib/hooks/useBookmarkImport.ts
+++ b/apps/web/lib/hooks/useBookmarkImport.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { toast } from "@/components/ui/sonner";
 import { useTranslation } from "@/lib/i18n/client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -24,9 +24,9 @@ export function useBookmarkImport() {
   const { t } = useTranslation();
   const api = useTRPC();
 
-  const [importProgress, setImportProgress] = useState<ImportProgress | null>(
-    null,
-  );
+  const [importProgress, setImportProgress] = useState<
+    Record<string, ImportProgress>
+  >({});
   const [quotaError, setQuotaError] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
@@ -38,6 +38,7 @@ export function useBookmarkImport() {
   const { mutateAsync: finalizeImportStaging } = useMutation(
     api.importSessions.finalizeImportStaging.mutationOptions(),
   );
+  const currentImportIds = useRef(new Map<File, string>());
 
   const uploadBookmarkFileMutation = useMutation({
     mutationFn: async ({
@@ -90,7 +91,10 @@ export function useBookmarkImport() {
               await finalizeImportStaging({ importSessionId: sessionId });
             },
           },
-          onProgress: (done, total) => setImportProgress({ done, total }),
+          onProgress: (id, done, total) => {
+            currentImportIds.current.set(file, id);
+            setImportProgress((prev) => ({ ...prev, [id]: { done, total } }));
+          },
         },
         {
           // Use a custom parser to avoid re-parsing the file
@@ -102,7 +106,13 @@ export function useBookmarkImport() {
       return result;
     },
     onSuccess: async (result) => {
-      setImportProgress(null);
+      setImportProgress((prev) => {
+        const next = { ...prev };
+        if (result.importSessionId) {
+          delete next[result.importSessionId];
+        }
+        return next;
+      });
 
       if (result.counts.total === 0) {
         toast({ description: "No bookmarks found in the file." });
@@ -114,8 +124,17 @@ export function useBookmarkImport() {
         variant: "default",
       });
     },
-    onError: (error) => {
-      setImportProgress(null);
+    onError: (error, variables) => {
+      const id = currentImportIds.current.get(variables.file);
+      setImportProgress((prev) => {
+        const next = { ...prev };
+        if (id) {
+          delete next[id];
+        }
+        return next;
+      });
+      currentImportIds.current.delete(variables.file);
+
       toast({
         description: error.message,
         variant: "destructive",

--- a/apps/web/lib/hooks/useBookmarkImport.ts
+++ b/apps/web/lib/hooks/useBookmarkImport.ts
@@ -105,7 +105,7 @@ export function useBookmarkImport() {
       );
       return result;
     },
-    onSuccess: async (result) => {
+    onSuccess: async (result, variables) => {
       setImportProgress((prev) => {
         const next = { ...prev };
         if (result.importSessionId) {
@@ -113,6 +113,7 @@ export function useBookmarkImport() {
         }
         return next;
       });
+      currentImportIds.current.delete(variables.file);
 
       if (result.counts.total === 0) {
         toast({ description: "No bookmarks found in the file." });

--- a/packages/shared/import-export/importer.test.ts
+++ b/packages/shared/import-export/importer.test.ts
@@ -97,7 +97,7 @@ describe("importBookmarksFromFile", () => {
           finalizeImportStaging,
           createImportSession,
         },
-        onProgress: (d, t) => progress.push(d / t),
+        onProgress: (i, d, t) => progress.push(d / t),
       },
       { parsers },
     );
@@ -261,7 +261,7 @@ describe("importBookmarksFromFile", () => {
           finalizeImportStaging,
           createImportSession,
         },
-        onProgress: (d, t) => progress.push(d / t),
+        onProgress: (i, d, t) => progress.push(d / t),
       },
       { parsers },
     );
@@ -361,7 +361,7 @@ describe("importBookmarksFromFile", () => {
           finalizeImportStaging,
           createImportSession,
         },
-        onProgress: (d, t) => progress.push(d / t),
+        onProgress: (i, d, t) => progress.push(d / t),
       },
       { parsers },
     );

--- a/packages/shared/import-export/importer.ts
+++ b/packages/shared/import-export/importer.ts
@@ -65,7 +65,7 @@ export async function importBookmarksFromFile(
     source: ImportSource;
     rootListName: string;
     deps: ImportDeps;
-    onProgress?: (done: number, total: number) => void;
+    onProgress?: (id: string, done: number, total: number) => void;
   },
   options: ImportOptions = {},
 ): Promise<ImportResult> {
@@ -91,7 +91,7 @@ export async function importBookmarksFromFile(
     rootListId: rootList.id,
   });
 
-  onProgress?.(0, parsedBookmarks.length);
+  onProgress?.(session.id, 0, parsedBookmarks.length);
 
   const externalListIdToCreatedListId: Record<string, string> = {};
   if (parsedLists.length > 0) {
@@ -268,7 +268,7 @@ export async function importBookmarksFromFile(
       bookmarks: batch,
     });
     staged += batch.length;
-    onProgress?.(staged, parsedBookmarks.length);
+    onProgress?.(session.id, staged, parsedBookmarks.length);
   }
 
   // Finalize staging - marks session as "pending" for worker pickup


### PR DESCRIPTION
## Description
Fixes an issue where importing from multiple sources in parallel only showed a single progress bar.
Each import job now tracks its own progress by session id instead of sharing one state object.

Fixes #858 

## How Has This Been Tested?

- [x] Tested two parallel imports and confirmed both progress bars update independently
- [x] Ran pnpm test on the affected test file and  typecheck, lint, format

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="1192" height="658" alt="48DA76D8-9264-47F8-99E0-F673BC0FF80B_1_105_c" src="https://github.com/user-attachments/assets/9f47f659-66b6-4679-ac7a-fd361cde3dc5" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used Claude like a rubber duck to guide me when I get stuck, no code generation