### PR TITLE
fix: defer tag updates in bookmark editor

### DIFF
--- a/apps/web/components/dashboard/bookmarks/EditBookmarkDialog.tsx
+++ b/apps/web/components/dashboard/bookmarks/EditBookmarkDialog.tsx
@@ -37,7 +37,10 @@ import { format } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { useForm } from "react-hook-form";
 
-import { useUpdateBookmark } from "@karakeep/shared-react/hooks/bookmarks";
+import {
+  useUpdateBookmark,
+  useUpdateBookmarkTags,
+} from "@karakeep/shared-react/hooks/bookmarks";
 import { useTRPC } from "@karakeep/shared-react/trpc";
 import {
   BookmarkTypes,
@@ -46,7 +49,13 @@ import {
 } from "@karakeep/shared/types/bookmarks";
 import { getBookmarkTitle } from "@karakeep/shared/utils/bookmarkUtils";
 
-import { BookmarkTagsEditor } from "./BookmarkTagsEditor";
+import {
+  createEmptyDeferredTagChanges,
+  persistBookmarkEdits,
+  stageTagAttachment,
+  stageTagDetachment,
+} from "./deferredBookmarkTags";
+import { TagsEditor } from "./TagsEditor";
 
 const formSchema = zUpdateBookmarksRequestSchema.extend({
   createdAt: z.date().optional(),
@@ -119,31 +128,65 @@ export function EditBookmarkDialog({
     defaultValues: bookmarkToDefault(bookmark),
   });
 
-  const { mutate: updateBookmarkMutate, isPending: isUpdatingBookmark } =
-    useUpdateBookmark({
-      onSuccess: (updatedBookmark) => {
-        toast({ description: "Bookmark details updated successfully!" });
-        // Close the dialog after successful detail update
-        setOpen(false);
-        // Reset form with potentially updated data
-        form.reset(bookmarkToDefault(updatedBookmark));
-      },
-      onError: (error) => {
-        toast({
-          variant: "destructive",
-          title: "Failed to update bookmark",
-          description: error.message,
-        });
-      },
-    });
+  const [deferredTagChanges, setDeferredTagChanges] = React.useState(
+    createEmptyDeferredTagChanges,
+  );
+  const [tagEditorSession, setTagEditorSession] = React.useState(0);
+  const initialTagsRef = React.useRef(bookmark.tags);
+  const previousOpenRef = React.useRef(open);
 
-  function onSubmit(values: BookmarkFormValues) {
+  React.useEffect(() => {
+    if (open && !previousOpenRef.current) {
+      initialTagsRef.current = bookmark.tags;
+      setDeferredTagChanges(createEmptyDeferredTagChanges());
+      setTagEditorSession((session) => session + 1);
+    }
+    previousOpenRef.current = open;
+  }, [bookmark.tags, open]);
+
+  const { mutateAsync: updateBookmarkMutate, isPending: isUpdatingBookmark } =
+    useUpdateBookmark();
+  const { mutateAsync: updateTagsMutate, isPending: isUpdatingTags } =
+    useUpdateBookmarkTags();
+  const isUpdating = isUpdatingBookmark || isUpdatingTags;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setDeferredTagChanges(createEmptyDeferredTagChanges());
+      setTagEditorSession((session) => session + 1);
+    }
+    setOpen(nextOpen);
+  };
+
+  async function onSubmit(values: BookmarkFormValues) {
     // Ensure optional fields that are empty strings are sent as null/undefined if appropriate
     const payload = {
       ...values,
       title: values.title ?? null,
     };
-    updateBookmarkMutate(payload);
+
+    try {
+      const updatedBookmark = await persistBookmarkEdits({
+        saveDetails: () => updateBookmarkMutate(payload),
+        saveTags: (changes) =>
+          updateTagsMutate({
+            bookmarkId: bookmark.id,
+            ...changes,
+          }),
+        tagChanges: deferredTagChanges,
+      });
+
+      toast({ description: "Bookmark details updated successfully!" });
+      handleOpenChange(false);
+      form.reset(bookmarkToDefault(updatedBookmark));
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Failed to update bookmark",
+        description:
+          error instanceof Error ? error.message : "Something went wrong",
+      });
+    }
   }
 
   // Reset form only when dialog is initially opened to preserve unsaved changes
