### PR TITLE
fix: save PDF URLs correctly when SingleFile is enabled

### DIFF
--- a/apps/browser-extension/src/SavePage.tsx
+++ b/apps/browser-extension/src/SavePage.tsx
@@ -21,7 +21,7 @@ import {
 } from "./utils/singlefile";
 import { useTRPC } from "./utils/trpc";
 import { MessageType } from "./utils/type";
-import { isHttpUrl } from "./utils/url";
+import { isHttpUrl, isLikelyDirectPdfUrl } from "./utils/url";
 
 export default function SavePage() {
   const api = useTRPC();
@@ -131,6 +131,9 @@ export default function SavePage() {
       !bookmark.precrawledArchiveId &&
       currentTabUrl !== undefined &&
       bookmark.url === currentTabUrl &&
+      // PDF viewer tabs only expose a useless HTML shell to SingleFile; let the
+      // server crawler download the real application/pdf bytes instead.
+      !isLikelyDirectPdfUrl(bookmark.url) &&
       // The `<all_urls>` host permission is optional and only granted when the
       // user opts in to client-side crawling; it may have been revoked since.
       (await hasHostPermission())

--- a/apps/browser-extension/src/utils/url.ts
+++ b/apps/browser-extension/src/utils/url.ts
@@ -9,6 +9,24 @@ export function isHttpUrl(url: string) {
 }
 
 /**
+ * Heuristic for direct PDF URLs where SingleFile would only capture the
+ * browser PDF viewer shell (e.g. arXiv `/pdf/<id>` with no `.pdf` suffix).
+ */
+export function isLikelyDirectPdfUrl(url: string): boolean {
+  try {
+    const { pathname } = new URL(url);
+    const lower = pathname.toLowerCase();
+    if (lower.endsWith(".pdf")) {
+      return true;
+    }
+    // arXiv and similar: /pdf/2301.04104 or /pdf/2301.04104v1
+    return /\/pdf\/[^/]+$/i.test(pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Normalize a URL by removing the hash and trailing slash.
  * @param url The URL to process.
  * @param base Optional base URL for relative URLs.

--- a/apps/workers/workers/assetPreprocessingWorker.ts
+++ b/apps/workers/workers/assetPreprocessingWorker.ts
@@ -33,6 +33,12 @@ import {
   EnqueueOptions,
   getQueueClient,
 } from "@karakeep/shared/queueing";
+import {
+  isWeakPdfTitle,
+  normalizePdfTitleCandidate,
+} from "@karakeep/shared/utils/pdfTitle";
+
+import { extractPdfOutlineTitle } from "./utils/pdfOutlineTitle";
 
 export class AssetPreprocessingWorker {
   static async build() {
@@ -169,7 +175,7 @@ async function readImageTextWithLLM(
 
 async function readPDFText(buffer: Buffer): Promise<{
   text: string;
-  metadata: Record<string, object>;
+  metadata: Record<string, unknown> | undefined;
 }> {
   return new Promise((resolve, reject) => {
     const pdfParser = new PDFParser(null, true);
@@ -177,11 +183,37 @@ async function readPDFText(buffer: Buffer): Promise<{
     pdfParser.on("pdfParser_dataReady", (pdfData) => {
       resolve({
         text: pdfParser.getRawTextContent(),
-        metadata: pdfData.Meta,
+        metadata: pdfData.Meta as Record<string, unknown> | undefined,
       });
     });
     pdfParser.parseBuffer(buffer);
   });
+}
+
+function titleFromPdfMetadata(
+  metadata: Record<string, unknown> | undefined,
+): string | null {
+  if (!metadata) {
+    return null;
+  }
+  return normalizePdfTitleCandidate(
+    typeof metadata.Title === "string" ? metadata.Title : null,
+  );
+}
+
+async function resolvePdfDocumentTitle(
+  buffer: Buffer,
+  metadata: Record<string, unknown> | undefined,
+): Promise<string | null> {
+  const fromMeta = titleFromPdfMetadata(metadata);
+  if (fromMeta) {
+    return fromMeta;
+  }
+  try {
+    return await extractPdfOutlineTitle(buffer);
+  } catch {
+    return null;
+  }
 }
 
 export async function extractAndSavePDFScreenshot(
@@ -368,6 +400,23 @@ async function extractAndSavePDFText(
       metadata: pdfParse.metadata ? JSON.stringify(pdfParse.metadata) : null,
     })
     .where(eq(bookmarkAssets.id, bookmark.id));
+
+  if (isWeakPdfTitle(bookmark.title, bookmark.asset.fileName)) {
+    const extractedTitle = await resolvePdfDocumentTitle(
+      asset,
+      pdfParse.metadata,
+    );
+    if (extractedTitle) {
+      await db
+        .update(bookmarks)
+        .set({ title: extractedTitle })
+        .where(eq(bookmarks.id, bookmark.id));
+      logger.info(
+        `[assetPreprocessing][${jobId}] Set PDF bookmark title from metadata/outline: "${extractedTitle}"`,
+      );
+    }
+  }
+
   return true;
 }
 

--- a/apps/workers/workers/crawler/crawlAndParse.ts
+++ b/apps/workers/workers/crawler/crawlAndParse.ts
@@ -34,6 +34,7 @@ import {
 import serverConfig from "@karakeep/shared/config";
 import logger from "@karakeep/shared/logger";
 import { BookmarkTypes } from "@karakeep/shared/types/bookmarks";
+import { isWeakPdfTitle } from "@karakeep/shared/utils/pdfTitle";
 
 import type { ParseSubprocessOutput } from "../utils/parseHtmlSubprocessIpc";
 import {
@@ -99,6 +100,14 @@ export async function handleAsAssetBookmark(
         return;
       }
       const fileName = path.basename(new URL(url).pathname);
+      const existing = await db.query.bookmarks.findFirst({
+        where: eq(bookmarks.id, bookmarkId),
+        columns: { title: true },
+      });
+      // Browser PDF tabs often set title to the arXiv id / filename. Clear those
+      // so asset preprocessing can fill a real title from PDF metadata/outline.
+      const clearWeakTitle =
+        assetType === "pdf" && isWeakPdfTitle(existing?.title, fileName);
       await db.transaction(async (trx) => {
         await updateAsset(
           undefined,
@@ -124,7 +133,10 @@ export async function handleAsAssetBookmark(
         // Switch the type of the bookmark from LINK to ASSET
         await trx
           .update(bookmarks)
-          .set({ type: BookmarkTypes.ASSET })
+          .set({
+            type: BookmarkTypes.ASSET,
+            ...(clearWeakTitle ? { title: null } : {}),
+          })
           .where(eq(bookmarks.id, bookmarkId));
         await trx.delete(bookmarkLinks).where(eq(bookmarkLinks.id, bookmarkId));
       });

--- a/apps/workers/workers/crawlerWorker.ts
+++ b/apps/workers/workers/crawlerWorker.ts
@@ -377,28 +377,35 @@ async function runCrawler(
     `[Crawler][${jobId}] Will crawl "${truncateUrl(url)}" for link with id "${bookmarkId}"`,
   );
 
-  if (precrawledArchiveAssetId) {
-    logger.info(
-      `[Crawler][${jobId}] Skipped fetching content-type for the url ${url} as precrawledArchiveAssetId exists`,
-    );
-  }
+  // Always resolve content-type even when a precrawled archive exists. Client-side
+  // SingleFile captures of PDF viewer tabs upload a useless HTML shell; without
+  // this check those bookmarks never become real PDF assets.
+  //
   // Retry runs re-probe for the content type, but if a previous run already
   // extracted and stored the probe metadata (probeMetadataAt), don't re-fetch
-  // it — reload it from the bookmark row instead.
+  // it - reload it from the bookmark row instead.
   const reuseStoredProbeMetadata =
     job.runNumber > 0 && probeMetadataAt !== null;
   const { contentType, metadata: probeMetadata }: UrlProbeResult =
-    precrawledArchiveAssetId
-      ? { contentType: ASSET_TYPES.TEXT_HTML, metadata: Promise.resolve(null) }
-      : await getContentTypeAndMetadata(url, jobId, job.abortSignal, runProxy, {
-          skipMetadataExtraction: reuseStoredProbeMetadata,
-        });
+    await getContentTypeAndMetadata(url, jobId, job.abortSignal, runProxy, {
+      skipMetadataExtraction: reuseStoredProbeMetadata,
+    });
   job.abortSignal.throwIfAborted();
+  if (precrawledArchiveAssetId) {
+    logger.info(
+      `[Crawler][${jobId}] Precrawled archive present; resolved content-type for ${url} as ${contentType ?? "unknown"}`,
+    );
+  }
 
   // Link bookmarks get transformed into asset bookmarks if they point to a supported asset instead of a webpage
   const isPdf = contentType === ASSET_TYPES.APPLICATION_PDF;
 
   if (isPdf) {
+    if (precrawledArchiveAssetId) {
+      logger.info(
+        `[Crawler][${jobId}] Ignoring precrawled HTML archive for PDF URL ${url}`,
+      );
+    }
     await handleAsAssetBookmark(
       url,
       "pdf",
@@ -413,6 +420,11 @@ async function runCrawler(
     IMAGE_ASSET_TYPES.has(contentType) &&
     SUPPORTED_UPLOAD_ASSET_TYPES.has(contentType)
   ) {
+    if (precrawledArchiveAssetId) {
+      logger.info(
+        `[Crawler][${jobId}] Ignoring precrawled HTML archive for image URL ${url}`,
+      );
+    }
     await handleAsAssetBookmark(
       url,
       "image",

--- a/apps/workers/workers/utils/pdfOutlineTitle.ts
+++ b/apps/workers/workers/utils/pdfOutlineTitle.ts
@@ -1,0 +1,31 @@
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+
+import { normalizePdfTitleCandidate } from "@karakeep/shared/utils/pdfTitle";
+
+/**
+ * Extract the first outline (bookmark) title from a PDF. LaTeX/hyperref often
+ * puts the paper title here while leaving the info dictionary /Title empty.
+ */
+export async function extractPdfOutlineTitle(
+  buffer: Buffer,
+): Promise<string | null> {
+  const loadingTask = getDocument({
+    data: new Uint8Array(buffer),
+    useSystemFonts: true,
+    isEvalSupported: false,
+    // Workers are unnecessary for a one-shot metadata read in Node.
+    useWorkerFetch: false,
+    isOffscreenCanvasSupported: false,
+  });
+
+  const doc = await loadingTask.promise;
+  try {
+    const outline = await doc.getOutline();
+    if (!outline || outline.length === 0) {
+      return null;
+    }
+    return normalizePdfTitleCandidate(outline[0]?.title);
+  } finally {
+    await doc.destroy();
+  }
+}

--- a/packages/shared/utils/pdfTitle.test.ts
+++ b/packages/shared/utils/pdfTitle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  isWeakPdfTitle,
+  looksLikeArxivId,
+  normalizePdfTitleCandidate,
+} from "./pdfTitle";
+
+describe("pdfTitle", () => {
+  test("normalizePdfTitleCandidate trims and rejects empty", () => {
+    expect(normalizePdfTitleCandidate("  Hello  ")).toBe("Hello");
+    expect(normalizePdfTitleCandidate("")).toBeNull();
+    expect(normalizePdfTitleCandidate("   ")).toBeNull();
+    expect(normalizePdfTitleCandidate(null)).toBeNull();
+  });
+
+  test("looksLikeArxivId matches common id shapes", () => {
+    expect(looksLikeArxivId("2301.04104")).toBe(true);
+    expect(looksLikeArxivId("2301.04104v1")).toBe(true);
+    expect(looksLikeArxivId("hep-th/9901001")).toBe(true);
+    expect(looksLikeArxivId("Attention Is All You Need")).toBe(false);
+    expect(looksLikeArxivId("paper.pdf")).toBe(false);
+  });
+
+  test("isWeakPdfTitle treats null, filename, and arxiv ids as weak", () => {
+    expect(isWeakPdfTitle(null)).toBe(true);
+    expect(isWeakPdfTitle("2301.04104")).toBe(true);
+    expect(isWeakPdfTitle("2301.04104", "2301.04104")).toBe(true);
+    expect(isWeakPdfTitle("report", "report.pdf")).toBe(true);
+    expect(isWeakPdfTitle("report.pdf", "report.pdf")).toBe(true);
+    expect(
+      isWeakPdfTitle(
+        "RAG-MCP: Mitigating Prompt Bloat in LLM Tool Selection",
+        "2505.03275",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/utils/pdfTitle.ts
+++ b/packages/shared/utils/pdfTitle.ts
@@ -1,0 +1,53 @@
+/**
+ * ArXiv ids look like `2301.04104` or `2301.04104v2` (optionally with a
+ * category prefix such as `hep-th/9901001` for older papers).
+ */
+// New-style: 2301.04104[vN]. Old-style: hep-th/9901001[vN].
+const ARXIV_ID_RE = /^(?:[a-z-]+\/)?(?:\d{4}\.\d{4,5}|\d{7})(?:v\d+)?$/i;
+
+export function looksLikeArxivId(value: string): boolean {
+  return ARXIV_ID_RE.test(value.trim());
+}
+
+/**
+ * Normalize a candidate PDF title. Returns null for empty / whitespace-only
+ * strings so callers can fall through to the next source.
+ */
+export function normalizePdfTitleCandidate(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Titles that are not useful for display — empty, equal to the asset filename,
+ * or an opaque arXiv paper id (common browser PDF tab titles).
+ */
+export function isWeakPdfTitle(
+  title: string | null | undefined,
+  fileName?: string | null,
+): boolean {
+  const normalized = normalizePdfTitleCandidate(title);
+  if (!normalized) {
+    return true;
+  }
+
+  const basename = fileName ? pathBasenameWithoutExtension(fileName) : null;
+  if (basename && normalized.toLowerCase() === basename.toLowerCase()) {
+    return true;
+  }
+  if (fileName && normalized.toLowerCase() === fileName.toLowerCase()) {
+    return true;
+  }
+
+  return looksLikeArxivId(normalized);
+}
+
+function pathBasenameWithoutExtension(fileName: string): string {
+  const base = fileName.split(/[/\\]/).pop() ?? fileName;
+  return base.replace(/\.pdf$/i, "");
+}


### PR DESCRIPTION
## Summary
- Skip SingleFile capture for direct PDF tabs (including arXiv `/pdf/<id>`), so the server can download the real PDF
- Always probe content-type even when a precrawled archive exists; ignore HTML archives for PDF/image URLs
- Set PDF bookmark titles from info `/Title` or outline metadata when the current title is weak (filename / arXiv id)

Fixes the common failure mode where client-side crawling captures the browser PDF viewer shell and the crawler then skips PDF detection.

Related: #2714

## Test plan
- [ ] Enable client-side crawling in the extension
- [ ] Save `https://arxiv.org/pdf/2505.03275` (has outline title)
- [ ] Confirm bookmark becomes a PDF asset with the paper title, not `2505.03275`
- [ ] Save a normal HTML page with SingleFile still on and confirm archive capture still works
- [ ] Save `https://arxiv.org/pdf/2301.04104` and confirm it becomes a PDF asset (title may stay as id if the PDF has no metadata/outline)