### PR TITLE
fix(trpc): show collaborator bookmarks in public lists

### DIFF
--- a/packages/trpc/lib/impersonate.ts
+++ b/packages/trpc/lib/impersonate.ts
@@ -1,12 +1,13 @@
 import { eq } from "drizzle-orm";
 
-import { db } from "@karakeep/db";
+import { db as globalDb } from "@karakeep/db";
 import { users } from "@karakeep/db/schema";
 
 import { AuthedContext } from "..";
 
 export async function buildImpersonatingAuthedContext(
   userId: string,
+  db: AuthedContext["db"] = globalDb,
 ): Promise<AuthedContext> {
   const user = await db.query.users.findFirst({
     where: eq(users.id, userId),

--- a/packages/trpc/models/lists.ts
+++ b/packages/trpc/models/lists.ts
@@ -218,7 +218,10 @@ export abstract class List {
     // The token here acts as an authed context, so we can create
     // an impersonating context for the list owner as long as
     // we don't leak the context.
-    const authedCtx = await buildImpersonatingAuthedContext(listdb.userId);
+    const authedCtx = await buildImpersonatingAuthedContext(
+      listdb.userId,
+      ctx.db,
+    );
     const listObj = List.fromData(
       authedCtx,
       {
@@ -228,11 +231,13 @@ export abstract class List {
       },
       null,
     );
-    const bookmarkIds = await listObj.getBookmarkIds();
+    const numItems = await listObj.getSize();
     const list = listObj.asZBookmarkList();
 
+    // Filtering by listId instead of by ids, because the ids path is scoped to
+    // the list owner and would hide the bookmarks added by collaborators.
     const bookmarks = await Bookmark.loadMulti(authedCtx, {
-      ids: bookmarkIds,
+      listId: listObj.id,
       includeContent: false,
       limit: pagination.limit,
       sortOrder: pagination.order,
@@ -245,7 +250,7 @@ export abstract class List {
         name: list.name,
         description: list.description,
         ownerName: listdb.user.name,
-        numItems: bookmarkIds.length,
+        numItems,
       },
       bookmarks: bookmarks.bookmarks.map((b) => b.asPublicBookmark()),
       nextCursor: bookmarks.nextCursor,

--- a/packages/trpc/routers/sharedLists.test.ts
+++ b/packages/trpc/routers/sharedLists.test.ts
@@ -868,6 +868,66 @@ describe("Shared Lists", () => {
     });
   });
 
+  describe("Public Shared Lists", () => {
+    test<CustomTestContext>("should show collaborator bookmarks in a public list", async ({
+      apiCallers,
+      unauthedAPICaller,
+    }) => {
+      const ownerApi = apiCallers[0];
+      const collaboratorApi = apiCallers[1];
+
+      const list = await ownerApi.lists.create({
+        name: "Public Shared List",
+        icon: "📚",
+        type: "manual",
+      });
+
+      // Owner adds a bookmark
+      const ownerBookmark = await ownerApi.bookmarks.createBookmark({
+        type: BookmarkTypes.TEXT,
+        text: "Owner's bookmark",
+      });
+
+      await ownerApi.lists.addToList({
+        listId: list.id,
+        bookmarkId: ownerBookmark.id,
+      });
+
+      await addAndAcceptCollaborator(
+        ownerApi,
+        collaboratorApi,
+        list.id,
+        "editor",
+      );
+
+      // Collaborator adds their own bookmark
+      const collabBookmark = await collaboratorApi.bookmarks.createBookmark({
+        type: BookmarkTypes.TEXT,
+        text: "Collaborator's bookmark",
+      });
+
+      await collaboratorApi.lists.addToList({
+        listId: list.id,
+        bookmarkId: collabBookmark.id,
+      });
+
+      await ownerApi.lists.edit({
+        listId: list.id,
+        public: true,
+      });
+
+      const publicView =
+        await unauthedAPICaller.publicBookmarks.getPublicBookmarksInList({
+          listId: list.id,
+        });
+
+      expect(publicView.list.numItems).toBe(2);
+      expect(publicView.bookmarks.map((b) => b.id).sort()).toEqual(
+        [ownerBookmark.id, collabBookmark.id].sort(),
+      );
+    });
+  });
+
   describe("Bookmark Editing Permissions", () => {
     test<CustomTestContext>("should not allow viewer to add bookmarks to list", async ({
       apiCallers,


### PR DESCRIPTION
## Description

When a shared list is made public, the public page only showed bookmarks belonging to the list owner. Anything a collaborator had added was missing, even though the item count at the top of the page was correct.

The cause is in `List.getPublicListContents`. It collected every bookmark id in the list and handed them to `Bookmark.loadMulti` as `ids`. That query path filters on `bookmarks.userId`, so bookmarks owned by a collaborator were dropped. The count came from a separate query with no such filter, which is why the number and the visible bookmarks disagreed. I changed it to pass `listId` instead. That is the same path the logged-in list view already uses, it drives off `bookmarksInLists` and does not filter by owner. Access control is unchanged, `getPublicList` has already proven the list is public or that the RSS token matched before this runs, and asset URLs are signed with each bookmark's own user id so a collaborator's assets get the right signature. The count now comes from `getSize()` since the full id list is no longer needed. Smart lists behave as before because `loadMulti` still resolves them to ids internally.

There is one supporting change in `buildImpersonatingAuthedContext`. It reached for the module-level db directly, so a test could not drive the real public endpoint against the in-memory test database. It now takes an optional db and `getPublicListContents` passes the one from the request context. Existing callers are untouched and fall back to the default.

Fixes #2594

## How Has This Been Tested?

- [x] New test in `packages/trpc/routers/sharedLists.test.ts`: the owner creates a manual list and adds a bookmark, an editor collaborator adds their own bookmark, the owner marks the list public, then the unauthenticated caller hits `publicBookmarks.getPublicBookmarksInList` and must get both bookmarks with `numItems` of 2. It fails on main, returning only the owner's bookmark while still reporting 2 items, and passes with this change.
- [x] Full trpc package suite: `pnpm --filter @karakeep/trpc exec vitest run`, 449 tests passing. Typecheck, lint and format are clean.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No visual change. The public list page now renders the bookmarks it was already counting.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used Claude Code for this one. It traced the owner filter through the list and bookmark models, wrote the fix and the test, and ran the suite. I read the diff myself and checked that the test really fails without the source change before opening this.