### PR TITLE
fix(readme): fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ Karakeep is licensed under [AGPL-3.0](https://github.com/karakeep-app/karakeep/b
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=karakeep-app/karakeep&type=Date)](https://star-history.com/#karakeep-app/karakeep&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=karakeep-app/karakeep&type=Date)](https://star-history.dera.page/#karakeep-app/karakeep&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This updates the chart to use a working provider so the project's star history stays visible.