### PR TITLE
feat(web): Sync theme-color with the in-app theme

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -55,8 +55,10 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  // Matches the `--background` token in tooling/tailwind/globals.css so that
-  // browser and installed-web-app chrome follows the active theme.
+  // Values match the `--background` token in tooling/tailwind/globals.css.
+  // These follow the OS color scheme only. An in-app theme override via
+  // next-themes is not reflected here, so chrome can differ from the page
+  // when a user picks a theme opposite to their system preference.
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#ffffff" },
     { media: "(prefers-color-scheme: dark)", color: "#020817" },

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import "@karakeep/tailwind-config/globals.css";
 import type { Viewport } from "next";
 import React from "react";
 import Providers from "@/lib/providers";
+import { THEME_COLORS } from "@/lib/themeColors";
 import { getUserLocalSettings } from "@/lib/userLocalSettings/userLocalSettings";
 import { getServerAuthSession } from "@/server/auth";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
@@ -56,12 +57,11 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   // Values match the `--background` token in tooling/tailwind/globals.css.
-  // These follow the OS color scheme only. An in-app theme override via
-  // next-themes is not reflected here, so chrome can differ from the page
-  // when a user picks a theme opposite to their system preference.
+  // These cover the pre-hydration and no-JavaScript cases; once mounted,
+  // <ThemeColorSync /> updates them to follow an in-app theme override.
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#020817" },
+    { media: "(prefers-color-scheme: light)", color: THEME_COLORS.light },
+    { media: "(prefers-color-scheme: dark)", color: THEME_COLORS.dark },
   ],
 };
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -55,6 +55,12 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  // Matches the `--background` token in tooling/tailwind/globals.css so that
+  // browser and installed-web-app chrome follows the active theme.
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#020817" },
+  ],
 };
 
 export default async function RootLayout({

--- a/apps/web/components/theme-color-sync.tsx
+++ b/apps/web/components/theme-color-sync.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { THEME_COLORS } from "@/lib/themeColors";
+import { useTheme } from "next-themes";
+
+/**
+ * Keeps the `theme-color` meta tags in sync with the theme the app is actually
+ * rendering.
+ *
+ * The static entries in `viewport.themeColor` use `prefers-color-scheme`, so on
+ * their own they follow the operating system rather than an in-app override. A
+ * user who selects a theme opposite to their system preference would otherwise
+ * get browser chrome that does not match the page.
+ *
+ * Every `theme-color` tag is set to the resolved color, so whichever media
+ * query the browser matches, it reads the same value. The static tags are left
+ * in the markup so that the correct color is still applied before hydration and
+ * when JavaScript is unavailable.
+ */
+export function ThemeColorSync() {
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    if (!resolvedTheme) {
+      return;
+    }
+    const color =
+      resolvedTheme === "dark" ? THEME_COLORS.dark : THEME_COLORS.light;
+    document
+      .querySelectorAll('meta[name="theme-color"]')
+      .forEach((tag) => tag.setAttribute("content", color));
+  }, [resolvedTheme]);
+
+  return null;
+}

--- a/apps/web/lib/providers.tsx
+++ b/apps/web/lib/providers.tsx
@@ -2,6 +2,7 @@
 
 import type { UserLocalSettings } from "@/lib/userLocalSettings/types";
 import React, { useState } from "react";
+import { ThemeColorSync } from "@/components/theme-color-sync";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Session, SessionProvider } from "@/lib/auth/client";
@@ -92,6 +93,7 @@ export default function Providers({
                   enableSystem
                   disableTransitionOnChange
                 >
+                  <ThemeColorSync />
                   <TooltipProvider delayDuration={0}>
                     {children}
                   </TooltipProvider>

--- a/apps/web/lib/themeColors.ts
+++ b/apps/web/lib/themeColors.ts
@@ -1,0 +1,11 @@
+/**
+ * Browser chrome colors, matching the `--background` token defined in
+ * tooling/tailwind/globals.css.
+ *
+ * Shared between the static `viewport.themeColor` entries in the root layout
+ * and the client-side sync that follows the in-app theme.
+ */
+export const THEME_COLORS = {
+  light: "#ffffff",
+  dark: "#020817",
+} as const;


### PR DESCRIPTION
Follow-up to #3051 — **stacked on that branch**, so this PR currently shows its commit too. Please merge #3051 first; the diff here will then reduce to the four files below.

## What

#3051 adds static `viewport.themeColor` entries, but as [@greptile-apps flagged there](https://github.com/karakeep-app/karakeep/pull/3051), those use `prefers-color-scheme` and therefore follow the **operating system**, not the theme the app is actually rendering.

`providers.tsx` runs the theme provider with `defaultTheme="system"` *and* `useToggleTheme()` calls `setTheme("light" | "dark")` explicitly, so the two can diverge. A user on a light OS who selects dark in-app gets white browser chrome over a dark page.

## How

A small client component reads `resolvedTheme` from next-themes and writes the matching color to **every** `theme-color` meta tag:

```tsx
document
  .querySelectorAll('meta[name="theme-color"]')
  .forEach((tag) => tag.setAttribute("content", color));
```

Setting all of them, rather than inserting a new tag, sidesteps the ordering rules the browser uses to pick between competing `theme-color` tags — whichever media query matches, it reads the resolved value.

The static entries stay. They still apply before hydration and with JavaScript unavailable, so the common `system` case is correct with no client-side work; the sync only matters once a user overrides the theme. Both now read from a shared `THEME_COLORS` constant so the values cannot drift apart.

### Files

| File | Change |
| --- | --- |
| `apps/web/lib/themeColors.ts` | new — shared `THEME_COLORS`, matching the `--background` token |
| `apps/web/components/theme-color-sync.tsx` | new — client component, renders `null`, effect only |
| `apps/web/lib/providers.tsx` | mount it inside `ThemeProvider` |
| `apps/web/app/layout.tsx` | use the shared constants |

## Verification

Ran against this branch on a clean checkout (Node 22.23.2, pnpm 11.2.1):

| Check | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | passes (2m 46s) |
| `pnpm --filter @karakeep/web typecheck` | **passes** — `tsc --noEmit`, exit 0 |
| `pnpm --filter @karakeep/web lint` | **passes** — oxlint, 0 warnings / 0 errors across 330 files |
| `pnpm format` | **passes** — 21/21 tasks, no files reformatted |

Worth being precise about what that does and does not cover: it confirms the change compiles, resolves and conforms to the repo's style, but not that the chrome visually updates. The behavioural check is manual — set the OS to light, toggle the app to dark, confirm the browser/PWA chrome follows — and I have not been able to run that on a real macOS installed web app, which is the scenario #3029 originally reported. A maintainer sanity-check there would be worthwhile.
