### PR TITLE
fix(web): fallback OAuth display name to given_name/family_name

### DIFF
--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -23,6 +23,7 @@ import { getRateLimitClient } from "@karakeep/shared/ratelimiting";
 import {
   containsUnsafeUserNameMarkup,
   normalizeUserNameInput,
+  resolveOAuthDisplayName,
 } from "@karakeep/shared/utils/userName";
 import { logEvent } from "@karakeep/shared-server";
 import { validatePassword } from "@karakeep/trpc/auth";
@@ -192,9 +193,15 @@ if (oauth.wellKnownUrl) {
         isFirstUser(),
       ]);
 
+      const displayName = resolveOAuthDisplayName(
+        profile.name,
+        profile.given_name,
+        profile.family_name,
+      );
+
       return {
         id: profile.sub,
-        name: normalizeSafeDisplayName(profile.name),
+        name: normalizeSafeDisplayName(displayName),
         email: profile.email,
         role: admin || firstUser ? "admin" : "user",
       };

--- a/packages/shared/utils/userName.test.ts
+++ b/packages/shared/utils/userName.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  containsUnsafeUserNameMarkup,
+  normalizeUserNameInput,
+  resolveOAuthDisplayName,
+} from "./userName";
+
+describe("normalizeUserNameInput", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeUserNameInput("  Jane Doe  ")).toBe("Jane Doe");
+  });
+});
+
+describe("containsUnsafeUserNameMarkup", () => {
+  it("detects angle brackets", () => {
+    expect(containsUnsafeUserNameMarkup("<script>")).toBe(true);
+    expect(containsUnsafeUserNameMarkup("Jane Doe")).toBe(false);
+  });
+});
+
+describe("resolveOAuthDisplayName", () => {
+  it("prefers the full name when present", () => {
+    expect(resolveOAuthDisplayName("Jane Doe", "Jane", "Doe")).toBe("Jane Doe");
+  });
+
+  it("combines given and family names when the full name is missing", () => {
+    expect(resolveOAuthDisplayName(undefined, "Jane", "Doe")).toBe("Jane Doe");
+  });
+
+  it("falls back to the given name when the family name is missing", () => {
+    expect(resolveOAuthDisplayName(undefined, "Jane", undefined)).toBe("Jane");
+  });
+
+  it("falls back to the family name when the given name is missing", () => {
+    expect(resolveOAuthDisplayName(null, null, "Doe")).toBe("Doe");
+  });
+
+  it("ignores empty strings when combining names", () => {
+    expect(resolveOAuthDisplayName("", "Jane", "")).toBe("Jane");
+  });
+
+  it("ignores a whitespace-only full name and falls back to the components", () => {
+    expect(resolveOAuthDisplayName("   ", "Jane", "Doe")).toBe("Jane Doe");
+  });
+
+  it("trims surrounding whitespace in the components", () => {
+    expect(resolveOAuthDisplayName(undefined, "  Jane  ", "  Doe  ")).toBe(
+      "Jane Doe",
+    );
+  });
+
+  it("drops whitespace-only components", () => {
+    expect(resolveOAuthDisplayName(undefined, "   ", "Doe")).toBe("Doe");
+  });
+
+  it("returns undefined when no usable name is provided", () => {
+    expect(resolveOAuthDisplayName(undefined, undefined, undefined)).toBe(
+      undefined,
+    );
+    expect(resolveOAuthDisplayName("", "", "")).toBe(undefined);
+  });
+});

--- a/packages/shared/utils/userName.ts
+++ b/packages/shared/utils/userName.ts
@@ -5,3 +5,18 @@ export function normalizeUserNameInput(input: string): string {
 export function containsUnsafeUserNameMarkup(input: string): boolean {
   return /[<>]/.test(input);
 }
+
+export function resolveOAuthDisplayName(
+  name: string | null | undefined,
+  givenName: string | null | undefined,
+  familyName: string | null | undefined,
+): string | undefined {
+  return (
+    name?.trim() ||
+    [givenName, familyName]
+      .map((part) => part?.trim())
+      .filter(Boolean)
+      .join(" ") ||
+    undefined
+  );
+}


### PR DESCRIPTION
## Description

Some OIDC providers do not emit the `name` claim — only `given_name` and
`family_name` (e.g. Rauthy and other self-hosted IdPs). When signing in through
such a provider, the account was created with the fallback display name "User",
and there is no way to edit the name afterwards, neither in the UI nor via the
admin API (`updateUserSchema` does not expose `name`).

This change adds a `resolveOAuthDisplayName` helper to
`packages/shared/utils/userName.ts` that falls back to `given_name + family_name`
when `name` is missing or empty, and uses it in the OAuth `profile` callback.

Fixes # N/A (no linked issue)

## How Has This Been Tested?

- [x] Added unit tests in `packages/shared/utils/userName.test.ts` covering the
      fallback behavior (full name, given + family, single name, empty strings,
      and no name at all). `pnpm --filter @karakeep/shared test` passes — 8 new
      tests.
- [x] Reproduced the issue on a self-hosted instance using Rauthy as the OIDC
      provider: the first sign-in persisted the account with display name "User".

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — backend-only change.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Drafted with AI assistance; reviewed and verified by the contributor.
