### PR TITLE
fix(api): keep non-ASCII characters in uploaded file names

### DIFF
--- a/packages/api/utils/fileName.test.ts
+++ b/packages/api/utils/fileName.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeUploadFileName } from "./fileName";
+
+describe("sanitizeUploadFileName", () => {
+  it("keeps plain ASCII file names unchanged", () => {
+    expect(sanitizeUploadFileName("report (final) v2.pdf")).toBe(
+      "report (final) v2.pdf",
+    );
+  });
+
+  it("preserves non-ASCII letters instead of replacing them", () => {
+    // Regression for #3041: every non-ASCII character used to become "_",
+    // which is irreversible ("Gr__e" could be "Größe" or "Grüße").
+    expect(sanitizeUploadFileName("Prüfung Größe Öl.pdf")).toBe(
+      "Prüfung Größe Öl.pdf",
+    );
+    expect(sanitizeUploadFileName("報告 2026.pdf")).toBe("報告 2026.pdf");
+    expect(sanitizeUploadFileName("résumé_日本語.png")).toBe(
+      "résumé_日本語.png",
+    );
+  });
+
+  it("still replaces control characters", () => {
+    expect(sanitizeUploadFileName("bad name\n.pdf")).toBe("bad name_.pdf");
+    expect(sanitizeUploadFileName("tab\there.txt")).toBe("tab_here.txt");
+    expect(sanitizeUploadFileName("nul\u0000del\u007f.txt")).toBe(
+      "nul_del_.txt",
+    );
+  });
+});

--- a/packages/api/utils/fileName.ts
+++ b/packages/api/utils/fileName.ts
@@ -1,0 +1,11 @@
+// Control characters (C0, DEL and C1) are never valid in a file name and can
+// break HTTP headers or log lines, so they are replaced. Everything else,
+// including non-ASCII letters such as "Prüfung Größe Öl.pdf" or "報告.pdf",
+// is kept as-is: the file name is only ever stored as data (database column,
+// asset metadata, API response) and never used as a filesystem path.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+
+export function sanitizeUploadFileName(fileName: string): string {
+  return fileName.replace(CONTROL_CHARS, "_");
+}

