### PR TITLE
fix(mobile): expand new bookmark input

### DIFF
--- a/apps/mobile/app/dashboard/bookmarks/new.tsx
+++ b/apps/mobile/app/dashboard/bookmarks/new.tsx
@@ -64,7 +64,8 @@ const NoteEditorPage = () => {
       )}
       <Input
         onChangeText={setText}
-        className="bg-card"
+        className="flex-1 bg-card"
+        inputClasses="h-auto flex-1 sm:h-auto"
         multiline
         placeholder="What's on your mind?"
         autoFocus


### PR DESCRIPTION
## Description

Make the new-bookmark text input use the available vertical space on mobile. The input remains multiline and the save button stays below it.

Fixes #2364

## How Has This Been Tested?

- [x] `git diff --check`
- [x] `pnpm --filter @karakeep/mobile format`

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (not applicable for this layout-only change)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM assistance was used to locate the mobile screen and draft the two layout-class changes. The final diff was reviewed against the existing `Input` component and formatter-checked.
