### PR TITLE
docs: add a Railway installation page

### DIFF
--- a/docs/docs/02-installation/11-railway.md
+++ b/docs/docs/02-installation/11-railway.md
@@ -20,6 +20,10 @@ This provisions three services wired together: Karakeep itself, Meilisearch for 
 search, and a headless Chrome instance for crawling. `NEXTAUTH_SECRET` and the Meilisearch
 master key are generated for you, and `NEXTAUTH_URL` is set to the assigned domain.
 
+A persistent volume is attached to the Karakeep service at `/data`, and a second one to
+Meilisearch at `/meili_data`. See [Data persistence](#data-persistence) below for why this
+matters.
+
 ### 2. Wait for the first deploy
 
 All three services start in a couple of minutes. Karakeep is then served over HTTPS on an
@@ -30,8 +34,22 @@ assigned `*.up.railway.app` domain, which you can swap for your own later.
 Visit the domain and register under _Sign Up_. Afterwards you may want to close registration
 by setting `DISABLE_SIGNUPS` to `true` in the Karakeep service's variables.
 
+### Data persistence
+
+`DATA_DIR` is set to `/data`, which is where Karakeep keeps its SQLite database as well as
+crawled assets. The template attaches a persistent volume there, so your bookmarks survive
+redeploys and restarts.
+
+:::warning
+Do not change `DATA_DIR`, and do not detach or remount the volume on a running service.
+Pointing `DATA_DIR` at a path without a volume behind it puts the database in the container's
+ephemeral filesystem, and everything is lost on the next deploy.
+:::
+
+Railway does not back volumes up automatically. For anything you'd be upset to lose, set up
+scheduled backups on the Karakeep service and keep a copy off Railway.
+
 ### Optional
 
 - Set `OPENAI_API_KEY` on the Karakeep service to enable AI tagging. Other options are in the
   [configuration docs](../03-configuration/01-environment-variables.md).
-- Attach a volume mounted at `/data` if you want bookmark assets to survive redeploys.

--- a/docs/docs/02-installation/11-railway.md
+++ b/docs/docs/02-installation/11-railway.md
@@ -1,0 +1,37 @@
+# Railway
+
+:::info
+This is a community-maintained template, not an official Karakeep build. If you'd rather the
+core team handled hosting, updates and backups for you, see [Karakeep Cloud](./09-cloud-hosting.md).
+:::
+
+[Railway](https://railway.com) runs containers for you, so there's no server to provision or
+maintain. Deploying Karakeep there takes one click.
+
+### Requirements
+
+- A _Railway_ account. Can be created [here](https://railway.com/login).
+
+### 1. Deploy the template
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/karakeep-2)
+
+This provisions three services wired together: Karakeep itself, Meilisearch for full-text
+search, and a headless Chrome instance for crawling. `NEXTAUTH_SECRET` and the Meilisearch
+master key are generated for you, and `NEXTAUTH_URL` is set to the assigned domain.
+
+### 2. Wait for the first deploy
+
+All three services start in a couple of minutes. Karakeep is then served over HTTPS on an
+assigned `*.up.railway.app` domain, which you can swap for your own later.
+
+### 3. Add your user
+
+Visit the domain and register under _Sign Up_. Afterwards you may want to close registration
+by setting `DISABLE_SIGNUPS` to `true` in the Karakeep service's variables.
+
+### Optional
+
+- Set `OPENAI_API_KEY` on the Karakeep service to enable AI tagging. Other options are in the
+  [configuration docs](../03-configuration/01-environment-variables.md).
+- Attach a volume mounted at `/data` if you want bookmark assets to survive redeploys.


### PR DESCRIPTION
Adds `Installation → Railway`, a sibling to the existing PikaPods page.

Same audience as PikaPods: people who want Karakeep running without administering a server.
One click brings up Karakeep, Meilisearch and headless Chrome wired together, generates
`NEXTAUTH_SECRET` and the Meilisearch master key, and serves the app over HTTPS on an assigned
domain. The page follows the PikaPods structure — requirements, numbered steps, optional
settings — and points at the same `DISABLE_SIGNUPS` and `OPENAI_API_KEY` knobs the rest of the
docs use.

Being upfront about incentives, since it matters here: unlike PikaPods there is **no revenue
share** on this, and the page is flagged as community-maintained rather than an official build.
The info banner at the top links straight to Karakeep Cloud for anyone who'd rather you handled
hosting, and I've deliberately left the README alone so Cloud stays the only hosted option
surfaced there. If you'd rather this page didn't exist at all given Cloud, say so and I'll
close it — no hard feelings.

### How I verified

Deployed the template twice from scratch today. All three services reach a healthy running
state on first deploy with no retries and no manual steps, and the app serves over HTTPS on
the assigned domain.

Docs only, no source touched.
