### PR TITLE
feat: support for custom AI prompts via external template files

### DIFF
--- a/apps/web/components/settings/AISettings.tsx
+++ b/apps/web/components/settings/AISettings.tsx
@@ -53,6 +53,11 @@ import {
   buildTextPromptUntruncated,
 } from "@karakeep/shared/prompts";
 import {
+  renderImageTaggingTemplate,
+  renderSummaryTemplate,
+  renderTextTaggingTemplate,
+} from "@karakeep/shared/prompts.templates";
+import {
   zNewPromptSchema,
   ZPrompt,
   zUpdatePromptSchema,
@@ -804,6 +809,26 @@ export function PromptDemo() {
     [needsTagExpansion, allTagsData],
   );
 
+  // Instance-wide prompt template overrides (files in PROMPTS_DIR). When an
+  // override exists, preview it instead of the built-in prompt.
+  const { data: promptTemplates } = useQuery(
+    api.promptTemplates.list.queryOptions(),
+  );
+
+  const textPromptTexts = withTagsExpanded(
+    (prompts ?? [])
+      .filter((p) => p.appliesTo == "text" || p.appliesTo == "all_tagging")
+      .map((p) => p.text),
+  );
+  const imagePromptTexts = withTagsExpanded(
+    (prompts ?? [])
+      .filter((p) => p.appliesTo == "images" || p.appliesTo == "all_tagging")
+      .map((p) => p.text),
+  );
+  const summaryPromptTexts = withTagsExpanded(
+    (prompts ?? []).filter((p) => p.appliesTo == "summary").map((p) => p.text),
+  );
+
   return (
     <SettingsSection
       title={t("settings.ai.prompt_preview")}
@@ -815,19 +840,22 @@ export function PromptDemo() {
             {t("settings.ai.text_prompt")}
           </p>
           <code className="block whitespace-pre-wrap rounded-md bg-muted p-3 text-sm text-muted-foreground">
-            {buildTextPromptUntruncated(
-              inferredTagLang,
-              withTagsExpanded(
-                (prompts ?? [])
-                  .filter(
-                    (p) =>
-                      p.appliesTo == "text" || p.appliesTo == "all_tagging",
-                  )
-                  .map((p) => p.text),
-              ),
-              "\n<CONTENT_HERE>\n",
-              tagStyle,
-              curatedTagNames,
+            {(promptTemplates?.textTagging != null
+              ? renderTextTaggingTemplate(
+                  promptTemplates.textTagging,
+                  inferredTagLang,
+                  textPromptTexts,
+                  "\n<CONTENT_HERE>\n",
+                  tagStyle,
+                  curatedTagNames,
+                )
+              : buildTextPromptUntruncated(
+                  inferredTagLang,
+                  textPromptTexts,
+                  "\n<CONTENT_HERE>\n",
+                  tagStyle,
+                  curatedTagNames,
+                )
             ).trim()}
           </code>
         </div>
@@ -836,18 +864,20 @@ export function PromptDemo() {
             {t("settings.ai.images_prompt")}
           </p>
           <code className="block whitespace-pre-wrap rounded-md bg-muted p-3 text-sm text-muted-foreground">
-            {buildImagePrompt(
-              inferredTagLang,
-              withTagsExpanded(
-                (prompts ?? [])
-                  .filter(
-                    (p) =>
-                      p.appliesTo == "images" || p.appliesTo == "all_tagging",
-                  )
-                  .map((p) => p.text),
-              ),
-              tagStyle,
-              curatedTagNames,
+            {(promptTemplates?.imageTagging != null
+              ? renderImageTaggingTemplate(
+                  promptTemplates.imageTagging,
+                  inferredTagLang,
+                  imagePromptTexts,
+                  tagStyle,
+                  curatedTagNames,
+                )
+              : buildImagePrompt(
+                  inferredTagLang,
+                  imagePromptTexts,
+                  tagStyle,
+                  curatedTagNames,
+                )
             ).trim()}
           </code>
         </div>
@@ -856,14 +886,18 @@ export function PromptDemo() {
             {t("settings.ai.summarization_prompt")}
           </p>
           <code className="block whitespace-pre-wrap rounded-md bg-muted p-3 text-sm text-muted-foreground">
-            {buildSummaryPromptUntruncated(
-              inferredTagLang,
-              withTagsExpanded(
-                (prompts ?? [])
-                  .filter((p) => p.appliesTo == "summary")
-                  .map((p) => p.text),
-              ),
-              "\n<CONTENT_HERE>\n",
+            {(promptTemplates?.summary != null
+              ? renderSummaryTemplate(
+                  promptTemplates.summary,
+                  inferredTagLang,
+                  summaryPromptTexts,
+                  "\n<CONTENT_HERE>\n",
+                )
+              : buildSummaryPromptUntruncated(
+                  inferredTagLang,
+                  summaryPromptTexts,
+                  "\n<CONTENT_HERE>\n",
+                )
             ).trim()}
           </code>
         </div>

--- a/apps/workers/workers/assetPreprocessingWorker.ts
+++ b/apps/workers/workers/assetPreprocessingWorker.ts
@@ -27,7 +27,7 @@ import { newAssetId, readAsset, saveAsset } from "@karakeep/shared/assetdb";
 import serverConfig from "@karakeep/shared/config";
 import { InferenceClientFactory } from "@karakeep/shared/inference";
 import logger from "@karakeep/shared/logger";
-import { buildOCRPrompt } from "@karakeep/shared/prompts";
+import { buildOCRPrompt } from "@karakeep/shared/prompts.external";
 import {
   DequeuedJob,
   EnqueueOptions,

--- a/apps/workers/workers/inference/tagging.ts
+++ b/apps/workers/workers/inference/tagging.ts
@@ -26,7 +26,7 @@ import {
 import { ASSET_TYPES, readAsset } from "@karakeep/shared/assetdb";
 import serverConfig from "@karakeep/shared/config";
 import logger from "@karakeep/shared/logger";
-import { buildImagePrompt } from "@karakeep/shared/prompts";
+import { buildImagePrompt } from "@karakeep/shared/prompts.external";
 import { buildTextPrompt } from "@karakeep/shared/prompts.server";
 import { DequeuedJob, EnqueueOptions } from "@karakeep/shared/queueing";
 import { RuleEngine } from "@karakeep/trpc/lib/ruleEngine";

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,3 @@
-################# Monolith Builder ##############
-FROM rust:1-bookworm AS monolith_builder
-
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        libssl-dev \
-        pkg-config \
-    && rm -rf /var/lib/apt/lists/* \
-    && cargo install monolith --locked
-
 ################# Base Builder ##############
 FROM node:24-slim AS base
 
@@ -141,8 +131,15 @@ RUN case ${TARGETARCH} in \
 # changes to the worker. Fixes karakeep-app/karakeep#2758.
 RUN echo "--js-runtimes node" > /etc/yt-dlp.conf
 
-# Copy monolith binary from builder
-COPY --from=monolith_builder /usr/local/cargo/bin/monolith /usr/local/bin/monolith
+# Install monolith from prebuilt release binaries
+ARG MONOLITH_VERSION=v2.10.1
+RUN case ${TARGETARCH} in \
+        "amd64")  MONOLITH_FILE=monolith-gnu-linux-x86_64 ;; \
+        "arm64")  MONOLITH_FILE=monolith-gnu-linux-aarch64 ;; \
+        *) echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && curl -fsSL https://github.com/Y2Z/monolith/releases/download/${MONOLITH_VERSION}/${MONOLITH_FILE} -o /usr/local/bin/monolith \
+    && chmod +x /usr/local/bin/monolith
 
 ######################
 # Prepare the web app

--- a/packages/shared/prompt-templates/README.md
+++ b/packages/shared/prompt-templates/README.md
@@ -1,0 +1,73 @@
+# External prompt templates
+
+Karakeep's AI prompts (tagging, summarization, OCR) can be overridden with
+plain-text template files, without rebuilding the app. The built-in prompts in
+`packages/shared/prompts.ts` remain the defaults; a template file, when
+present, fully replaces the corresponding built-in prompt.
+
+The files in this directory are reference copies of the built-in prompts.
+Copy the ones you want to change into your prompts directory and edit them.
+
+## Where the app looks for templates
+
+At runtime, the server looks for template files in:
+
+1. `$PROMPTS_DIR`, if the `PROMPTS_DIR` environment variable is set;
+2. otherwise `$DATA_DIR/prompts`.
+
+With the standard docker setup (`DATA_DIR=/data` backed by a volume), no extra
+configuration is needed — just place files in `/data/prompts/`, e.g.:
+
+```
+/data/prompts/text-tagging.txt
+/data/prompts/summary.txt
+```
+
+Alternatively, mount a host directory and point `PROMPTS_DIR` at it:
+
+```yaml
+services:
+  web:
+    environment:
+      PROMPTS_DIR: /etc/karakeep/prompts
+    volumes:
+      - ./my-prompts:/etc/karakeep/prompts:ro
+```
+
+Missing files simply fall back to the built-in prompt, so you only need to
+provide the prompts you want to change. Edits to template files are picked up
+automatically (files are re-read when their modification time changes) — no
+restart needed.
+
+## Template files and their placeholders
+
+| File                | Used for                       | Placeholders |
+| ------------------- | ------------------------------ | ------------ |
+| `text-tagging.txt`  | Tag suggestions for text/links | `{{lang}}`, `{{content}}`, `{{tagStyle}}`, `{{curatedTags}}`, `{{customPrompts}}` |
+| `image-tagging.txt` | Tag suggestions for images     | `{{lang}}`, `{{tagStyle}}`, `{{curatedTags}}`, `{{customPrompts}}` |
+| `summary.txt`       | Bookmark summarization         | `{{lang}}`, `{{content}}`, `{{customPrompts}}` |
+| `ocr.txt`           | LLM-based OCR of images        | (none) |
+
+Placeholder meanings:
+
+- `{{lang}}` — the language configured for AI responses.
+- `{{content}}` — the bookmark content (already truncated to fit the model's
+  context window).
+- `{{tagStyle}}` — the rendered instruction line for the user's configured tag
+  style (may be empty).
+- `{{curatedTags}}` — the rendered instruction line restricting tags to the
+  user's curated list (may be empty).
+- `{{customPrompts}}` — the user's custom prompts from the settings page,
+  rendered as a `- ` bulleted list (may be empty).
+
+Unknown `{{...}}` placeholders are left in the output verbatim, so typos are
+visible when inspecting the generated prompt.
+
+## Notes
+
+- The prompt preview in the web UI's AI settings page reflects file-based
+  overrides live, so it's a convenient way to verify a mounted template:
+  refresh the page after editing a file and the preview shows exactly what
+  will be sent to the AI. (The OCR prompt has no preview in the UI.)
+- Keep the JSON output instructions (for the tagging prompts) intact — the
+  workers parse the model response as `{"tags": [...]}`.

--- a/packages/shared/prompt-templates/README.md
+++ b/packages/shared/prompt-templates/README.md
@@ -43,8 +43,8 @@ restart needed.
 
 | File                | Used for                       | Placeholders |
 | ------------------- | ------------------------------ | ------------ |
-| `text-tagging.txt`  | Tag suggestions for text/links | `{{lang}}`, `{{content}}`, `{{tagStyle}}`, `{{curatedTags}}`, `{{customPrompts}}` |
-| `image-tagging.txt` | Tag suggestions for images     | `{{lang}}`, `{{tagStyle}}`, `{{curatedTags}}`, `{{customPrompts}}` |
+| `text-tagging.txt`  | Tag suggestions for text/links | `{{lang}}`, `{{content}}`, `{{tagStyle}}`, `{{curatedTags}}`, `{{potentialRelevantTags}}`, `{{customPrompts}}` |
+| `image-tagging.txt` | Tag suggestions for images     | `{{lang}}`, `{{tagStyle}}`, `{{curatedTags}}`, `{{potentialRelevantTags}}`, `{{customPrompts}}` |
 | `summary.txt`       | Bookmark summarization         | `{{lang}}`, `{{content}}`, `{{customPrompts}}` |
 | `ocr.txt`           | LLM-based OCR of images        | (none) |
 
@@ -57,6 +57,11 @@ Placeholder meanings:
   style (may be empty).
 - `{{curatedTags}}` — the rendered instruction line restricting tags to the
   user's curated list (may be empty).
+- `{{potentialRelevantTags}}` — the rendered instruction line suggesting tags
+  taken from bookmarks that are similar to this one (found via embeddings).
+  Empty when the feature is off or nothing similar was found. Omitting this
+  placeholder from a template silently disables the suggestions for that
+  prompt.
 - `{{customPrompts}}` — the user's custom prompts from the settings page,
   rendered as a `- ` bulleted list (may be empty).
 

--- a/packages/shared/prompt-templates/image-tagging.txt
+++ b/packages/shared/prompt-templates/image-tagging.txt
@@ -1,12 +1,20 @@
 
-You are an expert whose responsibility is to help with automatic text tagging for a read-it-later/bookmarking app.
+You are an expert whose responsibility is to help with automatic tagging for a read-it-later/bookmarking app.
 Analyze the attached image and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
-- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
+- Prefer concrete, durable tags: named products, technologies, projects, standards, subject areas, and important concepts.
+- Include only retrieval-worthy tags that describe the saved item's intended content, not incidental UI or page chrome.
 - The tags must be in {{lang}}.
-- If the tag is not generic enough, don't include it.
+- Keep each tag short: ideally 1-3 words. Do not include parenthetical explanations, comma-separated examples, or long descriptive phrases inside a tag.
+- Prefer durable subject tags over one-off facts, examples, source organizations, page sections, or implementation details unless they are central to the whole item.
+- Do NOT generate any tags if the image is mainly:
+    - A screenshot of an error, unavailable, forbidden, unauthorized, not found, DNS, timeout, or service failure page
+    - A Cloudflare/security check, CAPTCHA, bot check, anti-DDoS challenge, browser verification, or access-blocked page
+    - Boilerplate content such as cookie consent, login walls, GDPR notices, navigation menus, or a blank/empty image
+  In these cases, return an empty tags array. Do not tag the failure/interstitial page itself.
 - Aim for 10-15 tags.
-- If there are no good tags, don't emit any.
+- If there are no good tags, leave the array empty.
 {{curatedTags}}
+{{potentialRelevantTags}}
 {{tagStyle}}
 {{customPrompts}}
 You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.

--- a/packages/shared/prompt-templates/image-tagging.txt
+++ b/packages/shared/prompt-templates/image-tagging.txt
@@ -1,0 +1,12 @@
+
+You are an expert whose responsibility is to help with automatic text tagging for a read-it-later/bookmarking app.
+Analyze the attached image and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
+- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
+- The tags must be in {{lang}}.
+- If the tag is not generic enough, don't include it.
+- Aim for 10-15 tags.
+- If there are no good tags, don't emit any.
+{{curatedTags}}
+{{tagStyle}}
+{{customPrompts}}
+You must respond in valid JSON with the key "tags" and the value is list of tags. Don't wrap the response in a markdown code.

--- a/packages/shared/prompt-templates/ocr.txt
+++ b/packages/shared/prompt-templates/ocr.txt
@@ -1,0 +1,10 @@
+You are an OCR (Optical Character Recognition) expert. Your task is to extract ALL text from this image.
+
+Rules:
+- Extract every piece of text visible in the image, including titles, body text, captions, labels, watermarks, and any other textual content.
+- Preserve the original structure and formatting as much as possible (e.g., paragraphs, lists, headings).
+- If text appears in multiple columns, read from left to right, top to bottom.
+- If text is partially obscured or unclear, make your best attempt and indicate uncertainty with [unclear] if needed.
+- Do not add any commentary, explanations, or descriptions of non-text elements.
+- If there is no text in the image, respond with an empty string.
+- Output ONLY the extracted text, nothing else.

--- a/packages/shared/prompt-templates/summary.txt
+++ b/packages/shared/prompt-templates/summary.txt
@@ -1,0 +1,6 @@
+
+Summarize the following content responding ONLY with the summary. You MUST follow the following rules:
+- Summary must be in 3-4 sentences.
+- The summary must be in {{lang}}.
+{{customPrompts}}
+    {{content}}

--- a/packages/shared/prompt-templates/text-tagging.txt
+++ b/packages/shared/prompt-templates/text-tagging.txt
@@ -1,0 +1,19 @@
+
+You are an expert whose responsibility is to help with automatic tagging for a read-it-later/bookmarking app.
+Analyze the TEXT_CONTENT below and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
+- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
+- The tags must be in {{lang}}.
+- If the tag is not generic enough, don't include it.
+- Do NOT generate tags related to:
+    - An error page (404, 403, blocked, not found, dns errors)
+    - Boilerplate content (cookie consent, login walls, GDPR notices)
+- Aim for 3-5 tags.
+- If there are no good tags, leave the array empty.
+{{curatedTags}}
+{{tagStyle}}
+{{customPrompts}}
+
+<TEXT_CONTENT>
+{{content}}
+</TEXT_CONTENT>
+You must respond in JSON with the key "tags" and the value is an array of string tags.

--- a/packages/shared/prompt-templates/text-tagging.txt
+++ b/packages/shared/prompt-templates/text-tagging.txt
@@ -1,15 +1,20 @@
 
 You are an expert whose responsibility is to help with automatic tagging for a read-it-later/bookmarking app.
 Analyze the TEXT_CONTENT below and suggest relevant tags that describe its key themes, topics, and main ideas. The rules are:
-- Aim for a variety of tags, including broad categories, specific keywords, and potential sub-genres.
+- Prefer concrete, durable tags: named products, technologies, projects, standards, subject areas, and important concepts.
+- Include only retrieval-worthy tags that describe the saved item's intended content, not incidental page chrome.
 - The tags must be in {{lang}}.
-- If the tag is not generic enough, don't include it.
-- Do NOT generate tags related to:
-    - An error page (404, 403, blocked, not found, dns errors)
-    - Boilerplate content (cookie consent, login walls, GDPR notices)
+- Keep each tag short: ideally 1-3 words. Do not include parenthetical explanations, comma-separated examples, or long descriptive phrases inside a tag.
+- Prefer durable subject tags over one-off facts, examples, source organizations, page sections, or implementation details unless they are central to the whole item.
+- Ignore any part of the content that is:
+    - An error, unavailable, forbidden, unauthorized, not found, DNS, timeout, or service failure page
+    - A Cloudflare/security check, CAPTCHA, bot check, anti-DDoS challenge, browser verification, or access-blocked page
+    - Boilerplate content such as cookie consent, login walls, GDPR notices, navigation menus, or empty pages
+  If useful metadata or other legitimate content remains, generate tags using only that information. Otherwise, return an empty tags array. Never tag the failure, interstitial, or boilerplate content itself.
 - Aim for 3-5 tags.
 - If there are no good tags, leave the array empty.
 {{curatedTags}}
+{{potentialRelevantTags}}
 {{tagStyle}}
 {{customPrompts}}
 

--- a/packages/shared/prompts.external.test.ts
+++ b/packages/shared/prompts.external.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import * as defaultPrompts from "./prompts";
+import * as externalPrompts from "./prompts.external";
+
+describe("prompts.external", () => {
+  let dir: string;
+  let savedPromptsDir: string | undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "karakeep-prompts-"));
+    savedPromptsDir = process.env.PROMPTS_DIR;
+    process.env.PROMPTS_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (savedPromptsDir === undefined) {
+      delete process.env.PROMPTS_DIR;
+    } else {
+      process.env.PROMPTS_DIR = savedPromptsDir;
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("falls back to the built-in prompts when no override files exist", () => {
+    expect(
+      externalPrompts.constructTextTaggingPrompt(
+        "english",
+        ["be brief"],
+        "some content",
+        "lowercase-hyphens",
+        ["tech", "news"],
+      ),
+    ).toEqual(
+      defaultPrompts.constructTextTaggingPrompt(
+        "english",
+        ["be brief"],
+        "some content",
+        "lowercase-hyphens",
+        ["tech", "news"],
+      ),
+    );
+    expect(
+      externalPrompts.constructSummaryPrompt("english", [], "some content"),
+    ).toEqual(
+      defaultPrompts.constructSummaryPrompt("english", [], "some content"),
+    );
+    expect(
+      externalPrompts.buildImagePrompt("english", [], "as-generated"),
+    ).toEqual(defaultPrompts.buildImagePrompt("english", [], "as-generated"));
+    expect(externalPrompts.buildOCRPrompt()).toEqual(
+      defaultPrompts.buildOCRPrompt(),
+    );
+  });
+
+  it("renders an override template with placeholders substituted", () => {
+    fs.writeFileSync(
+      path.join(dir, "text-tagging.txt"),
+      "Tag in {{lang}}:\n{{customPrompts}}\n<C>{{content}}</C>",
+    );
+    expect(
+      externalPrompts.constructTextTaggingPrompt(
+        "german",
+        ["rule one", "rule two"],
+        "hello world",
+        "as-generated",
+      ),
+    ).toEqual("Tag in german:\n- rule one\n- rule two\n<C>hello world</C>");
+  });
+
+  it("substitutes tag style and curated tags instructions", () => {
+    fs.writeFileSync(
+      path.join(dir, "image-tagging.txt"),
+      "{{tagStyle}}|{{curatedTags}}",
+    );
+    const prompt = externalPrompts.buildImagePrompt(
+      "english",
+      [],
+      "lowercase-hyphens",
+      ["tech"],
+    );
+    expect(prompt).toContain("lowercase letters with hyphens");
+    expect(prompt).toContain("ONLY use tags from this predefined list: [tech]");
+  });
+
+  it("uses the ocr override verbatim", () => {
+    fs.writeFileSync(path.join(dir, "ocr.txt"), "Extract the text.");
+    expect(externalPrompts.buildOCRPrompt()).toEqual("Extract the text.");
+  });
+
+  it("leaves unknown placeholders intact", () => {
+    fs.writeFileSync(
+      path.join(dir, "summary.txt"),
+      "Summarize in {{lang}} {{unknownVar}}: {{content}}",
+    );
+    expect(
+      externalPrompts.constructSummaryPrompt("english", [], "abc"),
+    ).toEqual("Summarize in english {{unknownVar}}: abc");
+  });
+
+  it("picks up changes to an override file", () => {
+    const file = path.join(dir, "ocr.txt");
+    fs.writeFileSync(file, "version one");
+    expect(externalPrompts.buildOCRPrompt()).toEqual("version one");
+
+    fs.writeFileSync(file, "version two");
+    // Force a distinct mtime in case both writes land in the same tick.
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(file, future, future);
+    expect(externalPrompts.buildOCRPrompt()).toEqual("version two");
+  });
+
+  it("lists override templates, with null for missing ones", () => {
+    fs.writeFileSync(path.join(dir, "summary.txt"), "custom summary");
+    fs.writeFileSync(path.join(dir, "ocr.txt"), "custom ocr");
+    expect(externalPrompts.getExternalPromptTemplates()).toEqual({
+      textTagging: null,
+      imageTagging: null,
+      summary: "custom summary",
+      ocr: "custom ocr",
+    });
+  });
+
+  it("falls back again when an override file is removed", () => {
+    const file = path.join(dir, "ocr.txt");
+    fs.writeFileSync(file, "override");
+    expect(externalPrompts.buildOCRPrompt()).toEqual("override");
+    fs.rmSync(file);
+    expect(externalPrompts.buildOCRPrompt()).toEqual(
+      defaultPrompts.buildOCRPrompt(),
+    );
+  });
+});

--- a/packages/shared/prompts.external.test.ts
+++ b/packages/shared/prompts.external.test.ts
@@ -86,6 +86,73 @@ describe("prompts.external", () => {
     expect(prompt).toContain("ONLY use tags from this predefined list: [tech]");
   });
 
+  it("forwards potentially relevant tags to the built-in prompts", () => {
+    expect(
+      externalPrompts.constructTextTaggingPrompt(
+        "english",
+        [],
+        "some content",
+        "as-generated",
+        undefined,
+        ["rust", "compilers"],
+      ),
+    ).toEqual(
+      defaultPrompts.constructTextTaggingPrompt(
+        "english",
+        [],
+        "some content",
+        "as-generated",
+        undefined,
+        ["rust", "compilers"],
+      ),
+    );
+    expect(
+      externalPrompts.buildImagePrompt(
+        "english",
+        [],
+        "as-generated",
+        undefined,
+        ["rust"],
+      ),
+    ).toContain("rust");
+  });
+
+  it("substitutes potentially relevant tags in override templates", () => {
+    fs.writeFileSync(
+      path.join(dir, "text-tagging.txt"),
+      "{{potentialRelevantTags}}\n{{content}}",
+    );
+    fs.writeFileSync(
+      path.join(dir, "image-tagging.txt"),
+      "{{potentialRelevantTags}}",
+    );
+    expect(
+      externalPrompts.constructTextTaggingPrompt(
+        "english",
+        [],
+        "abc",
+        "as-generated",
+        undefined,
+        ["rust", "compilers"],
+      ),
+    ).toEqual(
+      "- Similar bookmarks were tagged with the following tags (reuse if possible, ignore if irrelevant): rust, compilers\nabc",
+    );
+    expect(
+      externalPrompts.buildImagePrompt(
+        "english",
+        [],
+        "as-generated",
+        undefined,
+        ["rust"],
+      ),
+    ).toContain("rust");
+    // Absent suggestions render as nothing, not as a dangling instruction.
+    expect(
+      externalPrompts.buildImagePrompt("english", [], "as-generated"),
+    ).toEqual("");
+  });
+
   it("uses the ocr override verbatim", () => {
     fs.writeFileSync(path.join(dir, "ocr.txt"), "Extract the text.");
     expect(externalPrompts.buildOCRPrompt()).toEqual("Extract the text.");
@@ -124,6 +191,32 @@ describe("prompts.external", () => {
     });
   });
 
+  it("falls back when the override path is a directory", () => {
+    fs.mkdirSync(path.join(dir, "ocr.txt"));
+    expect(externalPrompts.buildOCRPrompt()).toEqual(
+      defaultPrompts.buildOCRPrompt(),
+    );
+  });
+
+  it("falls back when an override file cannot be read", () => {
+    const file = path.join(dir, "ocr.txt");
+    fs.writeFileSync(file, "override");
+    fs.chmodSync(file, 0o000);
+    // Root ignores file permissions, so only assert if the read really fails.
+    let readable = true;
+    try {
+      fs.readFileSync(file, "utf8");
+    } catch {
+      readable = false;
+    }
+    if (!readable) {
+      expect(externalPrompts.buildOCRPrompt()).toEqual(
+        defaultPrompts.buildOCRPrompt(),
+      );
+    }
+    fs.chmodSync(file, 0o600);
+  });
+
   it("falls back again when an override file is removed", () => {
     const file = path.join(dir, "ocr.txt");
     fs.writeFileSync(file, "override");
@@ -132,5 +225,90 @@ describe("prompts.external", () => {
     expect(externalPrompts.buildOCRPrompt()).toEqual(
       defaultPrompts.buildOCRPrompt(),
     );
+  });
+
+  // The templates in prompt-templates/ are documented as reference copies of
+  // the built-in prompts, so they have to be refreshed whenever a built-in
+  // prompt changes. Rendering them must reproduce the built-ins exactly
+  // (modulo the trailing newline every text file ends with).
+  describe("the reference templates match the built-in prompts", () => {
+    const lang = "english";
+    const customPrompts = ["rule one", "rule two"];
+    const curatedTags = ["tech", "news"];
+    const potentialRelevantTags = ["rust", "compilers"];
+    const tagStyle = "lowercase-spaces" as const;
+    const content = "some content";
+
+    beforeEach(() => {
+      process.env.PROMPTS_DIR = path.join(__dirname, "prompt-templates");
+    });
+
+    it("text-tagging", () => {
+      expect(
+        externalPrompts
+          .constructTextTaggingPrompt(
+            lang,
+            customPrompts,
+            content,
+            tagStyle,
+            curatedTags,
+            potentialRelevantTags,
+          )
+          .trimEnd(),
+      ).toEqual(
+        defaultPrompts
+          .constructTextTaggingPrompt(
+            lang,
+            customPrompts,
+            content,
+            tagStyle,
+            curatedTags,
+            potentialRelevantTags,
+          )
+          .trimEnd(),
+      );
+    });
+
+    it("image-tagging", () => {
+      expect(
+        externalPrompts
+          .buildImagePrompt(
+            lang,
+            customPrompts,
+            tagStyle,
+            curatedTags,
+            potentialRelevantTags,
+          )
+          .trimEnd(),
+      ).toEqual(
+        defaultPrompts
+          .buildImagePrompt(
+            lang,
+            customPrompts,
+            tagStyle,
+            curatedTags,
+            potentialRelevantTags,
+          )
+          .trimEnd(),
+      );
+    });
+
+    it("summary", () => {
+      expect(
+        externalPrompts
+          .constructSummaryPrompt(lang, customPrompts, content)
+          .trimEnd(),
+      ).toEqual(
+        defaultPrompts
+          .constructSummaryPrompt(lang, customPrompts, content)
+          .trimEnd(),
+      );
+    });
+
+    it("ocr", () => {
+      expect(externalPrompts.buildOCRPrompt().trimEnd()).toEqual(
+        defaultPrompts.buildOCRPrompt().trimEnd(),
+      );
+    });
   });
 });

--- a/packages/shared/prompts.external.ts
+++ b/packages/shared/prompts.external.ts
@@ -51,11 +51,27 @@ export function loadTemplate(name: PromptTemplateName): string | null {
   } catch {
     return null;
   }
+  if (!stat.isFile()) {
+    logger.error(
+      `[prompts] Ignoring external prompt template at ${file}: not a regular file. Falling back to the built-in prompt.`,
+    );
+    return null;
+  }
   const cached = templateCache.get(file);
   if (cached && cached.mtimeMs === stat.mtimeMs) {
     return cached.text;
   }
-  const text = fs.readFileSync(file, "utf8");
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch (e) {
+    // Unreadable (permissions) or removed between the stat and the read.
+    // Degrade to the built-in prompt rather than failing the whole job.
+    logger.error(
+      `[prompts] Failed to read external prompt template at ${file}: ${String(e)}. Falling back to the built-in prompt.`,
+    );
+    return null;
+  }
   templateCache.set(file, { mtimeMs: stat.mtimeMs, text });
   logger.info(`[prompts] Loaded external prompt template from ${file}`);
   return text;
@@ -79,6 +95,7 @@ export function buildImagePrompt(
   customPrompts: string[],
   tagStyle: ZTagStyle,
   curatedTags?: string[],
+  potentialRelevantTags?: string[],
 ) {
   const template = loadTemplate("image-tagging");
   if (template === null) {
@@ -87,6 +104,7 @@ export function buildImagePrompt(
       customPrompts,
       tagStyle,
       curatedTags,
+      potentialRelevantTags,
     );
   }
   return renderImageTaggingTemplate(
@@ -95,6 +113,7 @@ export function buildImagePrompt(
     customPrompts,
     tagStyle,
     curatedTags,
+    potentialRelevantTags,
   );
 }
 
@@ -104,6 +123,7 @@ export function constructTextTaggingPrompt(
   content: string,
   tagStyle: ZTagStyle,
   curatedTags?: string[],
+  potentialRelevantTags?: string[],
 ): string {
   const template = loadTemplate("text-tagging");
   if (template === null) {
@@ -113,6 +133,7 @@ export function constructTextTaggingPrompt(
       content,
       tagStyle,
       curatedTags,
+      potentialRelevantTags,
     );
   }
   return renderTextTaggingTemplate(
@@ -122,6 +143,7 @@ export function constructTextTaggingPrompt(
     content,
     tagStyle,
     curatedTags,
+    potentialRelevantTags,
   );
 }
 

--- a/packages/shared/prompts.external.ts
+++ b/packages/shared/prompts.external.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { PromptTemplateName, PromptTemplates } from "./prompts.templates";
+import type { ZTagStyle } from "./types/users";
+import logger from "./logger";
+import * as defaultPrompts from "./prompts";
+import {
+  renderImageTaggingTemplate,
+  renderSummaryTemplate,
+  renderTextTaggingTemplate,
+} from "./prompts.templates";
+
+/**
+ * Server-side drop-in replacement for ./prompts that allows overriding the
+ * built-in prompt templates with files on disk. For each prompt kind, if
+ * `${PROMPTS_DIR}/<name>.txt` exists it is used as the template; otherwise
+ * the built-in prompt from ./prompts is used unchanged.
+ *
+ * PROMPTS_DIR defaults to `${DATA_DIR}/prompts`, so in a docker deployment
+ * override files can simply be dropped into the existing data volume
+ * (e.g. /data/prompts/text-tagging.txt).
+ *
+ * Template rendering lives in ./prompts.templates (client-safe), so the web
+ * UI's prompt preview renders override templates identically.
+ */
+
+function promptsDir(): string {
+  return (
+    process.env.PROMPTS_DIR ?? path.join(process.env.DATA_DIR ?? "", "prompts")
+  );
+}
+
+interface CacheEntry {
+  mtimeMs: number;
+  text: string;
+}
+
+const templateCache = new Map<string, CacheEntry>();
+
+/**
+ * Returns the override template for `name`, or null if no override file
+ * exists. Reads are cached and invalidated on mtime change, so templates
+ * can be edited without restarting the service.
+ */
+export function loadTemplate(name: PromptTemplateName): string | null {
+  const file = path.join(promptsDir(), `${name}.txt`);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    return null;
+  }
+  const cached = templateCache.get(file);
+  if (cached && cached.mtimeMs === stat.mtimeMs) {
+    return cached.text;
+  }
+  const text = fs.readFileSync(file, "utf8");
+  templateCache.set(file, { mtimeMs: stat.mtimeMs, text });
+  logger.info(`[prompts] Loaded external prompt template from ${file}`);
+  return text;
+}
+
+/**
+ * Returns all override templates (null for the ones without an override
+ * file). Used by the web UI's prompt preview.
+ */
+export function getExternalPromptTemplates(): PromptTemplates {
+  return {
+    textTagging: loadTemplate("text-tagging"),
+    imageTagging: loadTemplate("image-tagging"),
+    summary: loadTemplate("summary"),
+    ocr: loadTemplate("ocr"),
+  };
+}
+
+export function buildImagePrompt(
+  lang: string,
+  customPrompts: string[],
+  tagStyle: ZTagStyle,
+  curatedTags?: string[],
+) {
+  const template = loadTemplate("image-tagging");
+  if (template === null) {
+    return defaultPrompts.buildImagePrompt(
+      lang,
+      customPrompts,
+      tagStyle,
+      curatedTags,
+    );
+  }
+  return renderImageTaggingTemplate(
+    template,
+    lang,
+    customPrompts,
+    tagStyle,
+    curatedTags,
+  );
+}
+
+export function constructTextTaggingPrompt(
+  lang: string,
+  customPrompts: string[],
+  content: string,
+  tagStyle: ZTagStyle,
+  curatedTags?: string[],
+): string {
+  const template = loadTemplate("text-tagging");
+  if (template === null) {
+    return defaultPrompts.constructTextTaggingPrompt(
+      lang,
+      customPrompts,
+      content,
+      tagStyle,
+      curatedTags,
+    );
+  }
+  return renderTextTaggingTemplate(
+    template,
+    lang,
+    customPrompts,
+    content,
+    tagStyle,
+    curatedTags,
+  );
+}
+
+export function constructSummaryPrompt(
+  lang: string,
+  customPrompts: string[],
+  content: string,
+): string {
+  const template = loadTemplate("summary");
+  if (template === null) {
+    return defaultPrompts.constructSummaryPrompt(lang, customPrompts, content);
+  }
+  return renderSummaryTemplate(template, lang, customPrompts, content);
+}
+
+export function buildOCRPrompt(): string {
+  return loadTemplate("ocr") ?? defaultPrompts.buildOCRPrompt();
+}

--- a/packages/shared/prompts.server.ts
+++ b/packages/shared/prompts.server.ts
@@ -1,7 +1,10 @@
 import type { Tiktoken } from "js-tiktoken";
 
 import type { ZTagStyle } from "./types/users";
-import { constructSummaryPrompt, constructTextTaggingPrompt } from "./prompts";
+import {
+  constructSummaryPrompt,
+  constructTextTaggingPrompt,
+} from "./prompts.external";
 
 let encoding: Tiktoken | null = null;
 

--- a/packages/shared/prompts.templates.ts
+++ b/packages/shared/prompts.templates.ts
@@ -1,5 +1,9 @@
 import type { ZTagStyle } from "./types/users";
-import { getCuratedTagsPrompt, getTagStylePrompt } from "./utils/tag";
+import {
+  getCuratedTagsPrompt,
+  getPotentialRelevantTagsPrompt,
+  getTagStylePrompt,
+} from "./utils/tag";
 
 /**
  * Client-safe rendering of external prompt templates (no fs access). Used by
@@ -44,12 +48,16 @@ export function renderTextTaggingTemplate(
   content: string,
   tagStyle: ZTagStyle,
   curatedTags?: string[],
+  potentialRelevantTags?: string[],
 ): string {
   return render(template, {
     lang,
     content,
     tagStyle: getTagStylePrompt(tagStyle),
     curatedTags: getCuratedTagsPrompt(curatedTags),
+    potentialRelevantTags: getPotentialRelevantTagsPrompt(
+      potentialRelevantTags,
+    ),
     customPrompts: renderCustomPrompts(customPrompts),
   });
 }
@@ -60,11 +68,15 @@ export function renderImageTaggingTemplate(
   customPrompts: string[],
   tagStyle: ZTagStyle,
   curatedTags?: string[],
+  potentialRelevantTags?: string[],
 ): string {
   return render(template, {
     lang,
     tagStyle: getTagStylePrompt(tagStyle),
     curatedTags: getCuratedTagsPrompt(curatedTags),
+    potentialRelevantTags: getPotentialRelevantTagsPrompt(
+      potentialRelevantTags,
+    ),
     customPrompts: renderCustomPrompts(customPrompts),
   });
 }

--- a/packages/shared/prompts.templates.ts
+++ b/packages/shared/prompts.templates.ts
@@ -1,0 +1,83 @@
+import type { ZTagStyle } from "./types/users";
+import { getCuratedTagsPrompt, getTagStylePrompt } from "./utils/tag";
+
+/**
+ * Client-safe rendering of external prompt templates (no fs access). Used by
+ * ./prompts.external on the server and by the web UI's prompt preview, so
+ * both render override templates identically.
+ *
+ * Templates use `{{placeholder}}` syntax. Reference templates matching the
+ * built-in defaults live in packages/shared/prompt-templates/.
+ */
+
+export type PromptTemplateName =
+  | "text-tagging"
+  | "image-tagging"
+  | "summary"
+  | "ocr";
+
+export interface PromptTemplates {
+  textTagging: string | null;
+  imageTagging: string | null;
+  summary: string | null;
+  ocr: string | null;
+}
+
+/**
+ * Replaces known `{{key}}` placeholders. Unknown placeholders are left
+ * intact so that typos remain visible in the rendered prompt.
+ */
+function render(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) =>
+    key in vars ? vars[key] : match,
+  );
+}
+
+function renderCustomPrompts(customPrompts: string[]): string {
+  return customPrompts.map((p) => `- ${p}`).join("\n");
+}
+
+export function renderTextTaggingTemplate(
+  template: string,
+  lang: string,
+  customPrompts: string[],
+  content: string,
+  tagStyle: ZTagStyle,
+  curatedTags?: string[],
+): string {
+  return render(template, {
+    lang,
+    content,
+    tagStyle: getTagStylePrompt(tagStyle),
+    curatedTags: getCuratedTagsPrompt(curatedTags),
+    customPrompts: renderCustomPrompts(customPrompts),
+  });
+}
+
+export function renderImageTaggingTemplate(
+  template: string,
+  lang: string,
+  customPrompts: string[],
+  tagStyle: ZTagStyle,
+  curatedTags?: string[],
+): string {
+  return render(template, {
+    lang,
+    tagStyle: getTagStylePrompt(tagStyle),
+    curatedTags: getCuratedTagsPrompt(curatedTags),
+    customPrompts: renderCustomPrompts(customPrompts),
+  });
+}
+
+export function renderSummaryTemplate(
+  template: string,
+  lang: string,
+  customPrompts: string[],
+  content: string,
+): string {
+  return render(template, {
+    lang,
+    content,
+    customPrompts: renderCustomPrompts(customPrompts),
+  });
+}

--- a/packages/trpc/routers/_app.ts
+++ b/packages/trpc/routers/_app.ts
@@ -11,6 +11,7 @@ import { importSessionsRouter } from "./importSessions";
 import { invitesAppRouter } from "./invites";
 import { listsAppRouter } from "./lists";
 import { promptsAppRouter } from "./prompts";
+import { promptTemplatesAppRouter } from "./promptTemplates";
 import { publicBookmarks } from "./publicBookmarks";
 import { rulesAppRouter } from "./rules";
 import { subscriptionsRouter } from "./subscriptions";
@@ -25,6 +26,7 @@ export const appRouter = router({
   lists: listsAppRouter,
   tags: tagsAppRouter,
   prompts: promptsAppRouter,
+  promptTemplates: promptTemplatesAppRouter,
   admin: adminAppRouter,
   feeds: feedsAppRouter,
   backups: backupsAppRouter,

--- a/packages/trpc/routers/promptTemplates.ts
+++ b/packages/trpc/routers/promptTemplates.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+import { getExternalPromptTemplates } from "@karakeep/shared/prompts.external";
+
+import { authedProcedure, router } from "../index";
+
+/**
+ * Exposes the instance-wide external prompt template overrides (files in
+ * PROMPTS_DIR) so the web UI's prompt preview can render the prompts that
+ * are actually sent to the AI. Null means no override file exists and the
+ * built-in prompt is used.
+ */
+export const promptTemplatesAppRouter = router({
+  list: authedProcedure
+    .output(
+      z.object({
+        textTagging: z.string().nullable(),
+        imageTagging: z.string().nullable(),
+        summary: z.string().nullable(),
+        ocr: z.string().nullable(),
+      }),
+    )
+    .query(() => getExternalPromptTemplates()),
+});


### PR DESCRIPTION
## Description

Currently, the AI prompts used by Karakeep are baked into the image. This makes it impossible to e.g. optimize the prompts for the specific LLM which is configured, and in general to try different prompts. Any such change would require rebuilding the Karakeep docker image.

This PR adds machinery for allowing to load **per-instance** custom AI prompt templates from the Karakeep data directory. This allows self-hosted users to tailor the prompts to their needs and LLM configuration.

Fixes #2562 (at least partially).

### Implementation

As a first step, the template loading mechanism has been implemented as an optional feature. I.e. if no custom templates exist in the data directory, the hardcoded templates from `prompts.ts` are used.

This is achieved by adding `prompts.external.ts‎`. The module attempts to load the respective template from the Karakeep data directory, and falls back to the default `prompts.ts` implementation if no template is found. Then, the use of `prompts.ts` has been replaced with `prompts.external.ts‎` across the codebase.

To enable prompt preview in the AI settings page, a new `promptTemplates` tRPC endpoint has been added.

### Future work

#### Simplification
This PR intentionally avoided to make changes to `prompts.ts`. If this is merged, a reasonable next step would be to consolidate `prompts.ts` and `prompts.external.ts`, so that default prompts are also loaded from a file.

#### Per-user customization
Obviously, this solution allows customizing the prompts **per Karakeep instance**. This is an improvement geared towards self-hosting users.

There is also a call for user-customizable AI prompts in #2189. While this would be a great feature, it would probably need deeper structural changes. E.g. if each instance user can customize their AI prompt, it would only be reasonable to also require them to also specify their own AI backend and LLM access token, so that host is protected from malicious/illegal activities or excessive billing.

So, the details in #2189 were intentionally considered as out of scope.

## How Has This Been Tested?

I have built a custom image from v0.32 + these changes. I have been using it without issues for the last 2 weeks.

This only requires creating a `prompts` directory in the Karakeep data directory, and copying, customizing any of the templates from `prompt-templates`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

AI Settings page with custom prompt loaded.

<img width="1366" height="814" alt="image" src="https://github.com/user-attachments/assets/68834b3e-9463-4ae9-93ff-1ce7a146b4e2" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

My homelab host is pretty modest, so I have piggybacked one commit that updates Dockerfile to download monolith from its [releases page](https://github.com/Y2Z/monolith/releases/) rather than rebuilding it. I can spin-off the commit as a separate PR or remove it altogether, if needed.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Created with the help of Claude Fable, also credited in co-author line.
