### PR TITLE
Fix crash loop caused by better-sqlite3 and node.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
     && cargo install monolith --locked
 
 ################# Base Builder ##############
-FROM node:24-slim AS base
+# Replace with node:24-slim as soon as https://github.com/nodejs/node/pull/65042 is fixed and uploaded to Docker hub
+FROM node:24.18.1-slim AS base
 
 WORKDIR /app
 ENV PNPM_HOME="/pnpm"
@@ -75,7 +76,8 @@ RUN (cd apps/mcp && pnpm --config.verify-deps-before-run=false build)
 
 ################# The All-in-one builder ##############
 
-FROM node:24-slim AS aio_builder
+# Replace with node:24-slim as soon as https://github.com/nodejs/node/pull/65042 is fixed and uploaded to Docker hub
+FROM node:24.18.1-slim AS aio_builder
 LABEL org.opencontainers.image.source="https://github.com/karakeep-app/karakeep"
 WORKDIR /app
 
@@ -202,7 +204,8 @@ ENV USING_LEGACY_SEPARATE_CONTAINERS=true
 
 ################# The cli ##############
 
-FROM node:24-slim AS cli
+# Replace with node:24-slim as soon as https://github.com/nodejs/node/pull/65042 is fixed and uploaded to Docker hub
+FROM node:24.18.1-slim AS cli
 LABEL org.opencontainers.image.source="https://github.com/karakeep-app/karakeep"
 WORKDIR /app
 
@@ -217,7 +220,8 @@ ENTRYPOINT ["node", "index.mjs"]
 
 ################# MCP server ##############
 
-FROM node:24-slim AS mcp
+# Replace with node:24-slim as soon as https://github.com/nodejs/node/pull/65042 is fixed and uploaded to Docker hub
+FROM node:24.18.1-slim AS mcp
 LABEL org.opencontainers.image.source="https://github.com/karakeep-app/karakeep"
 WORKDIR /app
 


### PR DESCRIPTION
## Description

As outlined in

https://github.com/karakeep-app/karakeep/issues/2989

Karakeep keeps crashing due to a bad interaction
between node 24.19 and better-sqlite3.

This commit pins node to 24.18.1 for Docker
builds, which still works fine. Once the bug is
fixed in node and the fixed version has been
uploaded to Docker hub, this commit can be
reverted.

Fixes #2989 

## How Has This Been Tested?

Docker build and docker run on a system that was previously in a crash loop and with this patch, it works fine again.

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary. - No new dependencies
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No, no LLM was used.