### PR TITLE
Render Distill equations as native MathML in cached reader content

### DIFF
--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -30,6 +30,7 @@
     "https-proxy-agent": "^7.0.6",
     "ipaddr.js": "^2.2.0",
     "jsdom": "^24.0.0",
+    "katex": "^0.16.47",
     "liteque": "^0.9.1",
     "lru-cache": "^11.2.2",
     "metascraper": "^5.50.0",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@types/archiver": "^7.0.0",
     "@types/jsdom": "^21.1.6",
+    "@types/katex": "^0.16.8",
     "@types/node-cron": "^3.0.11",
     "tsdown": "^0.12.9",
     "vitest": "^3.2.4"

--- a/apps/workers/scripts/parseHtmlSubprocess.ts
+++ b/apps/workers/scripts/parseHtmlSubprocess.ts
@@ -1,5 +1,4 @@
 import { Readability } from "@mozilla/readability";
-import DOMPurify from "dompurify";
 import { HttpProxyAgent } from "http-proxy-agent";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { JSDOM, VirtualConsole } from "jsdom";
@@ -28,6 +27,7 @@ import {
   parseSubprocessInputSchema,
   parseSubprocessOutputSchema,
 } from "../workers/utils/parseHtmlSubprocessIpc";
+import { sanitizeReadableContent } from "../workers/utils/readerMath";
 import {
   assessReaderView,
   ReaderViewAssessment,
@@ -150,25 +150,19 @@ function extractReadableContent(
       };
     }
 