@@ -162,7 +205,7 @@ export function EditBookmarkDialog({
   const isAsset = bookmark.content.type === BookmarkTypes.ASSET;
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       {children && <DialogTrigger asChild>{children}</DialogTrigger>}
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
@@ -418,7 +461,20 @@ export function EditBookmarkDialog({
             <FormItem>
               <FormLabel>{t("common.tags")}</FormLabel>
               <FormControl>
-                <BookmarkTagsEditor bookmark={bookmark} />
+                <TagsEditor
+                  key={tagEditorSession}
+                  tags={bookmark.tags}
+                  onAttach={(tag) => {
+                    setDeferredTagChanges((changes) =>
+                      stageTagAttachment(changes, initialTagsRef.current, tag),
+                    );
+                  }}
+                  onDetach={(tag) => {
+                    setDeferredTagChanges((changes) =>
+                      stageTagDetachment(changes, initialTagsRef.current, tag),
+                    );
+                  }}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -427,12 +483,12 @@ export function EditBookmarkDialog({
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => setOpen(false)}
-                disabled={isUpdatingBookmark}
+                onClick={() => handleOpenChange(false)}
+                disabled={isUpdating}
               >
                 {t("actions.cancel")}
               </Button>
-              <ActionButton type="submit" loading={isUpdatingBookmark}>
+              <ActionButton type="submit" loading={isUpdating}>
                 {t("bookmark_editor.save_changes")}
               </ActionButton>
             </DialogFooter>

--- a/apps/web/components/dashboard/bookmarks/EditBookmarkDialog.tsx
+++ b/apps/web/components/dashboard/bookmarks/EditBookmarkDialog.tsx
@@ -131,13 +131,14 @@ export function EditBookmarkDialog({
   const [deferredTagChanges, setDeferredTagChanges] = React.useState(
     createEmptyDeferredTagChanges,
   );
+  // Query refreshes must not overwrite tag changes staged in this edit session.
+  const [initialTags, setInitialTags] = React.useState(bookmark.tags);
   const [tagEditorSession, setTagEditorSession] = React.useState(0);
-  const initialTagsRef = React.useRef(bookmark.tags);
   const previousOpenRef = React.useRef(open);
 
   React.useEffect(() => {
     if (open && !previousOpenRef.current) {
-      initialTagsRef.current = bookmark.tags;
+      setInitialTags(bookmark.tags);
       setDeferredTagChanges(createEmptyDeferredTagChanges());
       setTagEditorSession((session) => session + 1);
     }
@@ -463,15 +464,15 @@ export function EditBookmarkDialog({
               <FormControl>
                 <TagsEditor
                   key={tagEditorSession}
-                  tags={bookmark.tags}
+                  tags={initialTags}
                   onAttach={(tag) => {
                     setDeferredTagChanges((changes) =>
-                      stageTagAttachment(changes, initialTagsRef.current, tag),
+                      stageTagAttachment(changes, initialTags, tag),
                     );
                   }}
                   onDetach={(tag) => {
                     setDeferredTagChanges((changes) =>
-                      stageTagDetachment(changes, initialTagsRef.current, tag),
+                      stageTagDetachment(changes, tag),
                     );
                   }}
                 />

--- a/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.test.ts
+++ b/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ZBookmarkTags } from "@karakeep/shared/types/tags";
+
+import {
+  createEmptyDeferredTagChanges,
+  persistBookmarkEdits,
+  stageTagAttachment,
+  stageTagDetachment,
+} from "./deferredBookmarkTags";
+
+const initialTags: ZBookmarkTags[] = [
+  { id: "tag-1", name: "news", attachedBy: "human" },
+];
+
+describe("deferred bookmark tag changes", () => {
+  it("cancels a pending attachment when the tag is removed", () => {
+    const attached = stageTagAttachment(
+      createEmptyDeferredTagChanges(),
+      initialTags,
+      { tagName: "later" },
+    );
+    expect(attached).toEqual({
+      attach: [{ tagName: "later" }],
+      detach: [],
+    });
+
+    const detached = stageTagDetachment(attached, initialTags, {
+      tagId: "temp-1",
+      tagName: "later",
+    });
+
+    expect(detached).toEqual(createEmptyDeferredTagChanges());
+  });
+
+  it("cancels a pending detachment when the original tag is restored", () => {
+    const detached = stageTagDetachment(
+      createEmptyDeferredTagChanges(),
+      initialTags,
+      { tagId: "tag-1", tagName: "news" },
+    );
+    expect(detached).toEqual({
+      attach: [],
+      detach: [{ tagId: "tag-1" }],
+    });
+
+    const restored = stageTagAttachment(detached, initialTags, {
+      tagId: "tag-1",
+      tagName: "news",
+    });
+
+    expect(restored).toEqual(createEmptyDeferredTagChanges());
+  });
+
+  it("saves details before applying tag changes", async () => {
+    const events: string[] = [];
+    const saveDetails = vi.fn(async () => {
+      events.push("details");
+      return { id: "bookmark-1" };
+    });
+    const saveTags = vi.fn(async () => {
+      events.push("tags");
+    });
+
+    await persistBookmarkEdits({
+      saveDetails,
+      saveTags,
+      tagChanges: {
+        attach: [],
+        detach: [{ tagId: "tag-1" }],
+      },
+    });
+
+    expect(events).toEqual(["details", "tags"]);
+  });
+
+  it("does not apply tag changes when saving details fails", async () => {
+    const error = new Error("details failed");
+    const saveTags = vi.fn();
+
+    await expect(
+      persistBookmarkEdits({
+        saveDetails: () => Promise.reject(error),
+        saveTags,
+        tagChanges: {
+          attach: [],
+          detach: [{ tagId: "tag-1" }],
+        },
+      }),
+    ).rejects.toBe(error);
+
+    expect(saveTags).not.toHaveBeenCalled();
+  });
+
+  it("skips the tag request when no tags changed", async () => {
+    const saveTags = vi.fn();
+
+    await persistBookmarkEdits({
+      saveDetails: async () => ({ id: "bookmark-1" }),
+      saveTags,
+      tagChanges: createEmptyDeferredTagChanges(),
+    });
+
+    expect(saveTags).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.test.ts
+++ b/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.test.ts
@@ -25,7 +25,7 @@ describe("deferred bookmark tag changes", () => {
       detach: [],
     });
 
-    const detached = stageTagDetachment(attached, initialTags, {
+    const detached = stageTagDetachment(attached, {
       tagId: "temp-1",
       tagName: "later",
     });
@@ -34,11 +34,10 @@ describe("deferred bookmark tag changes", () => {
   });
 
   it("cancels a pending detachment when the original tag is restored", () => {
-    const detached = stageTagDetachment(
-      createEmptyDeferredTagChanges(),
-      initialTags,
-      { tagId: "tag-1", tagName: "news" },
-    );
+    const detached = stageTagDetachment(createEmptyDeferredTagChanges(), {
+      tagId: "tag-1",
+      tagName: "news",
+    });
     expect(detached).toEqual({
       attach: [],
       detach: [{ tagId: "tag-1" }],
@@ -50,6 +49,18 @@ describe("deferred bookmark tag changes", () => {
     });
 
     expect(restored).toEqual(createEmptyDeferredTagChanges());
+  });
+
+  it("stages removal of a tag introduced after the editor opened", () => {
+    const detached = stageTagDetachment(createEmptyDeferredTagChanges(), {
+      tagId: "tag-2",
+      tagName: "refreshed",
+    });
+
+    expect(detached).toEqual({
+      attach: [],
+      detach: [{ tagId: "tag-2" }],
+    });
   });
 
   it("saves details before applying tag changes", async () => {

--- a/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.ts
+++ b/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.ts
@@ -48,7 +48,6 @@ export function stageTagAttachment(
 
 export function stageTagDetachment(
   changes: DeferredTagChanges,
-  initialTags: readonly ZBookmarkTags[],
   tag: DeferredTag & { tagId: string },
 ): DeferredTagChanges {
   const pendingAttachment = changes.attach.find((pending) =>
@@ -62,10 +61,6 @@ export function stageTagDetachment(
       ),
       detach: changes.detach,
     };
-  }
-
-  if (!initialTags.some((initial) => initial.id === tag.tagId)) {
-    return changes;
   }
 
   if (changes.detach.some(({ tagId }) => tagId === tag.tagId)) {

--- a/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.ts
+++ b/apps/web/components/dashboard/bookmarks/deferredBookmarkTags.ts
@@ -1,0 +1,101 @@
+import type { ZBookmarkTags } from "@karakeep/shared/types/tags";
+
+export interface DeferredTag {
+  tagId?: string;
+  tagName: string;
+}
+
+export interface DeferredTagChanges {
+  attach: DeferredTag[];
+  detach: { tagId: string }[];
+}
+
+export function createEmptyDeferredTagChanges(): DeferredTagChanges {
+  return { attach: [], detach: [] };
+}
+
+function refersToSameTag(left: DeferredTag, right: DeferredTag): boolean {
+  return (
+    (!!left.tagId && left.tagId === right.tagId) ||
+    left.tagName === right.tagName
+  );
+}
+
+export function stageTagAttachment(
+  changes: DeferredTagChanges,
+  initialTags: readonly ZBookmarkTags[],
+  tag: DeferredTag,
+): DeferredTagChanges {
+  const wasInitiallyAttached =
+    !!tag.tagId && initialTags.some((initial) => initial.id === tag.tagId);
+
+  if (wasInitiallyAttached) {
+    return {
+      attach: changes.attach,
+      detach: changes.detach.filter(({ tagId }) => tagId !== tag.tagId),
+    };
+  }
+
+  if (changes.attach.some((pending) => refersToSameTag(pending, tag))) {
+    return changes;
+  }
+
+  return {
+    attach: [...changes.attach, tag],
+    detach: changes.detach,
+  };
+}
+
+export function stageTagDetachment(
+  changes: DeferredTagChanges,
+  initialTags: readonly ZBookmarkTags[],
+  tag: DeferredTag & { tagId: string },
+): DeferredTagChanges {
+  const pendingAttachment = changes.attach.find((pending) =>
+    refersToSameTag(pending, tag),
+  );
+
+  if (pendingAttachment) {
+    return {
+      attach: changes.attach.filter(
+        (pending) => !refersToSameTag(pending, tag),
+      ),
+      detach: changes.detach,
+    };
+  }
+
+  if (!initialTags.some((initial) => initial.id === tag.tagId)) {
+    return changes;
+  }
+
+  if (changes.detach.some(({ tagId }) => tagId === tag.tagId)) {
+    return changes;
+  }
+
+  return {
+    attach: changes.attach,
+    detach: [...changes.detach, { tagId: tag.tagId }],
+  };
+}
+
+export function hasDeferredTagChanges(changes: DeferredTagChanges): boolean {
+  return changes.attach.length > 0 || changes.detach.length > 0;
+}
+
+export async function persistBookmarkEdits<T>({
+  saveDetails,
+  saveTags,
+  tagChanges,
+}: {
+  saveDetails: () => Promise<T>;
+  saveTags: (changes: DeferredTagChanges) => Promise<unknown>;
+  tagChanges: DeferredTagChanges;
+}): Promise<T> {
+  const updatedBookmark = await saveDetails();
+
+  if (hasDeferredTagChanges(tagChanges)) {
+    await saveTags(tagChanges);
+  }
+
+  return updatedBookmark;
+}


### PR DESCRIPTION
## Description

The bookmark editor now stages tag additions and removals until **Save changes** is submitted. Bookmark details are persisted first, then tag changes, so removing the active feed tag cannot unmount the dialog and discard unsaved title, note, or metadata edits. Cancelling the dialog discards the staged tag changes.

Each edit session uses a snapshot of the tags present when the dialog opens, so background query refreshes cannot overwrite in-progress selections. The reducer also handles add-then-remove, remove-then-restore, and removal of a tag introduced by a refresh without sending redundant mutations.

Fixes #2798

## How Has This Been Tested?

- [x] `TZ=UTC pnpm --filter @karakeep/web test -- --run` (33 tests)
- [x] Repository pre-commit checks: typecheck, lint, and format (64 tasks)
- [x] Manually reproduced the issue from a tag feed: edited the title, removed the feed tag, verified the dialog stayed open and retained the title, then saved and verified both the title and tag removal persisted

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not included because this change affects save timing rather than visual layout.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Codex was used to inspect the codebase, draft the implementation, and write the regression tests. I reviewed the final diff and verified the behavior locally through the full reproduction flow described above.