### PR TITLE
fix(web): Add scheme-aware theme-color for dark mode

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -55,8 +55,10 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  // Matches the `--background` token in tooling/tailwind/globals.css so that
-  // browser and installed-web-app chrome follows the active theme.
+  // Values match the `--background` token in tooling/tailwind/globals.css.
+  // These follow the OS color scheme only. An in-app theme override via
+  // next-themes is not reflected here, so chrome can differ from the page
+  // when a user picks a theme opposite to their system preference.
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#ffffff" },
     { media: "(prefers-color-scheme: dark)", color: "#020817" },

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -55,6 +55,12 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  // Matches the `--background` token in tooling/tailwind/globals.css so that
+  // browser and installed-web-app chrome follows the active theme.
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#020817" },
+  ],
 };
 
 export default async function RootLayout({


### PR DESCRIPTION
Fixes #3029

## What

The web app declares no `theme-color` at all — `grep` finds no `themeColor` or `theme-color` anywhere — and `apps/web/app/manifest.ts` carries a single light value:

```ts
background_color: "#ffffff",
theme_color: "#ffffff",
```

Browser and installed-web-app chrome is painted from that, so on macOS (Safari → *Add to Dock*) the title bar stays white while the UI is in dark mode.

This adds `themeColor` to the **existing** `viewport` export in `apps/web/app/layout.tsx` with light and dark variants, so the chrome follows the active scheme. It mirrors the `prefers-color-scheme` pattern already used for the icons in `metadata` just above it.

## On the dark value

The issue suggested `#0f172a`. I used **`#020817`** instead, which is the hex form of this project's own `--background` token for `.dark` in `tooling/tailwind/globals.css`:

```css
.dark {
  --background: 222.2 84% 4.9%;   /* -> #020817 */
}
```

`hsl(222.2 84% 4.9%)` converts to `#020817`, so the title bar matches the actual app background exactly rather than approximating it with `slate-900`. The light value `#ffffff` is likewise the `:root` `--background` (`0 0% 100%`).

## Scope

- `manifest.ts` is left unchanged — the manifest's `theme_color` accepts only a single value, so the scheme-aware `<meta>` tags are the right mechanism here.
- Next.js 16 `Viewport.themeColor` accepts an array of `{ media, color }` descriptors, which is what generates the two tags.
- These entries follow the **OS** color scheme. An in-app override via next-themes is not reflected here; that is addressed in the follow-up, #3052.

## Verification

Ran against this branch (`c17504f`) on a clean checkout, Node 22.23.2 / pnpm 11.2.1:

| Check | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | passes |
| `pnpm --filter @karakeep/web typecheck` | **passes** — `tsc --noEmit`, exit 0 |
| `pnpm --filter @karakeep/web lint` | **passes** — oxlint, 0 warnings / 0 errors across 328 files |

To be precise about the limits: this confirms the change compiles and conforms to the repo's style. It does not confirm the chrome renders as intended — that check is manual, on a real macOS installed web app, which is the scenario #3029 reports and which I have not been able to run. A maintainer sanity-check there would be worthwhile.
