### PR TITLE
fix(mobile): sort lists by name, as the web does

### DIFF
--- a/apps/mobile/app/dashboard/(tabs)/(lists)/index.tsx
+++ b/apps/mobile/app/dashboard/(tabs)/(lists)/index.tsx
@@ -34,6 +34,10 @@ interface ListLink {
   numBookmarks?: number;
 }
 
+function byName(a: ZBookmarkListTreeNode, b: ZBookmarkListTreeNode) {
+  return a.item.name.localeCompare(b.item.name);
+}
+
 function traverseTree(
   node: ZBookmarkListTreeNode,
   links: ListLink[],
@@ -55,16 +59,18 @@ function traverseTree(
   });
 
   if (node.children && showChildrenOf[node.item.id]) {
-    node.children.forEach((child) =>
-      traverseTree(
-        child,
-        links,
-        showChildrenOf,
-        listStats,
-        node.item.id,
-        level + 1,
-      ),
-    );
+    [...node.children]
+      .sort(byName)
+      .forEach((child) =>
+        traverseTree(
+          child,
+          links,
+          showChildrenOf,
+          listStats,
+          node.item.id,
+          level + 1,
+        ),
+      );
   }
 }
 
@@ -149,27 +155,31 @@ export default function Lists() {
 
     // Add shared lists as children if section is expanded
     if (showChildrenOf["shared-section"]) {
-      Object.values(lists.root).forEach((list) => {
-        if (list.item.userRole !== "owner") {
-          traverseTree(
-            list,
-            links,
-            showChildrenOf,
-            listStats?.stats,
-            "shared-section",
-            1,
-          );
-        }
-      });
+      Object.values(lists.root)
+        .sort(byName)
+        .forEach((list) => {
+          if (list.item.userRole !== "owner") {
+            traverseTree(
+              list,
+              links,
+              showChildrenOf,
+              listStats?.stats,
+              "shared-section",
+              1,
+            );
+          }
+        });
     }
   }
 
   // Add owned lists only
-  Object.values(lists.root).forEach((list) => {
-    if (list.item.userRole === "owner") {
-      traverseTree(list, links, showChildrenOf, listStats?.stats);
-    }
-  });
+  Object.values(lists.root)
+    .sort(byName)
+    .forEach((list) => {
+      if (list.item.userRole === "owner") {
+        traverseTree(list, links, showChildrenOf, listStats?.stats);
+      }
+    });
 
   return (
     <>


### PR DESCRIPTION
## Description

Fixes #2997

The mobile lists screen builds its rows from `Object.values(lists.root)` and `node.children` without sorting, so the order is whatever `listsToTree` happened to produce from the API response. That is why it looks arbitrary and does not match the web.

The web renders the same tree through `CollapsibleBookmarkLists`, which sorts both the root nodes and each node's children with `a.item.name.localeCompare(b.item.name)`. This applies the same comparator at the same two levels on mobile, so the two clients agree, which is what the issue asks for.

`node.children` is copied before sorting rather than sorted in place, since it belongs to the cached query data.

## How Has This Been Tested?

- [x] `tsc --noEmit` in `apps/mobile` is clean
- [x] `oxlint`: 0 warnings, 0 errors
- [x] `oxfmt --check`: clean

I could not run the Expo app on this machine, so I have not attached a screenshot. The change is confined to the ordering of the rows the screen already builds.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted with locating the two unsorted call sites and the matching web comparator. The change and the wording are mine, and I ran the typecheck, linter and formatter locally.