### PR TITLE
feat(search): expose meilisearch binaryQuantized for vector embeddings

### DIFF
--- a/packages/plugins/vectorstore-meilisearch/src/env.ts
+++ b/packages/plugins/vectorstore-meilisearch/src/env.ts
@@ -10,6 +10,12 @@ const rawConfig = z
     MEILI_VECTOR_MASTER_KEY: z.string().optional(),
     MEILI_BATCH_SIZE: z.coerce.number().int().positive().default(50),
     MEILI_BATCH_TIMEOUT_MS: z.coerce.number().int().positive().default(500),
+    // Store vectors binary-quantized (1 bit per dimension, ~32x smaller,
+    // faster search, small recall loss). Requires Meilisearch >= 1.12.
+    MEILI_BINARY_QUANTIZED: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((v) => v === "true"),
   })
   .parse(process.env);
 
@@ -19,4 +25,5 @@ export const envConfig = {
     rawConfig.MEILI_VECTOR_MASTER_KEY ?? rawConfig.MEILI_MASTER_KEY ?? "",
   MEILI_BATCH_SIZE: rawConfig.MEILI_BATCH_SIZE,
   MEILI_BATCH_TIMEOUT_MS: rawConfig.MEILI_BATCH_TIMEOUT_MS,
+  MEILI_BINARY_QUANTIZED: rawConfig.MEILI_BINARY_QUANTIZED,
 };

--- a/packages/plugins/vectorstore-meilisearch/src/index.ts
+++ b/packages/plugins/vectorstore-meilisearch/src/index.ts
@@ -261,11 +261,13 @@ export class MeiliSearchVectorProvider implements PluginProvider<VectorStoreClie
     // Configure embedders for vector search
     const currentEmbedders = settings.embedders;
     const desiredDimensions = serverConfig.embedding.dimensions;
+    const desiredBinaryQuantized = envConfig.MEILI_BINARY_QUANTIZED;
     const currentEmbedder = currentEmbedders?.default;
     if (
       !currentEmbedder ||
       currentEmbedder.source != "userProvided" ||
-      currentEmbedder.dimensions !== desiredDimensions
+      currentEmbedder.dimensions !== desiredDimensions ||
+      (currentEmbedder.binaryQuantized ?? false) !== desiredBinaryQuantized
     ) {
       console.log(`[meilisearch-vector] Configuring user-provided embedder`);
       try {
@@ -275,6 +277,7 @@ export class MeiliSearchVectorProvider implements PluginProvider<VectorStoreClie
             default: {
               source: "userProvided",
               dimensions: desiredDimensions,
+              binaryQuantized: desiredBinaryQuantized,
             },
           })
           .waitTask();


### PR DESCRIPTION
## What does this PR do?

Exposes Meilisearch binary quantization for the vector index behind a new opt-in `MEILI_BINARY_QUANTIZED` env var (default `false`). Binary-quantized vectors use ~3% of the space with a large speedup at a small recall cost, per the issue.

## Changes

- `MEILI_BINARY_QUANTIZED` env var (`"true"`/`"false"`, default `"false"` — current behavior unchanged unless opted in)
- Passed as `binaryQuantized` in the `userProvided` embedder config, with drift detection so flipping the var reconfigures the index on next startup
- Requires Meilisearch >= 1.12; the plugin already requires >= 1.13 for embeddings, so no new version gate needed

Fixes #1315