### PR TITLE
fix(shared): sort lists by name when building the list tree

### DIFF
--- a/packages/shared/utils/listUtils.test.ts
+++ b/packages/shared/utils/listUtils.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { ZBookmarkList } from "../types/lists";
+import { listsToTree } from "./listUtils";
+
+function list(
+  id: string,
+  name: string,
+  parentId: string | null = null,
+): ZBookmarkList {
+  return {
+    id,
+    name,
+    description: null,
+    icon: "🚀",
+    parentId,
+    type: "manual",
+    query: null,
+    public: false,
+    hasCollaborators: false,
+    userRole: "owner",
+  };
+}
+
+const names = (paths: ZBookmarkList[][]) =>
+  paths.map((path) => path.map((l) => l.name).join("/"));
+
+describe("listsToTree", () => {
+  it("sorts the root lists by name", () => {
+    const { root } = listsToTree([
+      list("lc", "Cooking"),
+      list("la", "Articles"),
+      list("lb", "Books"),
+    ]);
+
+    expect(Object.values(root).map((node) => node.item.name)).toEqual([
+      "Articles",
+      "Books",
+      "Cooking",
+    ]);
+  });
+
+  it("sorts the children of a list by name", () => {
+    const { root } = listsToTree([
+      list("lr", "Reading"),
+      list("lz", "Zines", "lr"),
+      list("lb", "Blogs", "lr"),
+      list("lp", "Papers", "lr"),
+    ]);
+
+    expect(root.lr.children.map((node) => node.item.name)).toEqual([
+      "Blogs",
+      "Papers",
+      "Zines",
+    ]);
+  });
+
+  it("returns allPaths in the order of the sorted tree", () => {
+    const { allPaths } = listsToTree([
+      list("lc", "Cooking"),
+      list("la", "Articles"),
+      list("lr", "Recipes", "lc"),
+      list("ld", "Desserts", "lc"),
+      list("lb", "Blogs", "la"),
+    ]);
+
+    expect(names(allPaths)).toEqual([
+      "Articles",
+      "Articles/Blogs",
+      "Cooking",
+      "Cooking/Desserts",
+      "Cooking/Recipes",
+    ]);
+  });
+
+  it("returns the same order no matter how the input is ordered", () => {
+    const lists = [
+      list("la", "Articles"),
+      list("lc", "Cooking"),
+      list("lb", "Blogs", "la"),
+      list("lr", "Recipes", "lc"),
+    ];
+
+    const { allPaths } = listsToTree(lists);
+    const { allPaths: reversedAllPaths } = listsToTree([...lists].reverse());
+
+    expect(names(reversedAllPaths)).toEqual(names(allPaths));
+  });
+
+  it("doesn't reorder the passed in lists", () => {
+    const lists = [list("lc", "Cooking"), list("la", "Articles")];
+    listsToTree(lists);
+
+    expect(lists.map((l) => l.name)).toEqual(["Cooking", "Articles"]);
+  });
+
+  it("resolves paths by id", () => {
+    const { getPathById } = listsToTree([
+      list("lc", "Cooking"),
+      list("lr", "Recipes", "lc"),
+      list("ld", "Desserts", "lr"),
+    ]);
+
+    expect(getPathById("ld")?.map((l) => l.name)).toEqual([
+      "Cooking",
+      "Recipes",
+      "Desserts",
+    ]);
+    expect(getPathById("unknown")).toBeUndefined();
+  });
+});

--- a/packages/shared/utils/listUtils.ts
+++ b/packages/shared/utils/listUtils.ts
@@ -8,15 +8,23 @@ export interface ZBookmarkListTreeNode {
 export type ZBookmarkListRoot = Record<string, ZBookmarkListTreeNode>;
 
 export function listsToTree(lists: ZBookmarkList[]) {
-  const idToList = lists.reduce<Record<string, ZBookmarkList>>((acc, list) => {
-    acc[list.id] = list;
-    return acc;
-  }, {});
+  // Sort by name upfront so that the roots, the children of every node and
+  // allPaths all end up in the same order, no matter how the lists were
+  // ordered by the caller.
+  const sortedLists = [...lists].sort((a, b) => a.name.localeCompare(b.name));
+
+  const idToList = sortedLists.reduce<Record<string, ZBookmarkList>>(
+    (acc, list) => {
+      acc[list.id] = list;
+      return acc;
+    },
+    {},
+  );
 
   const root: ZBookmarkListRoot = {};
 
   // Prepare all refs
-  const refIdx = lists.reduce<Record<string, ZBookmarkListTreeNode>>(
+  const refIdx = sortedLists.reduce<Record<string, ZBookmarkListTreeNode>>(
     (acc, l) => {
       acc[l.id] = {
         item: l,
@@ -28,7 +36,7 @@ export function listsToTree(lists: ZBookmarkList[]) {
   );
 
   // Build the tree
-  lists.forEach((list) => {
+  sortedLists.forEach((list) => {
     const node = refIdx[list.id];
     if (list.parentId) {
       refIdx[list.parentId].children.push(node);


### PR DESCRIPTION
## Description

Fixes #1581

The lists in the sidebar are sorted by name, but the list picker dropdowns are not. A dropdown renders `allPaths` from `listsToTree`, and that helper keeps whatever order the API sent, which is roughly creation order with shared lists tacked on the end. So the same lists show up in two different orders depending on where you look.

`listsToTree` now sorts a copy of the lists by name once, before it builds the tree. The roots, the children of each node and `allPaths` then all come out in the same order, so the web dropdowns, the mobile app and the CLI list output all agree with the sidebar. It sorts with `localeCompare`, the same comparator the sidebar was already using. Nothing changes on the server or in the API, it all runs on data the client has already fetched.

One note: the two `.sort()` calls in `CollapsibleBookmarkLists` are now redundant. I left them alone to keep this to a single file.

## How Has This Been Tested?

- [x] Added `packages/shared/utils/listUtils.test.ts` covering root order, child order, `allPaths` order, order being stable no matter how the input is ordered, the input array not being mutated, and `getPathById`. Four of the six tests fail on `main` and all pass with this change. Run with `pnpm --filter @karakeep/shared exec vitest run utils/listUtils.test.ts`.
- [x] `pnpm --filter @karakeep/shared test` for the rest of the shared tests.
- [x] `pnpm preflight` (typecheck, lint, format check) via the pre-commit hook.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Sidebar and the open list picker showing the same order after the change.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used Claude Code to trace where the ordering diverged and to draft the change, the tests and this description, then reviewed the diff, ran the tests myself and checked the wording before pushing.
