### PR TITLE
fix(invites): surface SMTP failures in invite create/resend

### DIFF
--- a/apps/web/components/admin/CreateInviteDialog.tsx
+++ b/apps/web/components/admin/CreateInviteDialog.tsx
@@ -53,21 +53,27 @@ export default function CreateInviteDialog({
 
   const createInviteMutation = useMutation(
     api.invites.create.mutationOptions({
-      onSuccess: () => {
-        toast({
-          description: "Invite sent successfully",
-        });
+      onSuccess: (data) => {
+        if (data.emailSent) {
+          toast({
+            description: "Invite sent successfully",
+          });
+        } else {
+          toast({
+            variant: "destructive",
+            description:
+              "Invite created, but the email could not be sent. Check that SMTP is configured, then use the resend button.",
+          });
+        }
         queryClient.invalidateQueries(api.invites.list.pathFilter());
         setOpen(false);
         form.reset();
         setErrorMessage("");
       },
       onError: (e) => {
-        if (e instanceof TRPCClientError) {
-          setErrorMessage(e.message);
-        } else {
-          setErrorMessage("Failed to send invite");
-        }
+        const message =
+          e instanceof TRPCClientError ? e.message : "Failed to send invite";
+        setErrorMessage(message);
       },
     }),
   );

--- a/apps/web/components/admin/InvitesList.tsx
+++ b/apps/web/components/admin/InvitesList.tsx
@@ -49,10 +49,18 @@ export default function InvitesList() {
 
   const { mutateAsync: resendInvite, isPending: isResendPending } = useMutation(
     api.invites.resend.mutationOptions({
-      onSuccess: () => {
-        toast({
-          description: "Invite resent successfully",
-        });
+      onSuccess: (data) => {
+        if (data.emailSent) {
+          toast({
+            description: "Invite resent successfully",
+          });
+        } else {
+          toast({
+            variant: "destructive",
+            description:
+              "The email could not be sent. Check that SMTP is configured.",
+          });
+        }
         queryClient.invalidateQueries(api.invites.list.pathFilter());
       },
       onError: (e) => {

--- a/packages/trpc/routers/invites.test.ts
+++ b/packages/trpc/routers/invites.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { invites, users } from "@karakeep/db/schema";
 
 import type { CustomTestContext } from "../testUtils";
+import * as emailModule from "../email";
 import { defaultBeforeEach, getApiCaller } from "../testUtils";
 
 // Mock server config with email settings
@@ -32,7 +33,11 @@ vi.mock("../email", () => ({
   sendInviteEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
-beforeEach<CustomTestContext>(defaultBeforeEach(false));
+beforeEach<CustomTestContext>(async (ctx) => {
+  await defaultBeforeEach(false)(ctx);
+  vi.mocked(emailModule.sendInviteEmail).mockReset();
+  vi.mocked(emailModule.sendInviteEmail).mockResolvedValue(undefined);
+});
 
 describe("Invites Router", () => {
   test<CustomTestContext>("admin can create invite", async ({
@@ -655,12 +660,6 @@ describe("Invites Router", () => {
     db,
     unauthedAPICaller,
   }) => {
-    // Mock the email module
-    const mockSendInviteEmail = vi.fn().mockResolvedValue(undefined);
-    vi.doMock("../email", () => ({
-      sendInviteEmail: mockSendInviteEmail,
-    }));
-
     const admin = await unauthedAPICaller.users.create({
       name: "Admin User",
       email: "admin@test.com",
@@ -674,8 +673,70 @@ describe("Invites Router", () => {
       email: "newuser@test.com",
     });
 
-    // Note: In a real test environment, we'd need to properly mock the email module
-    // This test demonstrates the structure but may not actually verify the mock call
-    // due to how the module is imported in the router
+    expect(emailModule.sendInviteEmail).toHaveBeenCalledWith(
+      "newuser@test.com",
+      expect.any(String),
+      "A Karakeep admin",
+    );
+  });
+
+  test<CustomTestContext>("create reports emailSent false when invite email cannot be sent", async ({
+    db,
+    unauthedAPICaller,
+  }) => {
+    vi.mocked(emailModule.sendInviteEmail).mockRejectedValue(
+      new Error("SMTP is not configured"),
+    );
+
+    const admin = await unauthedAPICaller.users.create({
+      name: "Admin User",
+      email: "admin@test.com",
+      password: "pass1234",
+      confirmPassword: "pass1234",
+    });
+
+    const adminCaller = getApiCaller(db, admin.id, admin.email, "admin");
+
+    const result = await adminCaller.invites.create({
+      email: "newuser@test.com",
+    });
+
+    expect(result.emailSent).toBe(false);
+    expect(result.email).toBe("newuser@test.com");
+
+    const dbInvite = await db.query.invites.findFirst({
+      where: eq(invites.email, "newuser@test.com"),
+    });
+    expect(dbInvite).toBeDefined();
+  });
+
+  test<CustomTestContext>("resend reports emailSent false when invite email cannot be sent", async ({
+    db,
+    unauthedAPICaller,
+  }) => {
+    const admin = await unauthedAPICaller.users.create({
+      name: "Admin User",
+      email: "admin@test.com",
+      password: "pass1234",
+      confirmPassword: "pass1234",
+    });
+
+    const adminCaller = getApiCaller(db, admin.id, admin.email, "admin");
+
+    const invite = await adminCaller.invites.create({
+      email: "newuser@test.com",
+    });
+    expect(invite.emailSent).toBe(true);
+
+    vi.mocked(emailModule.sendInviteEmail).mockRejectedValue(
+      new Error("SMTP is not configured"),
+    );
+
+    const result = await adminCaller.invites.resend({
+      inviteId: invite.id,
+    });
+
+    expect(result.emailSent).toBe(false);
+    expect(result.id).toBe(invite.id);
   });
 });

--- a/packages/trpc/routers/invites.ts
+++ b/packages/trpc/routers/invites.ts
@@ -60,6 +60,7 @@ export const invitesAppRouter = router({
         .returning();
 
       // Send invite email
+      let emailSent = true;
       try {
         await sendInviteEmail(
           input.email,
@@ -67,13 +68,14 @@ export const invitesAppRouter = router({
           ctx.user.name || "A Karakeep admin",
         );
       } catch (error) {
+        emailSent = false;
         console.error("Failed to send invite email:", error);
-        // Don't fail the invite creation if email sending fails
       }
 
       return {
         id: invite.id,
         email: invite.email,
+        emailSent,
       };
     }),
 
@@ -260,6 +262,7 @@ export const invitesAppRouter = router({
         .where(eq(invites.id, input.inviteId));
 
       // Send invite email with new token
+      let emailSent = true;
       try {
         await sendInviteEmail(
           invite.email,
@@ -267,13 +270,14 @@ export const invitesAppRouter = router({
           ctx.user.name || "A Karakeep admin",
         );
       } catch (error) {
+        emailSent = false;
         console.error("Failed to send invite email:", error);
-        // Don't fail the resend if email sending fails
       }
 
       return {
         id: invite.id,
         email: invite.email,
+        emailSent,
       };
     }),
 });


### PR DESCRIPTION
Swallowing email errors made the API return success, so the UI showed a success toast while failure only appeared in logs.

## Description

Describe your changes in detail:
Made it clearer that inviting can lead to no email sent if smtp is not setup

Why is this change required? What problem does it solve?
I saw the invite function. I tried it on my instance and message was successful, I was intrigue how it could be as I didn't setup anything. When looking at logs it logged a console.error. This change make it clearer that it didn't work and setup is needed

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A: pnpm dev, invite a user
- [X] Test B: pnpm dev, resend invite button

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

instructions to cursor while keeping an eye on code produced and tested locally to see result.
skills used: https://github.com/mattpocock/skills
