### PR TITLE
feat: publish a new karakeep chrome container

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -1,0 +1,178 @@
+name: Chrome Image
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/chrome.yml"
+      - "docker/chrome/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/chrome.yml"
+      - "docker/chrome/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+env:
+  IMAGE: ghcr.io/karakeep-app/karakeep-chrome
+  HEADLESS_SHELL_VERSION: 151.0.7922.47
+  IMAGE_REVISION: r1
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      created: ${{ steps.created.outputs.value }}
+    permissions:
+      contents: read
+    steps:
+      - name: Set image creation time
+        id: created
+        run: echo "value=$(date --utc +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.platform }}
+    needs: metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          build-args: |
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_CREATED=${{ needs.metadata.outputs.created }}
+          context: .
+          file: docker/chrome/Dockerfile
+          load: true
+          platforms: ${{ matrix.platform }}
+          tags: karakeep-chrome:build-check
+
+  publish-architectures:
+    name: Publish ${{ matrix.platform }}
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'karakeep-app/karakeep' &&
+      github.ref == 'refs/heads/main'
+    needs:
+      - metadata
+      - build
+    environment: chrome-production
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            suffix: amd64
+            os: ubuntu-latest
+          - platform: linux/arm64
+            suffix: arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Refuse to overwrite the immutable tag
+        env:
+          VERSION_TAG: ${{ env.IMAGE }}:${{ env.HEADLESS_SHELL_VERSION }}-${{ env.IMAGE_REVISION }}
+        run: |
+          if docker buildx imagetools inspect "$VERSION_TAG" >/dev/null 2>&1; then
+            echo "Refusing to overwrite published image $VERSION_TAG"
+            exit 1
+          fi
+
+      - name: Build and publish architecture image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          build-args: |
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_CREATED=${{ needs.metadata.outputs.created }}
+          context: .
+          file: docker/chrome/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ env.IMAGE }}:${{ env.HEADLESS_SHELL_VERSION }}-${{ env.IMAGE_REVISION }}-${{ matrix.suffix }}
+
+  publish-manifest:
+    name: Publish multi-architecture manifest
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'karakeep-app/karakeep' &&
+      github.ref == 'refs/heads/main'
+    needs: publish-architectures
+    environment: chrome-production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release manifests
+        env:
+          LATEST_TAG: ${{ env.IMAGE }}:latest
+          RELEASE_TAG: ${{ env.IMAGE }}:release
+          VERSION_TAG: ${{ env.IMAGE }}:${{ env.HEADLESS_SHELL_VERSION }}-${{ env.IMAGE_REVISION }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$VERSION_TAG" \
+            --tag "$LATEST_TAG" \
+            --tag "$RELEASE_TAG" \
+            "$VERSION_TAG-amd64" \
+            "$VERSION_TAG-arm64"
+
+      - name: Inspect published manifests
+        env:
+          LATEST_TAG: ${{ env.IMAGE }}:latest
+          RELEASE_TAG: ${{ env.IMAGE }}:release
+          VERSION_TAG: ${{ env.IMAGE }}:${{ env.HEADLESS_SHELL_VERSION }}-${{ env.IMAGE_REVISION }}
+        run: |
+          docker buildx imagetools inspect "$VERSION_TAG"
+          docker buildx imagetools inspect "$LATEST_TAG"
+          docker buildx imagetools inspect "$RELEASE_TAG"

--- a/docker/chrome/Dockerfile
+++ b/docker/chrome/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7
+
+ARG HEADLESS_SHELL_VERSION=151.0.7922.47
+ARG HEADLESS_SHELL_DIGEST=sha256:dabddca3d1b3d95f0004bd16c62e581b701e313b41cce1e36606db1bbac06db2
+
+FROM docker.io/chromedp/headless-shell:${HEADLESS_SHELL_VERSION}@${HEADLESS_SHELL_DIGEST}
+
+ARG HEADLESS_SHELL_VERSION
+ARG HEADLESS_SHELL_DIGEST
+ARG BUILD_REVISION=unknown
+ARG BUILD_CREATED=unknown
+
+LABEL org.opencontainers.image.title="Karakeep Chrome" \
+      org.opencontainers.image.description="Chrome Headless Shell tested and distributed for Karakeep" \
+      org.opencontainers.image.source="https://github.com/karakeep-app/karakeep" \
+      org.opencontainers.image.revision="${BUILD_REVISION}" \
+      org.opencontainers.image.created="${BUILD_CREATED}" \
+      org.opencontainers.image.version="${HEADLESS_SHELL_VERSION}" \
+      org.opencontainers.image.base.name="docker.io/chromedp/headless-shell:${HEADLESS_SHELL_VERSION}" \
+      org.opencontainers.image.base.digest="${HEADLESS_SHELL_DIGEST}"
+
+USER 65534:65534

--- a/docker/chrome/README.md
+++ b/docker/chrome/README.md
@@ -1,0 +1,36 @@
+# Karakeep Chrome
+
+This directory defines Karakeep's minimal Chrome Headless Shell image.
+
+This image is built on top of (https://github.com/chromedp/docker-headless-shell).
+
+## Testing locally
+
+Run Karakeep's e2e suite, which builds this image through its Compose file and
+exercises it through the real crawler:
+
+```sh
+pnpm --filter @karakeep/e2e_tests test
+```
+
+The crawler tests cover Playwright compatibility, context creation, local-page
+navigation, JavaScript execution, request routing, the CDP redirect guard,
+screenshots, and PDFs. The image workflow verifies that the image builds on both
+native target architectures before publishing.
+
+## Updating the image
+
+1. Choose an exact `chromedp/headless-shell` version that supports both target
+   architectures.
+2. Resolve its multi-architecture index digest with
+   `docker buildx imagetools inspect`.
+3. Update the version and digest in `Dockerfile` and the version and image
+   revision in `.github/workflows/chrome.yml`.
+4. Open a pull request and let both native architecture build jobs pass.
+5. After merge, manually dispatch the `Chrome Image` workflow from `main`.
+   Publishing is gated by the `chrome-production` GitHub environment.
+
+Use `-r1` for a new browser version. Increment the revision for a packaging-only
+change. Never reuse or mutate a published versioned tag. Each release also moves
+the `latest` and `release` tags to the newly published manifest. They currently
+move together but may use separate promotion policies in the future.

--- a/packages/e2e_tests/docker-compose.yml
+++ b/packages/e2e_tests/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       BROWSER_WEB_URL: http://chrome:9222
       CRAWLER_NUM_WORKERS: 6
       CRAWLER_ALLOWED_INTERNAL_HOSTNAMES: nginx
+      CRAWLER_STORE_PDF: "true"
       CRAWLER_VIDEO_DOWNLOAD: "true"
       CRAWLER_VIDEO_DOWNLOAD_MAX_SIZE: -1
       OPENAI_API_KEY: aimock-test-key
@@ -32,15 +33,18 @@ services:
       MEILI_NO_ANALYTICS: "true"
       MEILI_MASTER_KEY: dummy
   chrome:
-    image: gcr.io/zenika-hub/alpine-chrome:124
+    image: ${KARAKEEP_CHROME_IMAGE:-karakeep-chrome:e2e}
+    build:
+      context: ../..
+      dockerfile: docker/chrome/Dockerfile
     restart: unless-stopped
+    init: true
     command:
-      - --no-sandbox
       - --disable-gpu
       - --disable-dev-shm-usage
-      - --remote-debugging-address=0.0.0.0
-      - --remote-debugging-port=9222
       - --hide-scrollbars
+      - --disable-blink-features=AutomationControlled
+      - --window-size=1440,900
   nginx:
     image: nginx:alpine
     restart: unless-stopped

--- a/packages/e2e_tests/tests/workers/crawler.test.ts
+++ b/packages/e2e_tests/tests/workers/crawler.test.ts
@@ -65,6 +65,7 @@ describe("Crawler Tests", () => {
     expect(
       bookmark.assets.find((a) => a.assetType === "screenshot"),
     ).toBeDefined();
+    expect(bookmark.assets.find((a) => a.assetType === "pdf")).toBeDefined();
   });
 
   it("should crawl browser-rendered content", async () => {


### PR DESCRIPTION
Publish a new chrome container that's based on docker.io/chromedp/headless-shell. Another PR will migrate the callsites of the old chrome container to this new one.