### PR TITLE
fix(workers): use YouTube uploader for bookmark authors

### DIFF
--- a/apps/workers/workers/crawler/crawlAndParse.ts
+++ b/apps/workers/workers/crawler/crawlAndParse.ts
@@ -52,6 +52,7 @@ import {
 import { crawlPage } from "./crawlPage";
 import { runParseSubprocess } from "./parseSubprocess";
 import { redactUrlCredentials, shouldRetryCrawlStatusCode } from "./utils";
+import { fetchYouTubeAuthor } from "./youtubeMetadata";
 
 const tracer = getTracer("@karakeep/workers");
 
@@ -212,6 +213,11 @@ export async function crawlAndParseUrl(
       },
     },
     async () => {
+      const youtubeAuthorPromise = fetchYouTubeAuthor(
+        url,
+        abortSignal,
+        runProxy,
+      );
       let result: {
         htmlContent: string;
         screenshot: Buffer | undefined;
@@ -289,7 +295,10 @@ export async function crawlAndParseUrl(
       // The probe metadata extraction has been running alongside the crawl;
       // this is the point where it's needed. The promise never rejects and
       // all its underlying work is time-bounded.
-      const probeMetadata = await probeMetadataPromise;
+      const [probeMetadata, youtubeAuthor] = await Promise.all([
+        probeMetadataPromise,
+        youtubeAuthorPromise,
+      ]);
       abortSignal.throwIfAborted();
 
       // On the last retry attempt the crawl proceeds despite a blocked status
@@ -310,7 +319,14 @@ export async function crawlAndParseUrl(
           `[Crawler][${jobId}] The rendered page looks blocked (status ${statusCode}); preferring preflight probe metadata.`,
         );
       }
-      const meta = resolveMetadata(renderMeta, probeMetadata, renderBlocked);
+      const resolvedMeta = resolveMetadata(
+        renderMeta,
+        probeMetadata,
+        renderBlocked,
+      );
+      const meta = youtubeAuthor
+        ? { ...resolvedMeta, author: youtubeAuthor }
+        : resolvedMeta;
       const readerViewReasons: ZReaderViewReason[] | null = readerViewAssessment
         ? renderIsChallengePage &&
           !readerViewAssessment.reasons.includes("challenge_page")

--- a/apps/workers/workers/crawler/youtubeMetadata.test.ts
+++ b/apps/workers/workers/crawler/youtubeMetadata.test.ts
@@ -1,0 +1,53 @@
+import { fetchWithProxy } from "network";
+import { Response } from "node-fetch";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("network", () => ({
+  fetchWithProxy: vi.fn(),
+}));
+
+import { fetchYouTubeAuthor } from "./youtubeMetadata";
+
+const runProxy = {
+  httpProxy: undefined,
+  httpsProxy: undefined,
+  noProxy: undefined,
+};
+
+describe("fetchYouTubeAuthor", () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithProxy).mockReset();
+  });
+
+  it("gets the video uploader from YouTube oEmbed", async () => {
+    vi.mocked(fetchWithProxy).mockResolvedValue(
+      new Response(JSON.stringify({ author_name: "Actual uploader" }), {
+        status: 200,
+      }),
+    );
+
+    await expect(
+      fetchYouTubeAuthor(
+        "https://www.youtube.com/watch?v=video-id",
+        AbortSignal.timeout(1_000),
+        runProxy,
+      ),
+    ).resolves.toBe("Actual uploader");
+    expect(fetchWithProxy).toHaveBeenCalledWith(
+      "https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dvideo-id&format=json",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      runProxy,
+    );
+  });
+
+  it("does not request metadata for non-YouTube URLs", async () => {
+    await expect(
+      fetchYouTubeAuthor(
+        "https://example.com/watch?v=video-id",
+        AbortSignal.timeout(1_000),
+        runProxy,
+      ),
+    ).resolves.toBeNull();
+    expect(fetchWithProxy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/workers/workers/crawler/youtubeMetadata.ts
+++ b/apps/workers/workers/crawler/youtubeMetadata.ts
@@ -1,0 +1,45 @@
+import { fetchWithProxy } from "network";
+import type { RunProxyConfig } from "network";
+
+export async function fetchYouTubeAuthor(
+  url: string,
+  abortSignal: AbortSignal,
+  runProxy: RunProxyConfig,
+): Promise<string | null> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+  if (
+    parsedUrl.hostname !== "youtube.com" &&
+    !parsedUrl.hostname.endsWith(".youtube.com") &&
+    parsedUrl.hostname !== "youtu.be"
+  ) {
+    return null;
+  }
+
+  const endpoint = new URL("https://www.youtube.com/oembed");
+  endpoint.searchParams.set("url", parsedUrl.toString());
+  endpoint.searchParams.set("format", "json");
+
+  try {
+    const response = await fetchWithProxy(
+      endpoint.toString(),
+      {
+        signal: AbortSignal.any([AbortSignal.timeout(5_000), abortSignal]),
+      },
+      runProxy,
+    );
+    if (!response.ok) {
+      return null;
+    }
+    const data = (await response.json()) as { author_name?: unknown };
+    return typeof data.author_name === "string"
+      ? data.author_name.trim() || null
+      : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

YouTube author extraction currently trusts the supplied or rendered HTML, which can associate a bookmark with a commenter or an unrelated channel. Resolve the uploader from YouTube oEmbed and retain the scraped author as a fallback when that lookup is unavailable.

### User impact

YouTube bookmarks consistently show the video's uploader as their author, including precrawled and intermittently misparsed pages.

Fixes #2205

## How Has This Been Tested?

- `pnpm --filter @karakeep/workers run test` — 29 tests passed
- `pnpm --filter @karakeep/workers run typecheck` — passed
- `pnpm --filter @karakeep/workers run lint` — passed with 0 warnings and 0 errors
- `pnpm --filter @karakeep/workers run format` — passed
- `pnpm --filter @karakeep/workers run build` — passed; retained the existing optional `@node-rs/xxhash` warning
- Live lookup for a video reported in #2205 returned the expected uploader, `StezStix Fix?`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable; this changes crawler metadata resolution.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

OpenAI Codex assisted with codebase analysis, regression-test drafting, implementation, and diff review. The checks above were run locally.