### PR TITLE
feat(browser-extension): edit bookmark metadata after saving

### DIFF
--- a/apps/browser-extension/src/BookmarkSavedPage.tsx
+++ b/apps/browser-extension/src/BookmarkSavedPage.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { useDeleteBookmark } from "@karakeep/shared-react/hooks/bookmarks";
 
 import BookmarkLists from "./components/BookmarkLists";
+import { BookmarkMetadataEditor } from "./components/BookmarkMetadataEditor";
 import { ListsSelector } from "./components/ListsSelector";
 import { NoteEditor } from "./components/NoteEditor";
 import TagList from "./components/TagList";
@@ -84,6 +85,8 @@ export default function BookmarkSavedPage() {
           </Button>
         </div>
       </div>
+      <hr />
+      <BookmarkMetadataEditor bookmarkId={bookmarkId} />
       <hr />
       <p className="text-lg">Notes</p>
       <NoteEditor bookmarkId={bookmarkId} />

--- a/apps/browser-extension/src/components/BookmarkMetadataEditor.tsx
+++ b/apps/browser-extension/src/components/BookmarkMetadataEditor.tsx
@@ -1,0 +1,209 @@
+import { FormEvent, useEffect, useState } from "react";
+import { Check, Save, Star } from "lucide-react";
+
+import { MAX_BOOKMARK_TITLE_LENGTH } from "@karakeep/shared/types/bookmarks";
+import {
+  useAutoRefreshingBookmarkQuery,
+  useUpdateBookmark,
+} from "@karakeep/shared-react/hooks/bookmarks";
+
+import Spinner from "../Spinner";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+
+interface TitleState {
+  draft: string;
+  saved: string;
+}
+
+export function BookmarkMetadataEditor({ bookmarkId }: { bookmarkId: string }) {
+  const {
+    data: bookmark,
+    error: bookmarkError,
+    isPending: isBookmarkPending,
+    refetch,
+  } = useAutoRefreshingBookmarkQuery({ bookmarkId });
+  const [titleState, setTitleState] = useState<TitleState | null>(null);
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [favouriteError, setFavouriteError] = useState<string | null>(null);
+  const [favouriteOverride, setFavouriteOverride] = useState<boolean | null>(
+    null,
+  );
+
+  const serverTitle = bookmark?.title ?? "";
+  useEffect(() => {
+    setTitleState((current) => {
+      if (current && current.draft !== current.saved) {
+        return current;
+      }
+      return { draft: serverTitle, saved: serverTitle };
+    });
+  }, [serverTitle]);
+
+  const serverFavourite = bookmark?.favourited;
+  useEffect(() => {
+    if (
+      serverFavourite !== undefined &&
+      favouriteOverride === serverFavourite
+    ) {
+      setFavouriteOverride(null);
+    }
+  }, [serverFavourite, favouriteOverride]);
+
+  const titleMutation = useUpdateBookmark({
+    onSuccess: (updatedBookmark) => {
+      const updatedTitle = updatedBookmark.title ?? "";
+      setTitleState({ draft: updatedTitle, saved: updatedTitle });
+      setTitleError(null);
+    },
+    onError: (error) => {
+      setTitleError(error.message || "Failed to save title");
+    },
+  });
+
+  const favouriteMutation = useUpdateBookmark({
+    onSuccess: (updatedBookmark) => {
+      setFavouriteOverride(updatedBookmark.favourited);
+      setFavouriteError(null);
+    },
+    onError: (error) => {
+      setFavouriteOverride(null);
+      setFavouriteError(error.message || "Failed to update favourite");
+    },
+  });
+
+  if (isBookmarkPending) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner />
+        <span>Loading bookmark details...</span>
+      </div>
+    );
+  }
+
+  if (bookmarkError || !bookmark) {
+    return (
+      <div className="flex flex-col gap-2" role="alert">
+        <p className="text-sm text-red-500">Could not load bookmark details.</p>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          Try Again
+        </Button>
+      </div>
+    );
+  }
+
+  const resolvedTitleState = titleState ?? {
+    draft: serverTitle,
+    saved: serverTitle,
+  };
+  const isUpdating = titleMutation.isPending || favouriteMutation.isPending;
+  const hasUnsavedTitle = resolvedTitleState.draft !== resolvedTitleState.saved;
+  const isFavourited = favouriteOverride ?? bookmark.favourited;
+
+  const saveTitle = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!hasUnsavedTitle || isUpdating) {
+      return;
+    }
+
+    setTitleError(null);
+    titleMutation.mutate({
+      bookmarkId,
+      title:
+        resolvedTitleState.draft.length > 0 ? resolvedTitleState.draft : null,
+    });
+  };
+
+  const toggleFavourite = () => {
+    if (isUpdating) {
+      return;
+    }
+
+    const nextFavourite = !isFavourited;
+    setFavouriteError(null);
+    setFavouriteOverride(nextFavourite);
+    favouriteMutation.mutate({
+      bookmarkId,
+      favourited: nextFavourite,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <label className="text-lg" htmlFor="bookmark-title">
+          Title
+        </label>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          aria-label={
+            isFavourited ? "Remove from favourites" : "Add to favourites"
+          }
+          aria-pressed={isFavourited}
+          disabled={isUpdating}
+          onClick={toggleFavourite}
+        >
+          {favouriteMutation.isPending ? (
+            <Spinner />
+          ) : (
+            <Star
+              aria-hidden="true"
+              className="h-4 w-4"
+              fill={isFavourited ? "#ebb434" : "none"}
+              color={isFavourited ? "#ebb434" : "currentColor"}
+            />
+          )}
+          {isFavourited ? "Favourited" : "Favourite"}
+        </Button>
+      </div>
+      <form className="flex items-center gap-2" onSubmit={saveTitle}>
+        <Input
+          id="bookmark-title"
+          maxLength={MAX_BOOKMARK_TITLE_LENGTH}
+          placeholder="Untitled"
+          value={resolvedTitleState.draft}
+          onChange={(event) => {
+            setTitleError(null);
+            setTitleState((current) => ({
+              saved: current?.saved ?? serverTitle,
+              draft: event.currentTarget.value,
+            }));
+          }}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          className="gap-1.5"
+          disabled={!hasUnsavedTitle || isUpdating}
+        >
+          {titleMutation.isPending ? (
+            <>
+              <Save aria-hidden="true" className="h-3.5 w-3.5 animate-pulse" />
+              Saving...
+            </>
+          ) : hasUnsavedTitle ? (
+            <>
+              <Save aria-hidden="true" className="h-3.5 w-3.5" />
+              Save
+            </>
+          ) : (
+            <>
+              <Check aria-hidden="true" className="h-3.5 w-3.5" />
+              Saved
+            </>
+          )}
+        </Button>
+      </form>
+      <div className="min-h-4 text-xs" aria-live="polite">
+        {titleError && <p className="text-red-500">{titleError}</p>}
+        {!titleError && hasUnsavedTitle && (
+          <p className="text-amber-600 dark:text-amber-500">Unsaved changes</p>
+        )}
+        {favouriteError && <p className="text-red-500">{favouriteError}</p>}
+      </div>
+    </div>
+  );
+}

--- a/apps/browser-extension/src/components/BookmarkMetadataEditor.tsx
+++ b/apps/browser-extension/src/components/BookmarkMetadataEditor.tsx
@@ -51,9 +51,16 @@ export function BookmarkMetadataEditor({ bookmarkId }: { bookmarkId: string }) {
   }, [serverFavourite, favouriteOverride]);
 
   const titleMutation = useUpdateBookmark({
-    onSuccess: (updatedBookmark) => {
+    onSuccess: (updatedBookmark, request) => {
       const updatedTitle = updatedBookmark.title ?? "";
-      setTitleState({ draft: updatedTitle, saved: updatedTitle });
+      const submittedTitle = request.title ?? "";
+      setTitleState((current) => ({
+        draft:
+          current && current.draft !== submittedTitle
+            ? current.draft
+            : updatedTitle,
+        saved: updatedTitle,
+      }));
       setTitleError(null);
     },
     onError: (error) => {


### PR DESCRIPTION
## description

- adds an editable title to the browser extension's post-save view
- adds a favourite toggle that reflects the saved bookmark state
- preserves unsaved title text during bookmark refreshes
- prevents title and favourite updates from racing
- includes loading, retry, saved, unsaved, pending, and error states

fixes #2882

## how has this been tested?

- [x] browser-extension typecheck with typescript 5.9.3
- [x] focused oxlint check with no warnings or errors
- [x] focused oxfmt check
- [x] production vite build with 1,963 modules transformed
- [x] interface detector with no findings

the browser-extension package has no test script or component-test setup. so i did not add a new test dependency for this focused ui change.

<details><summary><h2>screenshots</h2></summary>

not included. the post-save view needs an authenticated extension session that is not available in this terminal environment.

</details>

## checklist

- [x] i have carefully read contributing.md
- [x] i have performed a self-review of my own code
- [x] documentation changes are not required for this extension ui change
- [x] i have no unrelated changes in the pull request
- [x] i have added no dependencies
- [x] the package has no existing test command, and the focused validation above passes

## llm use

codex helped research issue ownership, review edge cases and draft the PR comment. everything else was done by me.
