### PR TITLE
fix(inference): strip reasoning tags from inference responses

### DIFF
--- a/packages/shared/inference.test.ts
+++ b/packages/shared/inference.test.ts
@@ -5,6 +5,7 @@ import { OpenAIInferenceClient } from "./inference";
 import type { OpenAIInferenceConfig } from "./inference";
 
 const capturedBodies: Record<string, unknown>[] = [];
+const mockCompletion: { content: string | null } = { content: "{}" };
 const tagSchema = z.object({ tags: z.array(z.string()) });
 
 vi.mock("openai", () => {
@@ -14,7 +15,7 @@ vi.mock("openai", () => {
         create: vi.fn(async (body: Record<string, unknown>) => {
           capturedBodies.push(body);
           return {
-            choices: [{ message: { content: "{}" } }],
+            choices: [{ message: { content: mockCompletion.content } }],
             usage: { total_tokens: 1 },
           };
         }),
@@ -49,6 +50,7 @@ function makeConfig(
 describe("OpenAIInferenceClient response_format", () => {
   beforeEach(() => {
     capturedBodies.length = 0;
+    mockCompletion.content = "{}";
   });
 
   it("omits response_format for schema-less text inference in json mode", async () => {
@@ -90,5 +92,84 @@ describe("OpenAIInferenceClient response_format", () => {
       type: "json_schema",
       json_schema: { name: "schema" },
     });
+  });
+});
+
+describe("OpenAIInferenceClient reasoning tags", () => {
+  beforeEach(() => {
+    capturedBodies.length = 0;
+    mockCompletion.content = "{}";
+  });
+
+  it("strips a complete think block from a text response", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("plain"));
+    mockCompletion.content =
+      "<think>Let me extract the key points first.</think>\n\nReal summary.";
+
+    const result = await client.inferFromText("summarize this text", {
+      schema: null,
+    });
+
+    expect(result.response).toBe("Real summary.");
+  });
+
+  it("strips the preamble when the provider only emits a closing tag", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("plain"));
+    mockCompletion.content =
+      "Let me extract the key points first.</think>\n\nReal summary.";
+
+    const result = await client.inferFromText("summarize this text", {
+      schema: null,
+    });
+
+    expect(result.response).toBe("Real summary.");
+  });
+
+  it("strips a complete think block from an image response", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("plain"));
+    mockCompletion.content =
+      "<thinking>This looks like a cat.</thinking>A cat on a sofa.";
+
+    const result = await client.inferFromImage(
+      "describe this image",
+      "image/png",
+      "BASE64",
+      { schema: null },
+    );
+
+    expect(result.response).toBe("A cat on a sofa.");
+  });
+
+  it("leaves a response without reasoning tags untouched", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("plain"));
+    mockCompletion.content = "Real summary. It mentions <thinks> in passing.";
+
+    const result = await client.inferFromText("summarize this text", {
+      schema: null,
+    });
+
+    expect(result.response).toBe(
+      "Real summary. It mentions <thinks> in passing.",
+    );
+  });
+
+  it("leaves a json response untouched", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("json"));
+    mockCompletion.content = '{"tags":["cooking","recipes"]}';
+
+    const result = await client.inferFromText("infer tags as json", {
+      schema: tagSchema,
+    });
+
+    expect(result.response).toBe('{"tags":["cooking","recipes"]}');
+  });
+
+  it("throws when the response is nothing but reasoning", async () => {
+    const client = new OpenAIInferenceClient(makeConfig("plain"));
+    mockCompletion.content = "<think>I have no idea what to say.</think>";
+
+    await expect(
+      client.inferFromText("summarize this text", { schema: null }),
+    ).rejects.toThrow("Got no message content from OpenAI");
   });
 });

--- a/packages/shared/inference.ts
+++ b/packages/shared/inference.ts
@@ -123,6 +123,24 @@ const defaultInferenceOptions: InferenceOptions = {
   schema: null,
 };
 
+/**
+ * Some reasoning models inline their chain of thought in the message content
+ * instead of a separate field, so we have to drop it before using the response.
+ */
+export function stripReasoningBlocks(text: string): string {
+  // Remove complete <think>/<thinking> blocks anywhere in the text.
+  let out = text.replace(/<(think|thinking)>[\s\S]*?<\/\1>/gi, "");
+
+  // Some providers only emit the closing tag, in which case everything before
+  // it is reasoning.
+  const strayClosingTag = out.match(/<\/(?:think|thinking)>/i);
+  if (strayClosingTag?.index !== undefined) {
+    out = out.slice(strayClosingTag.index + strayClosingTag[0].length);
+  }
+
+  return out.trim();
+}
+
 export interface EmbeddingClient {
   generateEmbeddingFromText(inputs: string[]): Promise<EmbeddingResponse>;
 }
@@ -330,7 +348,9 @@ export class OpenAIInferenceClient implements InferenceClient {
       },
     );
 
-    const response = chatCompletion.choices[0].message.content;
+    const response = stripReasoningBlocks(
+      chatCompletion.choices[0].message.content ?? "",
+    );
     if (!response) {
       throw new Error(`Got no message content from OpenAI`);
     }
@@ -381,7 +401,9 @@ export class OpenAIInferenceClient implements InferenceClient {
       },
     );
 
-    const response = chatCompletion.choices[0].message.content;
+    const response = stripReasoningBlocks(
+      chatCompletion.choices[0].message.content ?? "",
+    );
     if (!response) {
       throw new Error(`Got no message content from OpenAI`);
     }
@@ -513,7 +535,7 @@ class OllamaInferenceClient implements InferenceClient {
       }
     }
 
-    return { response, totalTokens };
+    return { response: stripReasoningBlocks(response), totalTokens };
   }
 
   async inferFromText(


### PR DESCRIPTION
## Description

Reasoning models served over the OpenAI compatible API often put their chain of thought inline in the message content wrapped in `<think>` tags, rather than returning it in a separate field. MiniMax-M3 does this by default and several ollama models behave the same way. Karakeep stored that content as it came back, so the summary shown on the bookmark started with a wall of raw reasoning text.

This adds a small helper that removes complete `<think>` and `<thinking>` blocks, and applies it at the single point where provider text turns into an `InferenceResponse`. Summaries, tagging and image captioning all read cleaned text as a result. Some providers emit only the closing tag with no opener, so that case drops everything before it. If nothing is left after stripping, the existing empty response error is thrown instead of saving an empty summary. JSON output is not affected, since a well formed JSON body has no `<think>` in it.

Worth saying that this is separate from the reasoning effort option added in #2718. That one asks the provider to reason less, which only helps when the provider honours the request parameter. This cleans up the providers that ignore it and inline the trace regardless.

Fixes #2894

## How Has This Been Tested?

- [x] Added unit tests in `packages/shared/inference.test.ts` for a complete think block, a stray closing tag with no opener, an image response, plain text and JSON left alone, and the case where only reasoning comes back. They fail on main and pass with this change.
- [x] `pnpm --filter @karakeep/shared exec vitest run` passes, 113 tests. Typecheck, lint and format all pass.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used Claude Code to write the helper, the tests and this description, and I reviewed the diff and ran the tests myself before opening it.