### PR TITLE
feat(mobile): take and upload photos in app

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -96,6 +96,8 @@ export default {
         {
           photosPermission:
             "The app access your photo gallary on your request to hoard them.",
+          cameraPermission:
+            "The app accesses your camera on your request to save photos.",
         },
       ],
       [

--- a/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(home)/index.tsx
@@ -50,16 +50,42 @@ function useNewBookmarkActions(openNewBookmarkModal: () => void) {
     Haptics.selectionAsync();
     if (nativeEvent.event === "new") {
       openNewBookmarkModal();
-    } else if (nativeEvent.event === "library") {
+    } else if (
+      nativeEvent.event === "library" ||
+      nativeEvent.event === "camera"
+    ) {
+      const isCamera = nativeEvent.event === "camera";
+      const sourceName = isCamera ? "camera" : "photo library";
       try {
         uploadToastIdRef.current = sonnerToast.loading(
-          "Opening photo library...",
+          `Opening ${sourceName}...`,
         );
-        const result = await ImagePicker.launchImageLibraryAsync({
-          mediaTypes: ["images"],
-          quality: settings.imageQuality,
-          allowsMultipleSelection: false,
-        });
+        if (isCamera) {
+          const permission = await ImagePicker.requestCameraPermissionsAsync();
+          if (!permission.granted) {
+            sonnerToast.error(
+              permission.canAskAgain
+                ? "Camera permission is required to take a photo."
+                : "Camera access is disabled. Enable it in your device settings.",
+              { id: uploadToastIdRef.current },
+            );
+            uploadToastIdRef.current = null;
+            return;
+          }
+        }
+        const result = await (isCamera
+          ? ImagePicker.launchCameraAsync({
+              mediaTypes: ["images"],
+              quality: settings.imageQuality,
+            })
+          : ImagePicker.launchImageLibraryAsync({
+              mediaTypes: ["images"],
+              quality: settings.imageQuality,
+              allowsMultipleSelection: false,
+              preferredAssetRepresentationMode:
+                ImagePicker.UIImagePickerPreferredAssetRepresentationMode
+                  .Compatible,
+            }));
         if (!result.canceled) {
           const asset = result.assets[0];
           if (!asset) {
@@ -81,12 +107,15 @@ function useNewBookmarkActions(openNewBookmarkModal: () => void) {
         }
       } catch {
         if (uploadToastIdRef.current !== null) {
-          sonnerToast.error("Failed to open photo library", {
-            id: uploadToastIdRef.current,
-          });
+          sonnerToast.error(
+            isCamera
+              ? "Unable to open camera. Check camera access and device availability."
+              : "Unable to open photo library.",
+            {
+              id: uploadToastIdRef.current,
+            },
+          );
           uploadToastIdRef.current = null;
-        } else {
-          sonnerToast.error("Failed to open photo library");
         }
       }
     } else if (nativeEvent.event === "clipboard") {
@@ -137,21 +166,27 @@ function useNewBookmarkActions(openNewBookmarkModal: () => void) {
 
   const actions = [
     {
-      id: "clipboard",
-      title: "Clipboard",
-      image: Platform.select({ ios: "clipboard" }),
-      imageColor: Platform.select({ ios: menuIconColor }),
-    },
-    {
       id: "new",
       title: "New Bookmark",
       image: Platform.select({ ios: "square.and.pencil" }),
       imageColor: Platform.select({ ios: menuIconColor }),
     },
     {
+      id: "clipboard",
+      title: "Clipboard",
+      image: Platform.select({ ios: "clipboard" }),
+      imageColor: Platform.select({ ios: menuIconColor }),
+    },
+    {
       id: "library",
       title: "Photo Library",
       image: Platform.select({ ios: "photo" }),
+      imageColor: Platform.select({ ios: menuIconColor }),
+    },
+    {
+      id: "camera",
+      title: "Camera",
+      image: Platform.select({ ios: "camera" }),
       imageColor: Platform.select({ ios: menuIconColor }),
     },
   ];


### PR DESCRIPTION
## feat(mobile): take and upload photos in app

<!--- Describe your changes in detail -->
Changes:
- Fourth option for "Camera" which requests native camera app for simple uploading (now organized for 4 items)
- HEIF and other formats are converted to compatible formats first (iOS only)

<!--- Why is this change required? What problem does it solve? -->
Why:
- Makes the goal of adding photos to Karakeep easier by skipping Camera app
- Ensures HEIF images are uploaded properly rather than fail silently

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2942 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Can take photos and upload to personal Karakeep instance
- [x] Uploading images from library works

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="200" alt="IMG_3909" src="https://github.com/user-attachments/assets/c5f09a7f-1f56-492e-8754-9ade6e0df2fb" />

https://github.com/user-attachments/assets/562486fa-aada-4a55-ab6d-6013431995aa


</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Codex was used to develop this code. Several iterations of testing and development were needed to ensure permission prompts were requested, and images were uploaded.
