### PR TITLE
docs: add alfred-karakeep (inline search Alfred workflow) to community projects

### DIFF
--- a/docs/docs/07-community/01-community-projects.md
+++ b/docs/docs/07-community/01-community-projects.md
@@ -14,6 +14,14 @@ A user-friendly Raycast extension that seamlessly integrates with Karakeep, brin
 
 Get it [here](https://www.raycast.com/luolei/karakeep).
 
+### Alfred Workflow (inline search)
+
+_By [@Kyzcreig](https://github.com/Kyzcreig)_
+
+An Alfred workflow for inline bookmark search — type `kk <query>` and see live results (title, tags, URL) directly in Alfred, using Karakeep's full query language (`is:fav`, `#tag`, `list:`, `age:`). Enter opens the original URL; Cmd-Enter opens the bookmark in Karakeep. Responses are cached per-query so typing stays lag-free.
+
+Get it [here](https://github.com/Kyzcreig/alfred-karakeep).
+
 ### Alfred Workflow
 
 _By [@yinan-c](https://github.com/yinan-c)_


### PR DESCRIPTION
Adds [alfred-karakeep](https://github.com/Kyzcreig/alfred-karakeep) to the community projects page — an MIT-licensed Alfred workflow for **inline** bookmark search (the existing listed workflow focuses on saving/opening; this one renders live search results inside Alfred).

- `kk <query>` → results (title, tags, URL) inline in Alfred via `/api/v1/bookmarks/search`
- Full query language works inline (`is:fav`, `#tag`, `list:`, `age:`)
- Enter opens the original URL; Cmd-Enter opens the bookmark in Karakeep
- Per-query response caching + queue-delay so typing doesn't hammer the instance
- Works with self-hosted + cloud; zero dependencies (macOS system python3)

Been running it daily against a self-hosted instance with ~10k bookmarks — search responses are fast enough for inline use thanks to Meilisearch. Thanks for the great product! 💙