### PR TITLE
fix(mobile): server save button clipped by keyboard

### DIFF
--- a/apps/mobile/app/server-address.tsx
+++ b/apps/mobile/app/server-address.tsx
@@ -89,9 +89,16 @@ export default function ServerAddress() {
 
   return (
     <KeyboardAwareScrollView
-      contentContainerClassName="items-center gap-4 px-4 py-4"
+      contentContainerStyle={{
+        alignItems: "center",
+        gap: 16,
+        paddingHorizontal: 16,
+        paddingTop: 16,
+        paddingBottom: 96,
+      }}
       bottomOffset={20}
       keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="interactive"
       contentInsetAdjustmentBehavior="automatic"
     >
       {/* Error Message */}
@@ -131,15 +138,15 @@ export default function ServerAddress() {
       </View>
 
       {/* Custom Headers Section */}
-      <View className="w-full">
-        <Text className="mb-2 px-1 text-sm font-medium text-muted-foreground">
+      <View className="w-full items-center">
+        <Text className="mb-2 px-1 text-center text-sm font-medium text-muted-foreground">
           Custom Headers
           {headers.length > 0 && (
             <Text className="text-muted-foreground"> ({headers.length})</Text>
           )}
         </Text>
         <View className="w-full gap-3 rounded-lg bg-card px-4 py-4">
-          <Text className="text-sm text-muted-foreground">
+          <Text className="text-center text-sm text-muted-foreground">
             Add custom HTTP headers for API requests
           </Text>
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Fixes the "save" button in the server configuration being clipped by the keyboard on iOS 26, especially on smaller devices like the Iphone SE. This is done by modifying the padding attributes in the KeyboardAwareScrollView.
- While I was here I also noticed that the text for the custom headers wasn't centered, so I fixed that also.
<!--- Why is this change required? What problem does it solve? -->
A user might encounter this bug while trying to setup a server, and have trouble hiding the keyboard to show this button. 
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2999 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
This bug was only reproducible on iOS 26 (18 is excluded). I used the simulator to reproduce and test fixes.
<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Before  

https://github.com/user-attachments/assets/32fad451-0b4b-4641-963d-8a695d09ea33

After  

https://github.com/user-attachments/assets/4bad84b5-00a9-493f-9925-ad1dee17f3fb

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Copilot was used to suggest the changes, which I reviewed. After that I was able to reduce the diff, and then validated it in the simulator.