### PR TITLE
Fix broken gcr.io chrome image in docker/docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,10 +22,12 @@ services:
   chrome:
     image: ghcr.io/karakeep-app/karakeep-chrome:release
     restart: unless-stopped
-    init: true
     command:
+      - --no-sandbox
       - --disable-gpu
       - --disable-dev-shm-usage
+      - --remote-debugging-address=0.0.0.0
+      - --remote-debugging-port=9222
       - --hide-scrollbars
       - --disable-blink-features=AutomationControlled
       - --window-size=1440,900


### PR DESCRIPTION
## Problem

`docker/docker-compose.yml` still references `gcr.io/zenika-hub/alpine-chrome:124` for the `chrome` service, which currently fails to pull:

```
Error response from daemon: Head "https://gcr.io/v2/zenika-hub/alpine-chrome/manifests/124":
denied: This API method requires billing to be enabled. Please enable billing on project #...
```

This is the same failure mode reported in #72 back in 2024, where @MohamedBassem confirmed switching away from the `gcr.io/zenika-hub/` mirror as the fix.

## What this PR does

`docker/docker-compose.yml` is the *only* deployment file left in the repo still pointing at the old `gcr.io/zenika-hub/alpine-chrome` image. Every other compose/deployment file already uses the first-party image:

- `docker/docker-compose.dev.yml`
- `docker/docker-compose.build.yml`
- `kubernetes/chrome-deployment.yaml`
- `packages/benchmarks/docker-compose.yml`
- `tools/seed-snapshot/docker-compose.yml`
- `start-dev.sh`

...all use `ghcr.io/karakeep-app/karakeep-chrome:release`. This PR just brings the main production compose template in line with the rest of the repo, so users following the primary install docs don't hit the GCR billing wall.

## Testing

Applied this exact change to my own self-hosted instance and confirmed `docker compose up -d` pulls and starts `chrome` cleanly with no image errors.