### PR TITLE
fix: is:inlist search filter ignores smart list membership

### DIFF
--- a/packages/trpc/lib/__tests__/search.test.ts
+++ b/packages/trpc/lib/__tests__/search.test.ts
@@ -542,6 +542,32 @@ describe("getBookmarkIdsFromMatcher", () => {
     expect(result).toEqual(["b3"]);
   });
 
+  it("should count smart list membership as being in a list", async () => {
+    // b3 is archived and matches no manual list. A smart list querying
+    // "is:archived" also matches it (along with the already-listed b2/b6),
+    // so is:inlist should now include it and -is:inlist should not.
+    await mockCtx.db.insert(bookmarkLists).values({
+      id: "l6",
+      userId: testUserId,
+      name: "archived smart list",
+      icon: "🗄️",
+      type: "smart",
+      query: "is:archived",
+    });
+
+    const inList = await getBookmarkIdsFromMatcher(mockCtx, {
+      type: "inlist",
+      inList: true,
+    });
+    expect(inList.sort()).toEqual(["b1", "b2", "b3", "b4", "b5", "b6"]);
+
+    const notInList = await getBookmarkIdsFromMatcher(mockCtx, {
+      type: "inlist",
+      inList: false,
+    });
+    expect(notInList).toEqual([]);
+  });
+
   it("should handle rssFeedName matcher", async () => {
     const matcher: Matcher = {
       type: "rssFeedName",

--- a/packages/trpc/lib/search.ts
+++ b/packages/trpc/lib/search.ts
@@ -196,19 +196,56 @@ async function getIds(
         );
     }
     case "inlist": {
-      const comp = matcher.inList ? exists : notExists;
+      // A bookmark counts as "in a list" if it's a member of a manual
+      // list, or if it matches one of the user's smart list queries. The
+      // join table only tracks manual membership, so smart lists have to
+      // be resolved separately, the same way case "listName" resolves them.
+      const { List } = await import("../models/lists");
+
+      const [manualRows, smartLists] = await Promise.all([
+        db
+          .selectDistinct({ id: bookmarksInLists.bookmarkId })
+          .from(bookmarksInLists)
+          .innerJoin(bookmarks, eq(bookmarks.id, bookmarksInLists.bookmarkId))
+          .where(eq(bookmarks.userId, userId)),
+        db.query.bookmarkLists.findMany({
+          where: and(
+            eq(bookmarkLists.userId, userId),
+            eq(bookmarkLists.type, "smart"),
+          ),
+        }),
+      ]);
+
+      const inListBookmarkIds = new Set(manualRows.map((r) => r.id));
+      const smartListBookmarkIds = await Promise.all(
+        smartLists.map(async (list) => {
+          const listModel = await List.fromId(ctx, list.id);
+          return listModel.getBookmarkIds(visitedListIds);
+        }),
+      );
+      for (const ids of smartListBookmarkIds) {
+        ids.forEach((id) => inListBookmarkIds.add(id));
+      }
+
+      if (inListBookmarkIds.size === 0) {
+        if (matcher.inList) {
+          return [];
+        }
+        return db
+          .selectDistinct({ id: bookmarks.id })
+          .from(bookmarks)
+          .where(eq(bookmarks.userId, userId));
+      }
+
       return db
-        .select({ id: bookmarks.id })
+        .selectDistinct({ id: bookmarks.id })
         .from(bookmarks)
         .where(
           and(
             eq(bookmarks.userId, userId),
-            comp(
-              db
-                .select()
-                .from(bookmarksInLists)
-                .where(and(eq(bookmarksInLists.bookmarkId, bookmarks.id))),
-            ),
+            matcher.inList
+              ? inArray(bookmarks.id, [...inListBookmarkIds])
+              : notInArray(bookmarks.id, [...inListBookmarkIds]),
           ),
         );
     }


### PR DESCRIPTION
## Description

`is:inlist` / `-is:inlist` only checked the `bookmarksInLists` join table, which records manual list membership. Smart lists have no rows there, their membership is computed by re-running the smart list's own query, so a bookmark that only matched a smart list was treated as being in no list at all.

`list:<name>` already resolves membership correctly through the List model (see the comment above that case). This makes `is:inlist` do the same thing for "does this bookmark belong to any list", instead of only checking the join table.

Fixes #3031

## How Has This Been Tested?

- [x] Added a regression test in packages/trpc/lib/__tests__/search.test.ts covering a bookmark that only matches a smart list
- [ ] Manual verification against a running instance

I traced the fix and the test by hand against the source, and confirmed the fix mirrors the existing `list:<name>` handling in the same function. I was not able to run the trpc suite locally: it crashes in my environment with a better-sqlite3 native addon assertion during Node teardown, and the same crash reproduces on unmodified `main`, so it is a pre-existing toolchain issue unrelated to this change. I am relying on CI for the authoritative test run.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantial, and disclosed. I run an automated static analysis and triage pipeline that surfaced this bug and drafted the fix and the regression test. I reviewed the diff, traced the root cause against the source myself, and confirmed it mirrors the existing list:<name> handling.
