### PR TITLE
fix(web): default the preview pane to the Video section when a video asset exists

### DIFF
--- a/apps/web/components/dashboard/preview/LinkContentSection.tsx
+++ b/apps/web/components/dashboard/preview/LinkContentSection.tsx
@@ -124,7 +124,12 @@ export default function LinkContentSection({
   const { settings } = useReaderSettings();
   const availableRenderers = contentRendererRegistry.getRenderers(bookmark);
   const defaultSection =
-    availableRenderers.length > 0 ? availableRenderers[0].id : "cached";
+    availableRenderers.length > 0
+      ? availableRenderers[0].id
+      : bookmark.content.type === BookmarkTypes.LINK &&
+          bookmark.content.videoAssetId
+        ? "video"
+        : "cached";
   const [section, setSection] = useQueryState("section", {
     defaultValue: defaultSection,
   });


### PR DESCRIPTION
When `CRAWLER_VIDEO_DOWNLOAD` is enabled and a link bookmark has a downloaded video (`videoAssetId` set), the preview pane still defaults to the cached reader view — which for JS-heavy sources (Pinterest, Vimeo, Behance) is often
signed-out boilerplate. The downloaded video sits behind the section dropdown where it is easy to miss.

This changes the default section order to:

1. custom content renderer (YouTube/TikTok embeds — unchanged, still first)
2. **video, when the bookmark has a `videoAssetId`** (new)
3. cached reader view (unchanged fallback)

No behavior change for bookmarks without a video asset.