-    const purifyWindow = new JSDOM("").window;
+    const purifiedHTML = sanitizeReadableContent(readableContent.content);
+    const extractedDom = new JSDOM(purifiedHTML, { url, virtualConsole });
     try {
-      const purify = DOMPurify(purifyWindow);
-      const purifiedHTML = purify.sanitize(readableContent.content);
-      const extractedDom = new JSDOM(purifiedHTML, { url, virtualConsole });
-      try {
-        return {
-          readableContent: { content: purifiedHTML },
-          readerViewAssessment: assessReaderView(
-            dom.window.document,
-            extractedDom.window.document,
-            url,
-          ),
-        };
-      } finally {
-        extractedDom.window.close();
-      }
+      return {
+        readableContent: { content: purifiedHTML },
+        readerViewAssessment: assessReaderView(
+          dom.window.document,
+          extractedDom.window.document,
+          url,
+        ),
+      };
     } finally {
-      purifyWindow.close();
+      extractedDom.window.close();
     }
   } finally {
     dom.window.close();
@@ -205,25 +199,19 @@ async function main() {
   if (!metadataOnly && meta.readableContentHtml) {
     // Sanitize plugin-provided HTML through DOMPurify (the extractReadableContent
     // path already does this, but the direct-content path was missing it).
-    const purifyWindow = new JSDOM("").window;
+    const purifiedHTML = sanitizeReadableContent(meta.readableContentHtml);
+    readableContent = { content: purifiedHTML };
+    const sourceDom = new JSDOM(htmlContent, { url });
+    const extractedDom = new JSDOM(purifiedHTML, { url });
     try {
-      const purify = DOMPurify(purifyWindow);
-      const purifiedHTML = purify.sanitize(meta.readableContentHtml);
-      readableContent = { content: purifiedHTML };
-      const sourceDom = new JSDOM(htmlContent, { url });
-      const extractedDom = new JSDOM(purifiedHTML, { url });
-      try {
-        readerViewAssessment = assessReaderView(
-          sourceDom.window.document,
-          extractedDom.window.document,
-          url,
-        );
-      } finally {
-        sourceDom.window.close();
-        extractedDom.window.close();
-      }
+      readerViewAssessment = assessReaderView(
+        sourceDom.window.document,
+        extractedDom.window.document,
+        url,
+      );
     } finally {
-      purifyWindow.close();
+      sourceDom.window.close();
+      extractedDom.window.close();
     }
   }
 

--- a/apps/workers/workers/utils/readerMath.test.ts
+++ b/apps/workers/workers/utils/readerMath.test.ts
@@ -30,7 +30,7 @@ describe("reader math", () => {
       inspect(readable!.content!, (document) => {
         expect(document.querySelectorAll("math")).toHaveLength(2);
         expect(document.querySelector("msubsup > mi")?.textContent).toBe("W");
-        expect(document.querySelector("msubsup")?.textContent).toBe("Wencℓ");
+        expect(document.querySelector("msubsup")?.textContent).toBe("Wencâ„“");
         expect(
           document.querySelector("d-math, script, .katex-html"),
         ).toBeNull();
@@ -136,6 +136,34 @@ describe("reader math", () => {
         expect(document.querySelector("script, [onclick], [href]")).toBeNull();
         expect(document.body.textContent).toContain("Before");
         expect(document.querySelector("math mi")?.textContent).toBe("y");
+      },
+    );
+  });
+
+  it("limits conversion attempts across the article, including failures", () => {
+    // Failed parses consume the same call budget as successful conversions.
+    const invalid = String.raw`<d-math>\unknowncommand{x}</d-math>`;
+    const html = invalid.repeat(255) + "<d-math>x</d-math><d-math>y</d-math>";
+    inspect(html, (document) => {
+      expect(document.querySelectorAll("math")).toHaveLength(1);
+      expect(document.querySelector("math mi")?.textContent).toBe("x");
+      expect(document.body.textContent?.endsWith("y")).toBe(true);
+      expect(document.body.textContent).toContain(
+        String.raw`\unknowncommand{x}`,
+      );
+    });
+    const once = sanitizeReadableContent(html);
+    expect(sanitizeReadableContent(once)).toBe(once);
+  });
+
+  it("limits total source size without losing equations or following text", () => {
+    const formula = "x".padEnd(10_000, " ");
+    inspect(
+      `<d-math>${formula}</d-math>`.repeat(5) +
+        "<d-math>y</d-math><p>After</p>",
+      (document) => {
+        expect(document.querySelectorAll("math")).toHaveLength(5);
+        expect(document.body.textContent?.endsWith("yAfter")).toBe(true);
       },
     );
   });

--- a/apps/workers/workers/utils/readerMath.test.ts
+++ b/apps/workers/workers/utils/readerMath.test.ts
@@ -1,0 +1,168 @@
+import { Readability } from "@mozilla/readability";
+import DOMPurify from "dompurify";
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+
+import { sanitizeReadableContent } from "./readerMath";
+
+function inspect(html: string, check: (document: Document) => void) {
+  const dom = new JSDOM(sanitizeReadableContent(html));
+  try {
+    check(dom.window.document);
+  } finally {
+    dom.window.close();
+  }
+}
+
+describe("reader math", () => {
+  it("renders the reported Distill formula after Readability extraction", () => {
+    // https://github.com/karakeep-app/karakeep/issues/1243
+    const html = String.raw`<html><head><title>Encoder notes</title></head><body><article>
+      <p>We examine the encoder matrix and its relationship to the layer index.
+      This paragraph provides enough surrounding article content for extraction.
+      The reader should preserve the explanation and render the inline notation.</p>
+      <p>where <d-math>W_{enc}^{\ell}</d-math> is the CLT encoder matrix at layer <d-math>\ell</d-math>.</p>
+      </article></body></html>`;
+    const dom = new JSDOM(html);
+    try {
+      const readable = new Readability(dom.window.document).parse();
+      expect(readable?.content).toContain("d-math");
+      inspect(readable!.content!, (document) => {
+        expect(document.querySelectorAll("math")).toHaveLength(2);
+        expect(document.querySelector("msubsup > mi")?.textContent).toBe("W");
+        expect(document.querySelector("msubsup")?.textContent).toBe("Wencℓ");
+        expect(
+          document.querySelector("d-math, script, .katex-html"),
+        ).toBeNull();
+        expect(
+          document.querySelector("math")?.getAttribute("display"),
+        ).toBeNull();
+      });
+    } finally {
+      dom.window.close();
+    }
+  });
+
+  it("preserves block layout and equation structure", () => {
+    inspect(String.raw`<d-math block>\frac{x^2}{y}</d-math>`, (document) => {
+      expect(document.querySelector("math")?.getAttribute("display")).toBe(
+        "block",
+      );
+      expect(document.querySelector("mfrac > msup")?.textContent).toBe("x2");
+      expect(document.querySelector("mfrac > mi")?.textContent).toBe("y");
+    });
+  });
+
+  it("handles HTML entities and uppercase custom tags", () => {
+    inspect("<D-MATH>x &lt; y</D-MATH>", (document) => {
+      expect(document.querySelector("math mo")?.textContent).toBe("<");
+      expect(document.querySelectorAll("math")).toHaveLength(1);
+    });
+  });
+
+  it("keeps one MathML representation in already-rendered captures", () => {
+    inspect(
+      `<d-math block><span class="katex"><span class="katex-mathml">
+      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mi>x</mi></math>
+      </span><span class="katex-html" aria-hidden="true">duplicate x</span></span></d-math>`,
+      (document) => {
+        expect(document.querySelectorAll("math")).toHaveLength(1);
+        expect(document.body.textContent).toBe("x");
+        expect(document.querySelector("math")?.getAttribute("display")).toBe(
+          "block",
+        );
+        expect(document.querySelector(".katex-html")).toBeNull();
+      },
+    );
+  });
+
+  it("leaves ordinary HTML and existing native MathML on the sanitizer path", () => {
+    const html =
+      "<p>Price $5 and $10; literal \\(x\\).</p><math><mi>Q</mi></math>";
+    const dom = new JSDOM("");
+    try {
+      expect(sanitizeReadableContent(html)).toBe(
+        DOMPurify(dom.window).sanitize(html),
+      );
+    } finally {
+      dom.window.close();
+    }
+  });
+
+  it("does not interpret code examples", () => {
+    inspect(
+      String.raw`<pre><d-math>x^2</d-math></pre><code><d-math>\ell</d-math></code>`,
+      (document) => {
+        expect(document.querySelector("math")).toBeNull();
+        expect(document.querySelector("pre")?.textContent).toBe("x^2");
+        expect(document.querySelector("code")?.textContent).toBe(
+          String.raw`\ell`,
+        );
+      },
+    );
+  });
+
+  it.each([
+    String.raw`\unknowncommand{x}`,
+    String.raw`\frac{`,
+    String.raw`\def\a{\a}\a`,
+  ])("keeps unsupported or unbounded source readable: %s", (source) => {
+    inspect(
+      `<p>Before</p><d-math>${source}</d-math><p>After</p>`,
+      (document) => {
+        expect(document.querySelector("math")).toBeNull();
+        expect(document.body.textContent).toBe(`Before${source}After`);
+      },
+    );
+  });
+
+  it("preserves empty and over-limit formulas without evaluating them", () => {
+    const source = "x".repeat(10_001);
+    inspect(
+      `<p>Before</p><d-math> </d-math><d-math>${source}</d-math>`,
+      (document) => {
+        expect(document.querySelector("math")).toBeNull();
+        expect(document.body.textContent).toBe(`Before ${source}`);
+      },
+    );
+  });
+
+  it("sanitizes both rendered content and surrounding HTML", () => {
+    inspect(
+      String.raw`<p onclick="alert(1)">Before</p><script>alert(1)</script>
+      <d-math>\href{javascript:alert(1)}{x}</d-math>
+      <d-math><math><mi onclick="alert(1)">y</mi></math></d-math>`,
+      (document) => {
+        expect(document.querySelector("script, [onclick], [href]")).toBeNull();
+        expect(document.body.textContent).toContain("Before");
+        expect(document.querySelector("math mi")?.textContent).toBe("y");
+      },
+    );
+  });
+
+  it("is stable when cached content is processed again", () => {
+    const once = sanitizeReadableContent(
+      String.raw`<p>Before <d-math>W_{enc}^{\ell}</d-math> after.</p>`,
+    );
+    expect(sanitizeReadableContent(once)).toBe(once);
+    const first = new JSDOM(once);
+    const second = new JSDOM(sanitizeReadableContent(once));
+    try {
+      // Text-node offsets are identical after a reload; no client renderer
+      // inserts a second visual representation after highlights are applied.
+      function texts(document: Document) {
+        const walker = document.createTreeWalker(document.body, 4);
+        const result: string[] = [];
+        while (walker.nextNode())
+          result.push(walker.currentNode.textContent ?? "");
+        return result;
+      }
+      expect(texts(second.window.document)).toEqual(
+        texts(first.window.document),
+      );
+    } finally {
+      first.window.close();
+      second.window.close();
+    }
+  });
+});

--- a/apps/workers/workers/utils/readerMath.ts
+++ b/apps/workers/workers/utils/readerMath.ts
@@ -1,0 +1,64 @@
+import DOMPurify from "dompurify";
+import { JSDOM } from "jsdom";
+import { renderToString } from "katex";
+
+export function sanitizeReadableContent(html: string): string {
+  const window = new JSDOM("").window;
+  try {
+    const purify = DOMPurify(window);
+    if (!/<d-math[\s>]/i.test(html)) {
+      return purify.sanitize(html);
+    }
+    const template = window.document.createElement("template");
+    template.innerHTML = html;
+    renderReaderMath(template.content);
+    return purify.sanitize(template.innerHTML);
+  } finally {
+    window.close();
+  }
+}
+
+/**
+ * Distill's custom element normally needs page JavaScript and KaTeX CSS.
+ * Resolve it before sanitization removes the element, using native MathML so
+ * cached reader content needs neither scripts nor a client-side DOM rewrite.
+ */
+export function renderReaderMath(root: ParentNode): void {
+  for (const element of root.querySelectorAll("d-math")) {
+    if (element.closest("pre, code, math")) {
+      continue;
+    }
+
+    // A browser/SingleFile capture may already contain both KaTeX's MathML and
+    // its CSS-dependent HTML fallback. Keep only the native representation.
+    const existingMath = element.querySelector("math");
+    if (existingMath) {
+      element.replaceWith(existingMath.cloneNode(true));
+      continue;
+    }
+
+    const source = element.textContent ?? "";
+    if (!source.trim() || source.length > 10_000) {
+      continue;
+    }
+
+    try {
+      const template = element.ownerDocument.createElement("template");
+      template.innerHTML = renderToString(source, {
+        output: "mathml",
+        displayMode: element.hasAttribute("block"),
+        throwOnError: true,
+        trust: false,
+        maxExpand: 1_000,
+        maxSize: 20,
+      });
+      const math = template.content.querySelector("math");
+      if (math) {
+        element.replaceWith(math);
+      }
+    } catch {
+      // Unsupported TeX must not discard the article or the original formula.
+      // Leave it for the normal sanitizer, which retains the text content.
+    }
+  }
+}

--- a/apps/workers/workers/utils/readerMath.ts
+++ b/apps/workers/workers/utils/readerMath.ts
@@ -24,6 +24,10 @@ export function sanitizeReadableContent(html: string): string {
  * cached reader content needs neither scripts nor a client-side DOM rewrite.
  */
 export function renderReaderMath(root: ParentNode): void {
+  // Keep the parser's synchronous work bounded across the whole article,
+  // including failed conversions. Excess formulas retain their source text.
+  let remainingEquations = 256;
+  let remainingSourceCharacters = 50_000;
   for (const element of root.querySelectorAll("d-math")) {
     if (element.closest("pre, code, math")) {
       continue;
@@ -38,10 +42,17 @@ export function renderReaderMath(root: ParentNode): void {
     }
 
     const source = element.textContent ?? "";
-    if (!source.trim() || source.length > 10_000) {
+    if (
+      !source.trim() ||
+      source.length > 10_000 ||
+      remainingEquations === 0 ||
+      source.length > remainingSourceCharacters
+    ) {
       continue;
     }
 
+    remainingEquations--;
+    remainingSourceCharacters -= source.length;
     try {
       const template = element.ownerDocument.createElement("template");
       template.innerHTML = renderToString(source, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,6 +972,9 @@ importers:
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
+      katex:
+        specifier: ^0.16.47
+        version: 0.16.47
       liteque:
         specifier: ^0.9.1
         version: 0.9.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/react@19.2.15)(better-sqlite3@13.0.3)(react@19.2.3)
@@ -1069,6 +1072,9 @@ importers:
       '@types/jsdom':
         specifier: ^21.1.6
         version: 21.1.7
+      '@types/katex':
+        specifier: ^0.16.8
+        version: 0.16.8
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11


### PR DESCRIPTION
Distill `<d-math>` equations currently become raw TeX when reader HTML is sanitized. This converts them to native MathML before DOMPurify runs, for both Readability output and plugin-provided reader content. Inline/block layout is retained; already-rendered captures keep their existing MathML without the duplicate CSS-dependent fallback. Unsupported formulas retain their source.

References #1243. This addresses cached-reader rendering; it does not change the archive backend or add automatic math detection to ordinary text/code. Rendering happens in the worker, without a client-side DOM rewrite or additional reader CSS/scripts.

Validation:

- 14 Vitest tests passed with the actual locked Readability, DOMPurify and JSDOM versions, including the reported formula, block math, captured MathML, malformed/oversized formulas, sanitization and repeat-processing stability.
- Aggregate work is limited to 256 attempted conversions and 50,000 source characters per article, in addition to per-formula limits. Failed attempts consume the budget; excess equations retain their text. Regression tests cover both limits.
- Downloaded the reported Transformer Circuits article and passed it through Readability plus sanitization: **194 `<d-math>` elements extracted; 0 native equations before, 194 after; no remaining custom elements; repeat output identical**. The article itself is not included in this PR.
- Scoped TypeScript check, oxlint and oxfmt passed.
- Verified inline equations, subscripts/superscripts and fractions in Chrome using the actual sanitizer output: [standalone before/after HTML](https://gist.github.com/ikoomm/bed5501b3aedd74c2b0477e0a0cb79a5). Download/open the HTML to view it; this is an isolated renderer preview, not a full-app screenshot.

Existing bookmarks need reader content to be re-extracted. Full web/mobile interaction tests and migration of highlight offsets from older cached HTML are not covered here. KaTeX and its types already existed in the lockfile; this adds their worker importer entries.
