### PR TITLE
fix(mobile): render markdown list bullets and numbers in the foreground color

### DIFF
--- a/apps/mobile/components/bookmarks/BookmarkTextMarkdown.tsx
+++ b/apps/mobile/components/bookmarks/BookmarkTextMarkdown.tsx
@@ -5,17 +5,23 @@ export default function BookmarkTextMarkdown({ text }: { text: string }) {
   return (
     <TailwindResolver
       className="text-foreground"
-      comp={(styles) => (
-        <Markdown
-          style={{
-            text: {
-              color: styles?.color?.toString(),
-            },
-          }}
-        >
-          {text}
-        </Markdown>
-      )}
+      comp={(styles) => {
+        const color = styles?.color?.toString();
+        return (
+          <Markdown
+            style={{
+              text: { color },
+              // List bullets and numbers are rendered with these pseudo-class
+              // styles and don't inherit from `text`, so they'd otherwise fall
+              // back to the default black and be invisible in dark mode.
+              bullet_list_icon: { color },
+              ordered_list_icon: { color },
+            }}
+          >
+            {text}
+          </Markdown>
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
## Description

In dark mode, markdown notes on mobile render list bullets and numbers in black on a near-black background, so they look like they're missing (the text itself is white).

`BookmarkTextMarkdown` only passes the theme foreground color to the `text` style of `react-native-markdown-display`. The library renders list markers through the `bullet_list_icon` / `ordered_list_icon` pseudo-class styles (`renderRules.js` `list_item` rule), and those don't inherit from `text`, so the markers fall back to the default black. This PR applies the same resolved foreground color to those two keys.

I deliberately didn't switch to `body: { color }` (the approach the library README suggests): `body` cascades into `code_inline` / `code_block` / `fence`, which keep the library's default light `#f5f5f5` background, so that would turn inline code into white-on-light-grey in dark mode. Scoping the change to the two marker keys only affects the bullets/numbers.

Not included: the issue also suggests making bullets slightly larger. That's a visual preference call, so I left it out — happy to add a `fontSize` on `bullet_list_icon` if you'd like it in this PR.

Fixes #2367

## How Has This Been Tested?

- [x] `pnpm typecheck`, `pnpm lint` and `pnpm format` in `apps/mobile` pass
- [x] `apps/mobile` has no test suite, so I verified the behavior with a Node render probe plus `tsc`: rendered the real `react-native-markdown-display@7.0.2` with react-native primitives stubbed. With only `text: { color }` the bullet/number `<Text>` has no `color`; with this change they get the same color as the text
- [ ] Not verified on a device/simulator (I don't have the Expo build set up); the render path is a pure style merge so I'd expect it to match

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No simulator available; verified with a Node render probe: `bullet_list_icon` / `ordered_list_icon` now receive the theme color.

```
BEFORE: bullet color: undefined              | number color: undefined              | text color: rgb(255, 255, 255)
AFTER:  bullet color: rgb(255, 255, 255)     | number color: rgb(255, 255, 255)     | text color: rgb(255, 255, 255)
```

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM helped trace the library's render rules and draft the change and this description; I decided on the fix, reviewed the diff and ran the checks myself, and take responsibility for the change.