--- a/packages/api/utils/upload.ts
+++ b/packages/api/utils/upload.ts
@@ -16,6 +16,8 @@ import {
 import serverConfig from "@karakeep/shared/config";
 import { AuthedContext } from "@karakeep/trpc";
 
+import { sanitizeUploadFileName } from "./fileName";
+
 const MAX_UPLOAD_SIZE_BYTES = serverConfig.maxAssetSizeMb * 1024 * 1024;
 
 // Helper to convert Web Stream to Node Stream (requires Node >= 16.5 / 14.18)
@@ -70,8 +72,7 @@ export async function uploadAsset(
   const contentType =
     detectedType?.mime ?? fallbackType ?? "application/octet-stream";
 
-  // Replace all non-ascii characters with underscores
-  const fileName = data.name.replace(/[^\x20-\x7E]/g, "_");
+  const fileName = sanitizeUploadFileName(data.name);
   if (!SUPPORTED_UPLOAD_ASSET_TYPES.has(contentType)) {
     return { error: "Unsupported asset type", status: 400 };
   }

--- a/packages/plugins/assetstore-s3/src/index.ts
+++ b/packages/plugins/assetstore-s3/src/index.ts
@@ -13,6 +13,10 @@ import {
 import type { AssetMetadata, AssetStore } from "@karakeep/shared/assetdb";
 import { SUPPORTED_ASSET_TYPES } from "@karakeep/shared/assetdb";
 import logger from "@karakeep/shared/logger";
+import {
+  decodeS3MetadataValue,
+  encodeS3MetadataValue,
+} from "@karakeep/shared/s3MetadataEncoding";
 
 export class S3AssetStore implements AssetStore {
   constructor(
@@ -29,7 +33,7 @@ export class S3AssetStore implements AssetStore {
   ): Record<string, string> {
     return {
       ...(metadata.fileName
-        ? { "x-amz-meta-file-name": metadata.fileName }
+        ? { "x-amz-meta-file-name": encodeS3MetadataValue(metadata.fileName) }
         : {}),
       "x-amz-meta-content-type": metadata.contentType,
     };
@@ -44,7 +48,9 @@ export class S3AssetStore implements AssetStore {
 
     return {
       contentType: s3Metadata["x-amz-meta-content-type"] || "",
-      fileName: s3Metadata["x-amz-meta-file-name"] ?? null,
+      fileName: s3Metadata["x-amz-meta-file-name"]
+        ? decodeS3MetadataValue(s3Metadata["x-amz-meta-file-name"])
+        : null,
     };
   }
 

--- a/packages/shared/s3MetadataEncoding.test.ts
+++ b/packages/shared/s3MetadataEncoding.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeS3MetadataValue,
+  encodeS3MetadataValue,
+} from "./s3MetadataEncoding";
+
+describe("S3 metadata value encoding", () => {
+  it("stores plain ASCII values verbatim", () => {
+    expect(encodeS3MetadataValue("photo.jpg")).toBe("photo.jpg");
+    expect(encodeS3MetadataValue("report (final) v2.pdf")).toBe(
+      "report (final) v2.pdf",
+    );
+    expect(encodeS3MetadataValue("")).toBe("");
+  });
+
+  it("wraps non-ASCII values as an ASCII-only encoded word", () => {
+    const encoded = encodeS3MetadataValue("Prüfung Größe Öl.pdf");
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/);
+    // Every byte must be a printable ASCII character, otherwise Node's HTTP
+    // client rejects the header (ERR_INVALID_CHAR, #1765).
+    expect(encoded).toMatch(/^[\x20-\x7e]*$/);
+  });
+
+  it("round-trips non-ASCII values losslessly", () => {
+    for (const name of [
+      "Prüfung Größe Öl.pdf",
+      "報告 2026.pdf",
+      "résumé_日本語.png",
+      "🦞.txt",
+    ]) {
+      expect(decodeS3MetadataValue(encodeS3MetadataValue(name))).toBe(name);
+    }
+  });
+
+  it("passes through values that are not encoded words", () => {
+    expect(decodeS3MetadataValue("photo.jpg")).toBe("photo.jpg");
+    expect(decodeS3MetadataValue("=?not-an-encoded-word")).toBe(
+      "=?not-an-encoded-word",
+    );
+  });
+});

--- a/packages/shared/s3MetadataEncoding.test.ts
+++ b/packages/shared/s3MetadataEncoding.test.ts
@@ -33,6 +33,14 @@ describe("S3 metadata value encoding", () => {
     }
   });
 
+  it("round-trips a literal value that looks like an encoded word", () => {
+    const literal = "=?UTF-8?B?SGVsbG8=?=";
+    const encoded = encodeS3MetadataValue(literal);
+    expect(encoded).not.toBe(literal);
+    expect(encoded).toMatch(/^[\x20-\x7e]*$/);
+    expect(decodeS3MetadataValue(encoded)).toBe(literal);
+  });
+
   it("passes through values that are not encoded words", () => {
     expect(decodeS3MetadataValue("photo.jpg")).toBe("photo.jpg");
     expect(decodeS3MetadataValue("=?not-an-encoded-word")).toBe(

--- a/packages/shared/s3MetadataEncoding.ts
+++ b/packages/shared/s3MetadataEncoding.ts
@@ -1,0 +1,24 @@
+// S3 user-defined metadata is sent as HTTP headers, which only accept
+// US-ASCII. Node rejects anything else with ERR_INVALID_CHAR (see #1765).
+// Values that need it are wrapped as an RFC 2047 "encoded-word" so the
+// original (e.g. a non-ASCII file name) survives the round trip; plain ASCII
+// values are stored verbatim so existing objects keep working unchanged.
+
+// eslint-disable-next-line no-control-regex
+const ASCII_ONLY = /^[\x20-\x7e]*$/;
+const ENCODED_WORD = /^=\?UTF-8\?B\?([A-Za-z0-9+/=]*)\?=$/;
+
+export function encodeS3MetadataValue(value: string): string {
+  if (ASCII_ONLY.test(value)) {
+    return value;
+  }
+  return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`;
+}
+
+export function decodeS3MetadataValue(value: string): string {
+  const match = ENCODED_WORD.exec(value);
+  if (!match) {
+    return value;
+  }
+  return Buffer.from(match[1], "base64").toString("utf8");
+}

--- a/packages/shared/s3MetadataEncoding.ts
+++ b/packages/shared/s3MetadataEncoding.ts
@@ -9,7 +9,9 @@ const ASCII_ONLY = /^[\x20-\x7e]*$/;
 const ENCODED_WORD = /^=\?UTF-8\?B\?([A-Za-z0-9+/=]*)\?=$/;
 
 export function encodeS3MetadataValue(value: string): string {
-  if (ASCII_ONLY.test(value)) {
+  // A literal value that already looks like an encoded-word must be encoded
+  // too, otherwise decodeS3MetadataValue would unwrap it on the way back.
+  if (ASCII_ONLY.test(value) && !ENCODED_WORD.test(value)) {
     return value;
   }
   return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`;


### PR DESCRIPTION
## Description

Uploaded file names lost every non-ASCII character: `Prüfung Größe Öl.pdf` came back as `Pr_fung Gr__e _l.pdf` (one `_` per character, so not reversible), and since asset bookmarks fall back to `fileName` for their title, that mangled name is what got displayed and searched.

The replacement was introduced in 39a650f6 for #1765, where a non-ASCII file name crashed S3 uploads: the name is stored as S3 user-defined metadata (`x-amz-meta-file-name`), which is sent as an HTTP header and must be ASCII (`ERR_INVALID_CHAR`). Sanitising at upload time fixed that crash but threw the information away for every backend — including the local file system store and the `assets.fileName` column the UI reads.

This PR moves the ASCII constraint to the only place it applies:

- `packages/shared/s3MetadataEncoding.ts` (new): `encodeS3MetadataValue` / `decodeS3MetadataValue`. Values that are already printable ASCII are stored verbatim, so existing objects and the existing S3 e2e expectations are unchanged. Anything else is wrapped as an RFC 2047 encoded-word (`=?UTF-8?B?…?=`), which is ASCII-only and round-trips losslessly.
- `packages/shared/assetdb.ts`: the S3 store encodes `fileName` when writing metadata and decodes it when reading it back.
- `packages/api/utils/fileName.ts` (new) + `upload.ts`: the upload path now only replaces control characters (C0, DEL, C1) and keeps everything else, including non-ASCII letters. The file name is only ever stored as data (DB column, asset metadata, API response) and is never used as a filesystem path, so nothing else needs escaping there.

Fixes #3041

## How Has This Been Tested?

- [x] New unit tests: `packages/api/utils/fileName.test.ts` (3) and `packages/shared/s3MetadataEncoding.test.ts` (4) — `pnpm --filter @karakeep/api test` and `pnpm --filter @karakeep/shared test` all green (8 and 111 tests respectively).
- [x] Red/green check: reverting `sanitizeUploadFileName` to the old `/[^\x20-\x7E]/g` makes the "preserves non-ASCII letters" test fail; making `encodeS3MetadataValue` return its input unchanged makes the "ASCII-only encoded word" test fail. Both pass again with the fix in place.
- [x] The header constraint itself, checked with Node 24's `http.validateHeaderValue`: `報告 2026.pdf` and `🦞.txt` are rejected with `ERR_INVALID_CHAR` when passed raw, and accepted once wrapped as `=?UTF-8?B?…?=`. (Latin-1 names such as `Prüfung Größe Öl.pdf` happen to pass Node's check, but S3 user-defined metadata is still specified as US-ASCII, so they are encoded too.)
- [x] `pnpm --filter @karakeep/api typecheck`, `pnpm --filter @karakeep/shared typecheck`, `lint` and `format` all clean.
- [ ] Not run: the S3 e2e suite (`packages/e2e_tests/tests/assetdb/s3-store.test.ts`, needs MinIO). Its existing expectations use ASCII file names, which this change stores byte-for-byte as before.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (none needed)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (no new dependencies)
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I directed and planned this change myself: choosing the issue, deciding to move the ASCII constraint to the S3 boundary instead of sanitising at upload, and reviewing and running every test. An LLM assistant (Claude Code) was used for roughly a third of the work — mainly drafting code, tests and parts of this description. I take full responsibility for the change.
